### PR TITLE
Fix incorrect use of output.dtype

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -297,10 +297,10 @@ def rasterize(
             stacklevel=2)
     out = out if out is not None else output
     if out is not None:
-        if np.dtype(output.dtype).name not in valid_dtypes:
+        if np.dtype(out.dtype).name not in valid_dtypes:
             raise ValueError('Output image dtype must be one of: %s'
                              % (', '.join(valid_dtypes)))
-        if not can_cast_dtype(shape_values, output.dtype):
+        if not can_cast_dtype(shape_values, out.dtype):
             raise ValueError('shape values cannot be cast to dtype of output '
                              'image')
 

--- a/tests/test_features_rasterize.py
+++ b/tests/test_features_rasterize.py
@@ -29,6 +29,10 @@ def test_rasterize_geometries():
         truth[2:4, 2:4] = 1
         assert numpy.array_equal(result, truth)
 
+        out = numpy.zeros((rows, cols))
+        result = rasterize([geometry], out=out, default_value=1)
+        assert numpy.array_equal(out, truth)
+
         # we expect all touched pixels
         result = rasterize(
             [geometry], out_shape=(rows, cols), all_touched=True


### PR DESCRIPTION
Resolves #195 

Added a test to make sure that we handle rasterize with `out` parameter.
