### PR TITLE
Prevent segfault caused by reading invalid raster window.

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -593,6 +593,14 @@ cpdef eval_window(object window, int height, int width):
     if not c_stop >= c_start:
         raise ValueError(
             "invalid window: col range (%d, %d)" % (c_start, c_stop))
+    if height > 0:
+        if r_stop > height:
+            raise ValueError(
+                "invalid window: row range (%d, %d)" % (r_start, r_stop))
+    if width > 0:
+        if c_stop > width:
+            raise ValueError(
+                "invalid window: col range (%d, %d)" % (c_start, c_stop))
     return (r_start, r_stop), (c_start, c_stop)
 
 def window_shape(window, height=-1, width=-1):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -52,6 +52,15 @@ class WindowTest(unittest.TestCase):
         self.assertEqual(
             rasterio.eval_window(((None, -10), (None, -10)), 100, 90),
             ((0, 90), (0, 80)))
+    def test_eval_outofbounds(self):
+        self.assertRaises(
+            ValueError,
+            rasterio.eval_window,
+            ((0, 101), (0, 150)), 100, 150)
+        self.assertRaises(
+            ValueError,
+            rasterio.eval_window,
+            ((0, 100), (0, 151)), 100, 150)
 
 def test_window_index():
     idx = rasterio.window_index(((0,4),(1,12)))


### PR DESCRIPTION
Previously the following code would cause a segmentation fault:

```
import rasterio
filename = '/Users/snorf/Downloads/rasterio/tests/data/RGB.byte.tif'
with rasterio.open(filename, 'r') as src:
    data = src.read(1, window=((0, src.height+1), (0, 1)))
```

The code attempts to read data from a raster outside of the raster extent. This commit adds some code to `eval_window` to catch this before it happens and raise a `ValueError` instead.
