### PR TITLE
Added support for additional data types for rasterize function

### DIFF
--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -40,6 +40,14 @@ cdef class RasterUpdater(RasterReader):
     cdef readonly object _options
 
 
+cdef class InMemoryRaster:
+    cdef void *dataset
+    cdef void *band
+    cdef double transform[6]
+    cdef int band_ids[1]
+    cdef np.ndarray _image
+
+
 ctypedef np.uint8_t DTYPE_UBYTE_t
 ctypedef np.uint16_t DTYPE_UINT16_t
 ctypedef np.int16_t DTYPE_INT16_t
@@ -232,3 +240,4 @@ cdef int io_multi_cfloat64(
         long[:] indexes,
         int count)
 
+cdef int io_auto(image, void *hband, bint write)

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -489,6 +489,45 @@ cdef int io_multi_cfloat64(
 
     return retval
 
+
+cdef int io_auto(image, void *hband, bint write):
+    """
+    Convenience function to handle IO with a GDAL band and a 2D numpy image
+
+    :param image: a numpy 2D image
+    :param hband: an instance of GDALGetRasterBand
+    :param write: 1 (True) uses write mode, 0 (False) uses read
+    :return: the return value from the data-type specific IO function
+    """
+
+    if not len(image.shape) == 2:
+        raise ValueError("Specified image must have 2 dimensions")
+
+    cdef int width = image.shape[1]
+    cdef int height = image.shape[0]
+
+    dtype_name = image.dtype.name
+
+    if dtype_name == "float32":
+        return io_float32(hband, write, 0, 0, width, height, image)
+    elif dtype_name == "float64":
+        return io_float64(hband, write, 0, 0, width, height, image)
+    elif dtype_name == "uint8":
+        return io_ubyte(hband, write, 0, 0, width, height, image)
+    elif dtype_name == "int16":
+        return io_int16(hband, write, 0, 0, width, height, image)
+    elif dtype_name == "int32":
+        return io_int32(hband, write, 0, 0, width, height, image)
+    elif dtype_name == "uint16":
+        return io_uint16(hband, write, 0, 0, width, height, image)
+    elif dtype_name == "uint32":
+        return io_uint32(hband, write, 0, 0, width, height, image)
+    else:
+        raise ValueError("Image dtype is not supported for this function."
+                         "Must be float32, float64, int16, int32, uint8, "
+                         "uint16, or uint32")
+
+
 cdef class RasterReader(_base.DatasetReader):
 
     def read_band(self, bidx, out=None, window=None, masked=None):
@@ -812,7 +851,7 @@ cdef class RasterUpdater(RasterReader):
                     gdal_dtype = dtypes.dtype_rev.get(tp)
             else:
                 gdal_dtype = dtypes.dtype_rev.get(self._init_dtype)
-            
+
             # Creation options
             for k, v in self._options.items():
                 # Skip items that are definitely *not* valid driver options.
@@ -1207,3 +1246,85 @@ cdef class RasterUpdater(RasterReader):
             retval = io_ubyte(
                 hmask, 1, xoff, yoff, width, height, src)
 
+
+cdef class InMemoryRaster:
+    """
+    Class that manages a single-band in memory GDAL raster dataset.  Data type
+    is determined from the data type of the input numpy 2D array (image), and
+    must be one of the data types supported by GDAL
+    (see rasterio.dtypes.dtype_rev).  Data are populated at create time from
+    the 2D array passed in.
+
+    Use the 'with' pattern to instantiate this class for automatic closing
+    of the memory dataset.
+
+    This class includes attributes that are intended to be passed into GDAL
+    functions:
+    self.dataset
+    self.band
+    self.band_ids  (single element array with band ID of this dataset's band)
+    self.transform (GDAL compatible transform array)
+
+    This class is only intended for internal use within rasterio to support
+    IO with GDAL.  Other memory based operations should use numpy arrays.
+    """
+
+    def __init__(self, image, transform):
+        """
+        Create in-memory raster dataset, and populate its initial values with
+        the values in image.
+
+        :param image: 2D numpy array.  Must be of supported data type
+        (see rasterio.dtypes.dtype_rev)
+        :param transform: GDAL compatible transform array
+        """
+
+        self._image = image
+        self.dataset = NULL
+
+        cdef void *memdriver = _gdal.GDALGetDriverByName("MEM")
+
+        # Several GDAL operations require the array of band IDs as input
+        self.band_ids[0] = 1
+
+        self.dataset = _gdal.GDALCreate(
+            memdriver,
+            "output",
+            image.shape[1],
+            image.shape[0],
+            1,
+            <_gdal.GDALDataType>dtypes.dtype_rev[image.dtype.name],
+            NULL
+        )
+
+        if self.dataset == NULL:
+            raise ValueError("NULL output datasource")
+
+        for i in range(6):
+            self.transform[i] = transform[i]
+        err = _gdal.GDALSetGeoTransform(self.dataset, self.transform)
+        if err:
+            raise ValueError("transform not set: %s" % transform)
+
+        self.band = _gdal.GDALGetRasterBand(self.dataset, 1)
+        if self.band == NULL:
+            raise ValueError("NULL output band: {0}".format(i))
+
+        self.write(image)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
+
+    def close(self):
+        if self.dataset != NULL:
+            _gdal.GDALClose(self.dataset)
+
+    def read(self):
+        io_auto(self._image, self.band, False)
+        return self._image
+
+    def write(self, image):
+        io_auto(image, self.band, True)

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -71,3 +71,28 @@ def check_dtype(dt):
         except:
             return False
     return True
+
+
+def get_minimum_int_dtype(values):
+    """
+    Uses range checking to determine the minimum integer data type required
+    to represent values.
+
+    :param values: numpy array
+    :return: named data type that can be later used to create a numpy dtype
+    """
+
+    min_value = values.min()
+    max_value = values.max()
+    
+    if min_value >= 0:
+        if max_value <= 255:
+            return uint8
+        elif max_value <= 65535:
+            return uint16
+        elif max_value <= 4294967295:
+            return uint32
+    elif min_value >= -32768 and max_value <= 32767:
+        return int16
+    elif min_value >= -2147483648 and max_value <= 2147483647:
+        return int32

--- a/tests/test_features_rasterize.py
+++ b/tests/test_features_rasterize.py
@@ -11,28 +11,31 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 def test_rasterize_geometries():
     rows = cols = 10
     transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
-    geometry = {'type':'Polygon','coordinates':[[(2,2),(2,4.25),(4.25,4.25),(4.25,2),(2,2)]]}
+    geometry = {
+        'type':'Polygon',
+        'coordinates':[[(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)]]
+    }
 
     with rasterio.drivers():
         # we expect a subset of the pixels using default mode
         result = rasterize([geometry], out_shape=(rows, cols))
         truth = numpy.zeros((rows, cols))
-        truth[2:4, 2:4] = 255
-        assert (result == truth).min() == True
+        truth[2:4, 2:4] = 1
+        assert numpy.array_equal(result, truth)
 
         # we expect all touched pixels
         result = rasterize(
                     [geometry], out_shape=(rows, cols), all_touched=True)
         truth = numpy.zeros((rows, cols))
-        truth[2:5, 2:5] = 255
-        assert (result == truth).min() == True
+        truth[2:5, 2:5] = 1
+        assert numpy.array_equal(result, truth)
 
         # we expect the pixel value to match the one we pass in
         value = 5
         result = rasterize([(geometry, value)], out_shape=(rows, cols))
         truth = numpy.zeros((rows, cols))
         truth[2:4, 2:4] = value
-        assert (result == truth).min() == True
+        assert numpy.array_equal(result, truth)
         
         # Check the fill and default transform.
         # we expect the pixel value to match the one we pass in
@@ -43,7 +46,84 @@ def test_rasterize_geometries():
             fill=1 )
         truth = numpy.ones((rows, cols))
         truth[2:4, 2:4] = value
