### PR TITLE
Handle proj4 bare parameters with string values

### DIFF
--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -40,14 +40,19 @@ def from_string(prjs):
     """
     parts = [o.lstrip('+') for o in prjs.strip().split()]
     def parse(v):
-        try:
-            return int(v)
-        except ValueError:
-            pass
-        try:
-            return float(v)
-        except ValueError:
-            return v
+        if v in ('True', 'true'):
+            return True
+        elif v in ('False', 'false'):
+            return False
+        else:
+            try:
+                return int(v)
+            except ValueError:
+                pass
+            try:
+                return float(v)
+            except ValueError:
+                return v
     items = map(
         lambda kv: len(kv) == 2 and (kv[0], parse(kv[1])) or (kv[0], True),
         (p.split('=') for p in parts) )

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 
 import rasterio
+from rasterio import crs
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
@@ -54,3 +55,12 @@ def test_write_3857(tmpdir):
     EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],
     AUTHORITY["EPSG","3857"]]""" in info.decode('utf-8')
 
+
+def test_bare_parameters():
+    """ Make sure that bare parameters (e.g., no_defs) are handled properly,
+    even if they come in with key=True.  This covers interaction with pyproj,
+    which makes presents bare parameters as key=<bool>."""
+
+    # Example produced by pyproj
+    crs_dict = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
+    assert crs_dict.get('no_defs', False) is True


### PR DESCRIPTION
This fix covers the case where routing projections through pyproj, which represents proj4 bare parameters (e.g., `no_defs`) as `key=<bool>` instead of simply `key`.  Simply checks for boolean types as string values (e.g., `'True'`) prior to attempting to type-cast  values.
