### PR TITLE
Warp.py docstring wins

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -5,48 +5,138 @@ from rasterio.transform import guard_transform
 
 
 def transform(src_crs, dst_crs, xs, ys, zs=None):
-    """Return transformed vectors of x, y and optionally z.
-    
-    The sequences of points x, y, z in the coordinate system defined by
-    src_crs are transformed in the coordinate system defined by dst_crs.
-    z is optional, if it is not set it is assumed to be all zeros and only
-    x and y are returned.
+    """
+    Transform vectors of x, y and optionally z from source
+    coordinate reference system into target.
+
+    Parameters
+    ------------
+    src_crs: dict
+        Source coordinate reference system, in rasterio dict format.
+        Example: {'init': 'EPSG:4326'}
+    dst_crs: dict
+        Target coordinate reference system.
+    xs: array_like
+        Contains x values.  Will be cast to double floating point values.
+    ys:  array_like
+        Contains y values.
+    zs: array_like, optional
+        Contains z values.  Assumed to be all 0 if absent.
+
+    Returns
+    ---------
+    out: tuple of array_like, (xs, ys, [zs])
+    Tuple of x, y, and optionally z vectors, transformed into the target
+    coordinate reference system.
     """
     return _transform(src_crs, dst_crs, xs, ys, zs)
 
 
 def transform_geom(
-        src_crs, dst_crs, geom,
-        antimeridian_cutting=False, antimeridian_offset=10.0, precision=-1):
-    """Return transformed geometry."""
+        src_crs,
+        dst_crs,
+        geom,
+        antimeridian_cutting=False,
+        antimeridian_offset=10.0,
+        precision=-1):
+    """
+    Transform geometry from source coordinate reference system into target.
+
+    Parameters
+    ------------
+    src_crs: dict
+        Source coordinate reference system, in rasterio dict format.
+        Example: {'init': 'EPSG:4326'}
+    dst_crs: dict
+        Target coordinate reference system.
+    geom: GeoJSON like dict object
+    antimeridian_cutting: bool, optional
+        If True, cut geometries at the antimeridian, otherwise geometries will
+        not be cut (default).
+    antimeridian_offset: float
+        Offset from the antimeridian in degrees (default: 10) within which
+        any geometries will be split.
+    precision: float
+        If >= 0, geometry coordinates will be rounded to this number of decimal
+        places after the transform operation, otherwise original coordinate
+        values will be preserved (default).
+
+    Returns
+    ---------
+    out: GeoJSON like dict object
+        Transformed geometry in GeoJSON dict format
+    """
+
     return _transform_geom(
-        src_crs, dst_crs, geom,
-        antimeridian_cutting, antimeridian_offset, precision)
+        src_crs,
+        dst_crs,
+        geom,
+        antimeridian_cutting,
+        antimeridian_offset,
+        precision)
 
 
 def reproject(
-        source, destination,
-        src_transform=None, src_crs=None,
-        dst_transform=None, dst_crs=None,
+        source,
+        destination,
+        src_transform=None,
+        src_crs=None,
+        dst_transform=None,
+        dst_crs=None,
         resampling=RESAMPLING.nearest,
         **kwargs):
-    """Reproject a source raster to a destination.
-
-    If the source and destination are ndarrays, coordinate reference
-    system definitions and affine transformation parameters are required
-    for reprojection.
-
-    If the source and destination are rasterio Bands, shorthand for
-    bands of datasets on disk, the coordinate reference systems and
-    transforms will be read from the appropriate datasets.
     """
+    Reproject a source raster to a destination raster.
+
+    Parameters
+    ------------
+    source: ndarray or rasterio Band
+        Source raster.
+    destination: ndarray or rasterio Band
+        Target raster.
+    src_transform: affine transform object, optional
+        Source affine transformation.  Required if source and destination
+        are ndarrays.  Will be derived from source if it is a rasterio Band.
+    src_crs: dict, optional
+        Source coordinate reference system, in rasterio dict format.
+        Required if source and destination are ndarrays.
+        Will be derived from source if it is a rasterio Band.
+        Example: {'init': 'EPSG:4326'}
+    dst_transform: affine transform object, optional
+        Target affine transformation.  Required if source and destination
+        are ndarrays.  Will be derived from target if it is a rasterio Band.
+    dst_crs: dict, optional
+        Target coordinate reference system.  Required if source and destination
+        are ndarrays.  Will be derived from target if it is a rasterio Band.
+    resampling: int
+        Resampling method to use.  One of the following:
+            RESAMPLING.nearest,
+            RESAMPLING.bilinear,
+            RESAMPLING.cubic,
+            RESAMPLING.cubic_spline,
+            RESAMPLING.lanczos,
+            RESAMPLING.average,
+            RESAMPLING.mode
+    kwargs:  dict, optional
+        Additional arguments passed to transformation function.
+
+    Returns
+    ---------
+    out: None
+        Output is written to destination.
+    """
+
     if src_transform:
         src_transform = guard_transform(src_transform).to_gdal()
     if dst_transform:
         dst_transform = guard_transform(dst_transform).to_gdal()
 
     _reproject(
-        source, destination,
-        src_transform, src_crs,
-        dst_transform, dst_crs,
-        resampling, **kwargs)
+        source,
+        destination,
+        src_transform,
+        src_crs,
+        dst_transform,
+        dst_crs,
+        resampling,
+        **kwargs)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -12,6 +12,7 @@ from rasterio.warp import reproject, RESAMPLING, transform_geom, transform
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
+
 def test_transform():
     """2D and 3D"""
     WGS84_crs = {'init': 'EPSG:4326'}
