### PR TITLE
Fix read() when nodatavalue is NaN and masked is None

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -674,7 +674,7 @@ cdef class RasterReader(object):
                     and nodatavals[aix] is not None):
                 if ((res == nodatavals[aix]).any()
                         or (np.isnan(nodatavals[aix])
-                            and np.isnan(nodatavals[aix]).any())):
+                            and np.isnan(res).any())):
                     has_nodata = True
         if has_nodata:
             test1nodata = set(nodatavals)
@@ -691,7 +691,7 @@ cdef class RasterReader(object):
                     if nodatavals[aix] is None:
                         band_mask = False
                     elif np.isnan(nodatavals[aix]):
-                        band_mask = np.isnan(nodatavals[aix])
+                        band_mask = np.isnan(out[aix])
                     else:
                         band_mask = out[aix] == nodatavals[aix]
                     out[aix].mask = band_mask

--- a/rasterio/tests/test_read.py
+++ b/rasterio/tests/test_read.py
@@ -234,3 +234,8 @@ class ReaderContextTest(unittest.TestCase):
             a = s.read(masked=False)
             self.assertFalse(hasattr(a, 'mask'))
             self.assertTrue(numpy.isnan(a).any())
+            # Window does not contain a nodatavalue
+            a = s.read(window=((0, 2), (0, 2)))
+            self.assertEqual(a.ndim, 3)
+            self.assertEqual(a.shape, (1, 2, 2))
+            self.assertFalse(hasattr(a, 'mask'))


### PR DESCRIPTION
Fixed a couple of typos in the logic regarding tests of NaN in the read data.

Added a test to catch this.
