### PR TITLE
Remove excessively strict transform check.

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -1,12 +1,14 @@
-
 import warnings
 
 from affine import Affine
 
 IDENTITY = Affine.identity()
 
-def tastes_like_gdal(t):
-    return t[2] == t[4] == 0.0 and t[1] > 0 and t[5] < 0
+
+def tastes_like_gdal(seq):
+    """Return True if `seq` matches the GDAL geotransform pattern."""
+    return seq[2] == seq[4] == 0.0 and seq[1] > 0 and seq[5] < 0
+
 
 def guard_transform(transform):
     """Return an Affine transformation instance"""
@@ -20,10 +22,4 @@ def guard_transform(transform):
             transform = Affine.from_gdal(*transform)
         else:
             transform = Affine(*transform)
-    a, e = transform.a, transform.e
-    if a == 0.0 or e == 0.0:
-        raise ValueError(
-            "Transform has invalid coefficients a, e: (%f, %f)" % (
-                transform.a, transform.e))
     return transform
-

--- a/tests/test_no_georef.py
+++ b/tests/test_no_georef.py
@@ -1,0 +1,30 @@
+# You should be able to write rasters with no georeferencing, e.g., plain old
+# PNGs and JPEGs.
+
+import rasterio
+
+
+def test_write(tmpdir):
+    name = str(tmpdir.join("test.png"))
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        kwargs = src.meta.copy()
+        del kwargs['affine']
+        del kwargs['transform']
+        del kwargs['crs']
+        kwargs['driver'] = 'PNG'
+        with rasterio.open(name, 'w', **kwargs) as dst:
+            dst.write(src.read())
+
+
+def test_read_write(tmpdir):
+    tif1 = str(tmpdir.join("test.tif"))
+    tif2 = str(tmpdir.join("test2.tif"))
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        kwargs = src.meta.copy()
+        del kwargs['affine']
+        del kwargs['transform']
+        del kwargs['crs']
+        with rasterio.open(tif1, 'w', **kwargs) as dst:
+            dst.write(src.read())
+    with rasterio.open(tif1) as src, rasterio.open(tif2, 'w', **src.meta) as dst:
+        dst.write(src.read())


### PR DESCRIPTION
Was introduced in 1be2c0f. Now we can again translate rasters with no georeferencing.

Closes #210.