@@ -26,34 +27,36 @@ def test_transform():
     UTM33_result = transform(WGS84_crs, UTM33_crs, *WGS84_points[:2])
     assert numpy.allclose(numpy.array(UTM33_result), numpy.array(UTM33_points))
 
+
 def test_reproject():
     """Ndarry to ndarray"""
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             source = src.read_band(1)
-        dst_transform = affine.Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
+        dst_transform = affine.Affine.from_gdal(
+            -8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
         dst_crs = dict(
-                    proj='merc',
-                    a=6378137,
-                    b=6378137,
-                    lat_ts=0.0,
-                    lon_0=0.0,
-                    x_0=0.0,
-                    y_0=0,
-                    k=1.0,
-                    units='m',
-                    nadgrids='@null',
-                    wktext=True,
-                    no_defs=True)
+            proj='merc',
+            a=6378137,
+            b=6378137,
+            lat_ts=0.0,
+            lon_0=0.0,
+            x_0=0.0,
+            y_0=0,
+            k=1.0,
+            units='m',
+            nadgrids='@null',
+            wktext=True,
+            no_defs=True)
         destin = numpy.empty(src.shape, dtype=numpy.uint8)
         reproject(
-            source, 
+            source,
             destin,
             src_transform=src.transform,
             src_crs=src.crs,
-            dst_transform=dst_transform, 
+            dst_transform=dst_transform,
             dst_crs=dst_crs,
-            resampling=RESAMPLING.nearest )
+            resampling=RESAMPLING.nearest)
     assert destin.any()
     try:
         import matplotlib.pyplot as plt
@@ -62,6 +65,7 @@ def test_reproject():
         plt.savefig('test_reproject.png')
     except:
         pass
+
 
 def test_reproject_multi():
     """Ndarry to ndarray"""
@@ -69,29 +73,29 @@ def test_reproject_multi():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             source = src.read()
         dst_transform = affine.Affine.from_gdal(
-                            -8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
+            -8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
         dst_crs = dict(
-                    proj='merc',
-                    a=6378137,
-                    b=6378137,
-                    lat_ts=0.0,
-                    lon_0=0.0,
-                    x_0=0.0,
-                    y_0=0,
-                    k=1.0,
-                    units='m',
-                    nadgrids='@null',
-                    wktext=True,
-                    no_defs=True)
+            proj='merc',
+            a=6378137,
+            b=6378137,
+            lat_ts=0.0,
+            lon_0=0.0,
+            x_0=0.0,
+            y_0=0,
+            k=1.0,
+            units='m',
+            nadgrids='@null',
+            wktext=True,
+            no_defs=True)
         destin = numpy.empty(source.shape, dtype=numpy.uint8)
         reproject(
-            source, 
+            source,
             destin,
             src_transform=src.transform,
             src_crs=src.crs,
-            dst_transform=dst_transform, 
+            dst_transform=dst_transform,
             dst_crs=dst_crs,
-            resampling=RESAMPLING.nearest )
+            resampling=RESAMPLING.nearest)
     assert destin.any()
     try:
         import matplotlib.pyplot as plt
