### PR TITLE
Fixes to rasterize geometries - GDAL options

### DIFF
--- a/examples/rasterize_geometry.py
+++ b/examples/rasterize_geometry.py
@@ -2,7 +2,7 @@ import logging
 import numpy
 import sys
 import rasterio
-from rasterio.features import rasterize_geometries
+from rasterio.features import rasterize
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
@@ -13,7 +13,7 @@ rows = cols = 10
 transform = [0, 1, 0, 0, 0, 1]
 geometry = {'type':'Polygon','coordinates':[[(2,2),(2,4.25),(4.25,4.25),(4.25,2),(2,2)]]}
 with rasterio.drivers():
-    result = rasterize_geometries([geometry], rows, cols, transform)
+    result = rasterize([geometry], out_shape=(rows, cols), transform=transform)
     with rasterio.open(
             "test.tif",
             'w',

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -227,8 +227,7 @@ def _rasterize(shapes, image, transform=None, all_touched=False):
 
     try:
         if all_touched:
-            options = <char **>_gdal.CPLMalloc(sizeof(char*))
-            options[0] = "ALL_TOUCHED=TRUE"
+            options = _gdal.CSLSetNameValue(options, "ALL_TOUCHED", "TRUE")
 
         # Do the boilerplate required to create a dataset, band, and 
         # set transformation
@@ -278,11 +277,14 @@ def _rasterize(shapes, image, transform=None, all_touched=False):
         retval = io_ubyte(out_band, 0, 0, 0, width, height, image)
 
     finally:
+        for i in range(num_geometries):
+            _deleteOgrGeom(ogr_geoms[i])
         _gdal.CPLFree(ogr_geoms)
-        _gdal.CPLFree(options)
         _gdal.CPLFree(pixel_values)
         if out_ds != NULL:
             _gdal.GDALClose(out_ds)
+        if options:
+            _gdal.CSLDestroy(options)
 
 
 cdef int io_ubyte(


### PR DESCRIPTION
This pull requests fixes a bad pattern for setting options passed to GDAL functions (previous pattern worked fine on windows but caused segfaults on Linux).

Also updates example to use updated parameters for rasterize function.