-        assert (result == truth).min() == True
+        assert numpy.array_equal(result, truth)
+
+
+def test_rasterize_dtype():
+    rows = cols = 10
+    transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+    geometry = {
+        'type':'Polygon',
+        'coordinates':[[(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)]]
+    }
+
+    with rasterio.drivers():
+        # Supported types should all work properly
+        supported_types = (('int16', -32768), ('int32', -2147483648),
+                     ('uint8', 255), ('uint16', 65535), ('uint32', 4294967295),
+                     ('float32', 1.434532), ('float64', -98332.133422114))
+
+        for dtype, default_value in supported_types:
+            truth = numpy.zeros((rows, cols), dtype=dtype)
+            truth[2:4, 2:4] = default_value
+
+            result = rasterize(
+                [geometry],
+                out_shape=(rows, cols),
+                default_value=default_value,
+                dtype=dtype
+            )
+            assert numpy.array_equal(result, truth)
+            assert numpy.dtype(result.dtype) == numpy.dtype(truth.dtype)
+
+            result = rasterize(
+                [(geometry, default_value)],
+                out_shape=(rows, cols)
+            )
+            if numpy.dtype(dtype).kind == 'f':
+                assert numpy.allclose(result, truth)
+            else:
+                assert numpy.array_equal(result, truth)
+            # Since dtype is auto-detected, it may not match due to upcasting
+
+        # Unsupported types should all raise exceptions
+        unsupported_types = (('int8', -127), ('int64', 20439845334323),
+                             ('float16', -9343.232))
+
+        for dtype, default_value in unsupported_types:
+            with pytest.raises(ValueError):
+                rasterize(
+                    [geometry],
+                    out_shape=(rows, cols),
+                    default_value=default_value,
+                    dtype=dtype
+                )
+
+            with pytest.raises(ValueError):
+                rasterize(
+                    [(geometry, default_value)],
+                    out_shape=(rows, cols),
+                    dtype=dtype
+                )
+
+        # Mismatched values and dtypes should raise exceptions
+        mismatched_types = (('uint8', 3.2423), ('uint8', -2147483648))
+        for dtype, default_value in mismatched_types:
+            print("Testing mismatched dtype {0} with value {1}".format(dtype, default_value))
+            with pytest.raises(ValueError):
+                rasterize(
+                    [geometry],
+                    out_shape=(rows, cols),
+                    default_value=default_value,
+                    dtype=dtype
+                )
+
+            with pytest.raises(ValueError):
+                rasterize(
+                    [(geometry, default_value)],
+                    out_shape=(rows, cols),
+                    dtype=dtype
+                )
 
 
 def test_rasterize_geometries_symmetric():
@@ -55,4 +135,5 @@ def test_rasterize_geometries_symmetric():
     with rasterio.drivers():
         s = shapes(truth, transform=transform)
         result = rasterize(s, out_shape=(rows, cols), transform=transform)
-        assert (result == truth).min() == True
+        assert numpy.array_equal(result, truth)
+


### PR DESCRIPTION
This resolves #136 by adding support for additional data types to rasterize. This includes additional dtype parameter to features.py::rasterize(), and one API change to the value of the default_value parameter (from 255 to 1).

This was aided by adding a utility class InMemoryRaster for use in cython to handle IO between 2D numpy arrays and GDAL raster bands used by the GDAL functions. This has broader applicability than just this issue; it will likely aid #138 and others.

This PR also includes io_auto in _io.pyx, which simplifies routing to the appropriate IO function for reading / writing between numpy arrays and GDAL raster bands, by routing to the appropriate function based on the dtype of the numpy array.

Validation logic inside features.py::rasterize() had to be completely rewritten to catch data type conflicts.

This also includes new test cases to make sure that the additional data types are handled correctly by rasterize, and some cleanup of the existing rasterize tests (including a bit of PEP8 conformance).