@@ -101,28 +105,30 @@ def test_reproject_multi():
     except:
         pass
 
+
 def test_warp_from_file():
     """File to ndarray"""
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        dst_transform = affine.Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
+        dst_transform = affine.Affine.from_gdal(
+            -8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
         dst_crs = dict(
-                    proj='merc',
-                    a=6378137,
-                    b=6378137,
-                    lat_ts=0.0,
-                    lon_0=0.0,
-                    x_0=0.0,
-                    y_0=0,
-                    k=1.0,
-                    units='m',
-                    nadgrids='@null',
-                    wktext=True,
-                    no_defs=True)
+            proj='merc',
+            a=6378137,
+            b=6378137,
+            lat_ts=0.0,
+            lon_0=0.0,
+            x_0=0.0,
+            y_0=0,
+            k=1.0,
+            units='m',
+            nadgrids='@null',
+            wktext=True,
+            no_defs=True)
         destin = numpy.empty(src.shape, dtype=numpy.uint8)
         reproject(
-            rasterio.band(src, 1), 
-            destin, 
-            dst_transform=dst_transform, 
+            rasterio.band(src, 1),
+            destin,
+            dst_transform=dst_transform,
             dst_crs=dst_crs)
     assert destin.any()
     try:
@@ -133,24 +139,26 @@ def test_warp_from_file():
     except:
         pass
 
