### PR TITLE
Testing requires the 'six' package for StringIO

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ Cython==0.20
 Numpy==1.8.0
 pytest
 setuptools
+six


### PR DESCRIPTION
I know I've grumbled in the past about using `six`, but it's fine here for testing with `requirements-dev.txt`.

This should fix the Travis CI tests.
