### PR TITLE
Run code coverage analysis with coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,10 @@ before_install:
 install:
   - "pip install -r requirements-dev.txt"
   - "pip install pytest"
+  - "pip install coveralls"
   - "pip install -e ."
-script: py.test
+script: 
+  - py.test
+  - coverage run --source=rasterio --omit='*.pxd,*.pyx,*/tests/*,*/docs/*,*/examples/*,*/benchmarks/*' -m py.test
+after_success:
+  - coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ git+https://github.com/sgillies/affine.git#egg=affine
 Cython>=0.20
 Numpy>=1.8.0
 pytest
+coveralls>=0.4
 setuptools
 six


### PR DESCRIPTION
This PR updates the Travis-CI config to integrate with [coveralls service[(https://coveralls.io/) for code coverage analysis.  Also adds coveralls requirement for local development.

To see what results look like, see [my first run of this on rasterio](https://coveralls.io/builds/1293566).

You will need to setup a primary account in coveralls service linked to github and enable this repo (interface is similar to Travis-CI).  Consider adding a badge to `readme.rst`

We may want to tweak the files to exclude; right now everything in `rio` is being analyzed even though there are no tests there.

While there are other code coverage tools out there, this provides a nice web interface that may help motivate contributors to write more tests...
