### PR TITLE
Overhauled documentation in features module and cleaned up PEP8 warnings

### DIFF
--- a/tests/test_features_rasterize.py
+++ b/tests/test_features_rasterize.py
@@ -2,18 +2,24 @@ import logging
 import sys
 import numpy
 import pytest
+
 import rasterio
 from rasterio.features import shapes, rasterize
+
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 def test_rasterize_geometries():
+    """
+    Make sure that geometries are correctly rasterized according to parameters
+    """
+
     rows = cols = 10
     transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
     geometry = {
-        'type':'Polygon',
-        'coordinates':[[(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)]]
+        'type': 'Polygon',
+        'coordinates': [[(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)]]
     }
 
     with rasterio.drivers():
@@ -25,7 +31,8 @@ def test_rasterize_geometries():
 
         # we expect all touched pixels
         result = rasterize(
-                    [geometry], out_shape=(rows, cols), all_touched=True)
+            [geometry], out_shape=(rows, cols), all_touched=True
+        )
         truth = numpy.zeros((rows, cols))
         truth[2:5, 2:5] = 1
         assert numpy.array_equal(result, truth)
@@ -36,32 +43,41 @@ def test_rasterize_geometries():
         truth = numpy.zeros((rows, cols))
         truth[2:4, 2:4] = value
         assert numpy.array_equal(result, truth)
-        
+
         # Check the fill and default transform.
         # we expect the pixel value to match the one we pass in
         value = 5
         result = rasterize(
-            [(geometry, value)], 
-            out_shape=(rows, cols), 
-            fill=1 )
+            [(geometry, value)],
+            out_shape=(rows, cols),
+            fill=1
+        )
         truth = numpy.ones((rows, cols))
         truth[2:4, 2:4] = value
         assert numpy.array_equal(result, truth)
 
 
 def test_rasterize_dtype():
+    """Make sure that data types are handled correctly"""
+
     rows = cols = 10
     transform = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
     geometry = {
-        'type':'Polygon',
-        'coordinates':[[(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)]]
+        'type': 'Polygon',
+        'coordinates': [[(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)]]
     }
 
     with rasterio.drivers():
         # Supported types should all work properly
-        supported_types = (('int16', -32768), ('int32', -2147483648),
-                     ('uint8', 255), ('uint16', 65535), ('uint32', 4294967295),
-                     ('float32', 1.434532), ('float64', -98332.133422114))
+        supported_types = (
+            ('int16', -32768),
+            ('int32', -2147483648),
+            ('uint8', 255),
+            ('uint16', 65535),
+            ('uint32', 4294967295),
+            ('float32', 1.434532),
+            ('float64', -98332.133422114)
+        )
 
         for dtype, default_value in supported_types:
             truth = numpy.zeros((rows, cols), dtype=dtype)
@@ -87,8 +103,11 @@ def test_rasterize_dtype():
             # Since dtype is auto-detected, it may not match due to upcasting
 
         # Unsupported types should all raise exceptions
-        unsupported_types = (('int8', -127), ('int64', 20439845334323),
-                             ('float16', -9343.232))
+        unsupported_types = (
+            ('int8', -127),
+            ('int64', 20439845334323),
+            ('float16', -9343.232)
+        )
 
         for dtype, default_value in unsupported_types:
             with pytest.raises(ValueError):
@@ -109,7 +128,6 @@ def test_rasterize_dtype():
         # Mismatched values and dtypes should raise exceptions
         mismatched_types = (('uint8', 3.2423), ('uint8', -2147483648))
         for dtype, default_value in mismatched_types:
-            print("Testing mismatched dtype {0} with value {1}".format(dtype, default_value))
             with pytest.raises(ValueError):
                 rasterize(
                     [geometry],
@@ -128,6 +146,7 @@ def test_rasterize_dtype():
 
 def test_rasterize_geometries_symmetric():
     """Make sure that rasterize is symmetric with shapes"""
+
     rows = cols = 10
     transform = (1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
     truth = numpy.zeros((rows, cols), dtype=rasterio.ubyte)
@@ -136,4 +155,3 @@ def test_rasterize_geometries_symmetric():
         s = shapes(truth, transform=transform)
         result = rasterize(s, out_shape=(rows, cols), transform=transform)
         assert numpy.array_equal(result, truth)
-

--- a/tests/test_features_shapes.py
+++ b/tests/test_features_shapes.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-
 import numpy
 import pytest
 
@@ -12,19 +11,19 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 def test_shapes():
-    """Access to shapes of labeled features"""
+    """Test creation of shapes from pixel values"""
 
     image = numpy.zeros((20, 20), dtype=rasterio.ubyte)
-    image[5:15,5:15] = 127
+    image[5:15, 5:15] = 127
     with rasterio.drivers():
         shapes = ftrz.shapes(image)
         shape, val = next(shapes)
         assert shape['type'] == 'Polygon'
-        assert len(shape['coordinates']) == 2 # exterior and hole
+        assert len(shape['coordinates']) == 2  # exterior and hole
         assert val == 0
         shape, val = next(shapes)
         assert shape['type'] == 'Polygon'
-        assert len(shape['coordinates']) == 1 # no hole
+        assert len(shape['coordinates']) == 1  # no hole
         assert val == 127
         try:
             shape, val = next(shapes)
@@ -35,7 +34,7 @@ def test_shapes():
 
 
 def test_shapes_band_shortcut():
-    """Access to shapes of labeled features"""
+    """Test rasterio bands as input to shapes"""
 
     with rasterio.drivers():
         with rasterio.open('tests/data/shade.tif') as src:
@@ -47,10 +46,10 @@ def test_shapes_band_shortcut():
 
 
 def test_shapes_internal_driver_manager():
-    """Access to shapes of labeled features"""
+    """Make sure this works if driver is managed outside this test"""
 
     image = numpy.zeros((20, 20), dtype=rasterio.ubyte)
-    image[5:15,5:15] = 127
+    image[5:15, 5:15] = 127
     shapes = ftrz.shapes(image)
     shape, val = next(shapes)
     assert shape['type'] == 'Polygon'
@@ -58,18 +57,20 @@ def test_shapes_internal_driver_manager():
 
 def test_shapes_connectivity():
     """Test connectivity options"""
+
     image = numpy.zeros((20, 20), dtype=rasterio.ubyte)
-    image[5:11,5:11] = 1
-    image[11,11] = 1
+    image[5:11, 5:11] = 1
+    image[11, 11] = 1
 
     shapes = ftrz.shapes(image, connectivity=8)
     shape, val = next(shapes)
     assert len(shape['coordinates'][0]) == 9
-    #Note: geometry is not technically valid at this point, it has a self intersection at 11,11
+    # Note: geometry is not technically valid at this point, it has a self
+    # intersection at 11,11
 
 
 def test_shapes_dtype():
-    """Test image dtype handling"""
+    """Test image data type handling"""
 
     rows = cols = 10
     with rasterio.drivers():

--- a/tests/test_features_sieve.py
+++ b/tests/test_features_sieve.py
@@ -57,7 +57,7 @@ def test_sieve_output():
 
         # Output should match returned array
         output = numpy.zeros_like(image)
-        output [1:3, 1:3] = 5
+        output[1:3, 1:3] = 5
         sieved_image = ftrz.sieve(image, 100, output=output)
         assert numpy.array_equal(output, sieved_image)
 
@@ -76,7 +76,8 @@ def test_sieve_mask():
         image[5:15, 5:15] = 1
         image[1:3, 1:3] = 2
 
-        # Blank mask has no effect, only areas smaller than size will be removed
+        # Blank mask has no effect, only areas smaller than size will be
+        # removed
         mask = numpy.ones(shape, dtype=rasterio.bool_)
         sieved_image = ftrz.sieve(image, 100, mask=mask)
         truth = numpy.zeros_like(image)
@@ -98,7 +99,7 @@ def test_sieve_mask():
 
 
 def test_dtypes():
-    """Test dtype support for sieve"""
+    """Test data type support for sieve"""
 
     rows = cols = 10
     with rasterio.drivers():


### PR DESCRIPTION
This addresses most of the items raised in #161 

It does not modify variable names.

Main changes are to docstrings to follow numpy standard, and hopefully produce much better results from `help()`.  They are much easier to read now.

Other changes were to white spaces - adding and removing as needed to reduce PEP8 warnings.

I split some of the longer lines (to achive <= 79 chars), and was aiming for better readability in these cases than some of the options permitted under PEP8, e.g., 

```
some_var = (
    foo, bar
)
```

rather than

```
some_var = (
    foo, bar)
```

There are no functional changes in this PR.