+
 def test_warp_from_to_file(tmpdir):
     """File to file"""
     tiffname = str(tmpdir.join('foo.tif'))
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        dst_transform = affine.Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
+        dst_transform = affine.Affine.from_gdal(
+            -8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
         dst_crs = dict(
-                    proj='merc',
-                    a=6378137,
-                    b=6378137,
-                    lat_ts=0.0,
-                    lon_0=0.0,
-                    x_0=0.0,
-                    y_0=0,
-                    k=1.0,
-                    units='m',
-                    nadgrids='@null',
-                    wktext=True,
-                    no_defs=True)
+            proj='merc',
+            a=6378137,
+            b=6378137,
+            lat_ts=0.0,
+            lon_0=0.0,
+            x_0=0.0,
+            y_0=0,
+            k=1.0,
+            units='m',
+            nadgrids='@null',
+            wktext=True,
+            no_defs=True)
         kwargs = src.meta.copy()
         kwargs.update(
             transform=dst_transform,
@@ -160,24 +168,26 @@ def test_warp_from_to_file(tmpdir):
                 reproject(rasterio.band(src, i), rasterio.band(dst, i))
     # subprocess.call(['open', tiffname])
 
+
 def test_warp_from_to_file_multi(tmpdir):
     """File to file"""
     tiffname = str(tmpdir.join('foo.tif'))
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        dst_transform = affine.Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
+        dst_transform = affine.Affine.from_gdal(
+            -8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
         dst_crs = dict(
-                    proj='merc',
-                    a=6378137,
-                    b=6378137,
-                    lat_ts=0.0,
-                    lon_0=0.0,
-                    x_0=0.0,
-                    y_0=0,
-                    k=1.0,
-                    units='m',
-                    nadgrids='@null',
-                    wktext=True,
-                    no_defs=True)
+            proj='merc',
+            a=6378137,
+            b=6378137,
+            lat_ts=0.0,
+            lon_0=0.0,
+            x_0=0.0,
+            y_0=0,
+            k=1.0,
+            units='m',
+            nadgrids='@null',
+            wktext=True,
+            no_defs=True)
         kwargs = src.meta.copy()
         kwargs.update(
             transform=dst_transform,
@@ -185,14 +195,67 @@ def test_warp_from_to_file_multi(tmpdir):
         with rasterio.open(tiffname, 'w', **kwargs) as dst:
             for i in (1, 2, 3):
                 reproject(
-                    rasterio.band(src, i), 
+                    rasterio.band(src, i),
                     rasterio.band(dst, i),
                     num_threads=2)
     # subprocess.call(['open', tiffname])
 
-def test_transform_geom_wrap():
-    geom = {'type': 'Polygon', 'coordinates': (((798842.3090855901, 6569056.500655151), (756688.2826828464, 6412397.888771972), (755571.0617232556, 6408461.009397383), (677605.2284582685, 6425600.39266733), (677605.2284582683, 6425600.392667332), (670873.3791649605, 6427248.603432341), (664882.1106069803, 6407585.48425362), (663675.8662823177, 6403676.990080649), (485120.71963574126, 6449787.167760638), (485065.55660851026, 6449802.826920689), (485957.03982722526, 6452708.625101285), (487541.24541826674, 6457883.292107048), (531008.5797472061, 6605816.560367976), (530943.7197027118, 6605834.9333479265), (531888.5010308184, 6608940.750411527), (533299.5981959199, 6613962.642851984), (533403.6388841148, 6613933.172096095), (576345.6064638699, 6761983.708069147), (577649.6721159086, 6766698.137844516), (578600.3589008929, 6770143.99782289), (578679.4732294685, 6770121.638265098), (655836.640492081, 6749376.357102599), (659913.0791150068, 6764770.1314677475), (661105.8478791204, 6769515.168134831), (661929.4670843681, 6772800.8565198565), (661929.4670843673, 6772800.856519875), (661975.1582566603, 6772983.354777632), (662054.7979028501, 6772962.86384242), (841909.6014891531, 6731793.200435557), (840726.455490463, 6727039.8672589315), (798842.3090855901, 6569056.500655151)),)}
+
+def test_transform_geom():
+    geom = {
+        'type': 'Polygon',
+        'coordinates': (
+            ((798842.3090855901, 6569056.500655151),
+                (756688.2826828464, 6412397.888771972),
+                (755571.0617232556, 6408461.009397383),
+                (677605.2284582685, 6425600.39266733),
+                (677605.2284582683, 6425600.392667332),
+                (670873.3791649605, 6427248.603432341),
+                (664882.1106069803, 6407585.48425362),
+                (663675.8662823177, 6403676.990080649),
+                (485120.71963574126, 6449787.167760638),
+                (485065.55660851026, 6449802.826920689),
+                (485957.03982722526, 6452708.625101285),
+                (487541.24541826674, 6457883.292107048),
+                (531008.5797472061, 6605816.560367976),
+                (530943.7197027118, 6605834.9333479265),
+                (531888.5010308184, 6608940.750411527),
+                (533299.5981959199, 6613962.642851984),
+                (533403.6388841148, 6613933.172096095),
+                (576345.6064638699, 6761983.708069147),
+                (577649.6721159086, 6766698.137844516),
+                (578600.3589008929, 6770143.99782289),
+                (578679.4732294685, 6770121.638265098),
+                (655836.640492081, 6749376.357102599),
+                (659913.0791150068, 6764770.1314677475),
+                (661105.8478791204, 6769515.168134831),
+                (661929.4670843681, 6772800.8565198565),
+                (661929.4670843673, 6772800.856519875),
+                (661975.1582566603, 6772983.354777632),
+                (662054.7979028501, 6772962.86384242),
+                (841909.6014891531, 6731793.200435557),
+                (840726.455490463, 6727039.8672589315),
+                (798842.3090855901, 6569056.500655151)),
+            )
+    }
+
+    result = transform_geom('EPSG:3373', 'EPSG:4326', geom)
+    assert result['type'] == 'Polygon'
+    assert len(result['coordinates']) == 1
+
     result = transform_geom(
-                'EPSG:3373', 'EPSG:4326', geom, antimeridian_cutting=True)
+        'EPSG:3373', 'EPSG:4326', geom, antimeridian_cutting=True)
     assert result['type'] == 'MultiPolygon'
     assert len(result['coordinates']) == 2
+
+    result = transform_geom(
+        'EPSG:3373', 
+        'EPSG:4326', 
+        geom, 
+        antimeridian_cutting=True, 
+        antimeridian_offset=0)
+    assert result['type'] == 'MultiPolygon'
+    assert len(result['coordinates']) == 2
+
+    result = transform_geom('EPSG:3373', 'EPSG:4326',  geom,  precision=1)
+    assert int(result['coordinates'][0][0][0] * 10) == -1778


### PR DESCRIPTION
Still chipping away at #161 

This adds numpy style docstrings to `warp.py`, deals with some PEP8 line break issues, and adds a couple permutations to the tests for `transform_geom` (though still not totally complete as far as unit tests).

No functional code in `warp.py` was changed, only changes are formatting (apologies for the quantity of lines involved).
