### PR TITLE
Added Windows binaries link to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,9 +169,11 @@ Development also requires (see requirements-dev.txt)
 Installation
 ------------
 
-Rasterio is a C extension and there are not yet any binary releases. You'll
-need a working compiler (XCode on OS X, etc). To install from the source 
-distribution on PyPI, do the following:
+Rasterio is a C extension and to install on Linux or OS X you'll need a working compiler
+(XCode on OS X etc). Unofficial Windows binary packages created by Christoph Gohlke 
+are available `here <http://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio>`_.
+
+To install from the source distribution on PyPI, do the following:
 
 .. code-block:: console
 


### PR DESCRIPTION
I've started playing around with rasterio on my mac, and on my Linux server, but assumed from the README that I couldn't use it on my Windows PC at work - which would be a showstopper for me.

I then found that Christoph Gohlke's wonderful page of binary Python packages for Windows has rasterio downloads, and I downloaded it and it worked perfectly. I thought that should be in the README, so I've added a link to it.
