### PR TITLE
Set co tiled=yes to actually use blockxsize

### DIFF
--- a/examples/parallel.py
+++ b/examples/parallel.py
@@ -45,6 +45,8 @@ def main(infile, outfile, num_workers=4, max_iterations=3):
         block_height, block_width = block_shapes.pop()
         meta.update(blockxsize=block_width, blockysize=block_height)
         
+        if block_width != src.shape[1]:
+          meta.update(tiled = 'yes')
         # Create an empty destination file on disk.
         with rasterio.open(outfile, 'w', **meta) as dst:
             pass


### PR DESCRIPTION
I don't know if this is the place to fix it. If tiff is the rasterio format of choice maybe this should be fixed in `_io.pyx` instead.

The output tiff file is not actually tiled unless tiled=yes is specified. If tiled=yes is not specified GDAL silently ignores blockxsize and structures the tiff in strips.

BTW A side effect of this patch is that the IOErrors seem to disappear.
