### PR TITLE
More graceful handling of windows.

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -598,11 +598,11 @@ cdef class RasterReader(_base.DatasetReader):
 
         # Windows are always limited to the dataset's extent.
         if window:
-            _ = eval_window(window, self.height, self.width)
+            window = eval_window(window, self.height, self.width)
             window = ((
-                    max(min(window[0][0] or 0, self.height), 0),
+                    min(window[0][0] or 0, self.height),
                     min(window[0][1] or self.height, self.height)), (
-                    max(min(window[1][0] or 0, self.width), 0),
+                    min(window[1][0] or 0, self.width),
                     min(window[1][1] or self.width, self.width)))
 
         out_shape = (len(indexes),) + (

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,9 +1,14 @@
+import logging
+import sys
 import unittest
 
 import numpy
 from hashlib import md5
 
 import rasterio
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 class ReaderContextTest(unittest.TestCase):
@@ -202,12 +207,12 @@ class ReaderContextTest(unittest.TestCase):
             a = s.read(window=((10000, 20000), (10000, 20000)))
             self.assertEqual(a.shape, (3,0,0))
 
-    def test_read_window_underflow(self):
+    def test_read_window_overlap(self):
         """Test graceful Numpy-like handling of windows beyond
         the dataset's bounds."""
         with rasterio.open('tests/data/RGB.byte.tif') as s:
-            a = s.read(window=((-10000, 20000), (-10000, 20000)))
-            self.assertEqual(a.shape, (3,) + s.shape)
+            a = s.read(window=((-100, 20000), (-100, 20000)))
+            self.assertEqual(a.shape, (3,100,100))
 
     def test_read_out(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:


### PR DESCRIPTION
Intent is to return no data when the window is beyond the dataset's
extent and clip to the dataset's extent when the window overflows.
In other words, just like Python slices and Numpy extended slices.

Closes #191.
