### PR TITLE
Added support for additional data types in shapes

### DIFF
--- a/rasterio/_gdal.pxd
+++ b/rasterio/_gdal.pxd
@@ -194,6 +194,7 @@ cdef extern from "gdalwarper.h":
 cdef extern from "gdal_alg.h":
     
     int GDALPolygonize(void *src_band, void *mask_band, void *layer, int fidx, char **options, void *progress_func, void *progress_data)
+    int GDALFPolygonize(void *src_band, void *mask_band, void *layer, int fidx, char **options, void *progress_func, void *progress_data)
     int GDALSieveFilter(void *src_band, void *mask_band, void *dst_band, int size, int connectivity, char **options, void *progress_func, void *progress_data)
     int GDALRasterizeGeometries(void *out_ds, int band_count, int *dst_bands, int geom_count, void **geometries,
                             GDALTransformerFunc transform_func, void *transform, double *pixel_values, char **options,

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1272,7 +1272,7 @@ cdef class InMemoryRaster:
     IO with GDAL.  Other memory based operations should use numpy arrays.
     """
 
-    def __init__(self, image, transform):
+    def __cinit__(self, image, transform):
         """
         Create in-memory raster dataset, and populate its initial values with
         the values in image.
@@ -1324,6 +1324,7 @@ cdef class InMemoryRaster:
     def close(self):
         if self.dataset != NULL:
             _gdal.GDALClose(self.dataset)
+            self.dataset = NULL
 
     def read(self):
         io_auto(self._image, self.band, False)

--- a/tests/test_features_shapes.py
+++ b/tests/test_features_shapes.py
@@ -7,10 +7,13 @@ import pytest
 import rasterio
 import rasterio.features as ftrz
 
+
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
 
 def test_shapes():
     """Access to shapes of labeled features"""
+
     image = numpy.zeros((20, 20), dtype=rasterio.ubyte)
     image[5:15,5:15] = 127
     with rasterio.drivers():
@@ -30,8 +33,10 @@ def test_shapes():
         else:
             assert False
 
+
 def test_shapes_band_shortcut():
     """Access to shapes of labeled features"""
+
     with rasterio.drivers():
         with rasterio.open('tests/data/shade.tif') as src:
             shapes = ftrz.shapes(rasterio.band(src, 1))
@@ -40,8 +45,10 @@ def test_shapes_band_shortcut():
             assert len(shape['coordinates']) == 1
             assert val == 255
 
+
 def test_shapes_internal_driver_manager():
     """Access to shapes of labeled features"""
+
     image = numpy.zeros((20, 20), dtype=rasterio.ubyte)
     image[5:15,5:15] = 127
     shapes = ftrz.shapes(image)
@@ -59,3 +66,44 @@ def test_shapes_connectivity():
     shape, val = next(shapes)
     assert len(shape['coordinates'][0]) == 9
     #Note: geometry is not technically valid at this point, it has a self intersection at 11,11
+
+
+def test_shapes_dtype():
+    """Test image dtype handling"""
+
+    rows = cols = 10
+    with rasterio.drivers():
+        supported_types = (
+            ('int16', -32768),
+            ('int32', -2147483648),
+            ('uint8', 255),
+            ('uint16', 65535),
+            ('float32', 1.434532)
+        )
+
+        for dtype, test_value in supported_types:
+            image = numpy.zeros((rows, cols), dtype=dtype)
+            image[2:5, 2:5] = test_value
+
+            shapes = ftrz.shapes(image)
+            shape, value = next(shapes)
+            if dtype == 'float32':
+                assert round(value, 6) == round(test_value, 6)
+            else:
+                assert value == test_value
+
+        # Unsupported types should all raise exceptions
+        unsupported_types = (
+            ('int8', -127),
+            ('uint32', 4294967295),
+            ('int64', 20439845334323),
+            ('float16', -9343.232),
+            ('float64', -98332.133422114)
+        )
+
+        for dtype, test_value in unsupported_types:
+            with pytest.raises(ValueError):
+                image = numpy.zeros((rows, cols), dtype=dtype)
+                image[2:5, 2:5] = test_value
+                shapes = ftrz.shapes(image)
+                shape, value = next(shapes)


### PR DESCRIPTION
This resolves #138 by adding support for additional data types for shapes.  Because GDAL uses 32 bit integers or floats internally for this operation, fewer data types are supported than for rasterize, but it at least includes int16, int32, uint8, uint16, float32.

This updated the internals of _features.pyx::_shapes() to use the newer in-memory raster class introduced in #155.

This also added the GDAL floating point function for shapes, and added support for that through the stack.
