### PR TITLE
Fixed proper handling of verbosity and output shape for rio merge

### DIFF
--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -26,7 +26,7 @@ def merge(ctx, files, driver):
     """
     import numpy as np
 
-    verbosity = ctx.obj['verbosity']
+    verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')
     try:
         with rasterio.drivers(CPL_DEBUG=verbosity>2):
@@ -36,7 +36,8 @@ def merge(ctx, files, driver):
             with rasterio.open(files[0]) as first:
                 kwargs = first.meta
                 kwargs['transform'] = kwargs.pop('affine')
-                dest = np.empty((3,) + first.shape, dtype=first.dtypes[0])
+                dest = np.empty((first.count,) + first.shape, 
+                    dtype=first.dtypes[0])
 
             if os.path.exists(output):
                 dst = rasterio.open(output, 'r+')

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -43,10 +43,10 @@ def test_data_dir(tmpdir):
 
 def test_merge(test_data_dir):
     outputname = str(test_data_dir.join('merged.tif'))
+    inputs = [str(x) for x in test_data_dir.listdir()]
+    inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(
-        merge,
-        [str(x) for x in test_data_dir.listdir()] + [outputname])
+    result = runner.invoke(merge, inputs + [outputname])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
     with rasterio.open(outputname) as out:

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -1,0 +1,91 @@
+import sys
+import os
+import logging
+import click
+import numpy
+from click.testing import CliRunner
+from pytest import fixture
+
+import rasterio
+from rasterio.rio.merge import merge
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+
+
+# Fixture to create test datasets within temporary directory
+@fixture(scope='function')
+def test_data_dir(tmpdir):
+    kwargs = {
+        "crs": {'init': 'epsg:4326'},
+        "transform": (-114, 0.2, 0, 46, 0, -0.1),
+        "count": 1,
+        "dtype": rasterio.uint8,
+        "driver": "GTiff",
+        "width": 10,
+        "height": 10,
+        "nodata": 0
+    }
+
+    with rasterio.drivers():
+        with rasterio.open(str(tmpdir.join('one.tif')), 'w', **kwargs) as dst:
+            data = numpy.zeros((10, 10), dtype=rasterio.uint8)
+            data[0:6, 0:6] = 255
+            dst.write_band(1, data)
+
+        with rasterio.open(str(tmpdir.join('two.tif')), 'w', **kwargs) as dst:
+            data = numpy.zeros((10, 10), dtype=rasterio.uint8)
+            data[4:8, 4:8] = 254
+            dst.write_band(1, data)
+
+    return tmpdir
+
+
+def test_merge(test_data_dir):
+    outputname = str(test_data_dir.join('merged.tif'))
+    runner = CliRunner()
+    result = runner.invoke(
+        merge,
+        [str(x) for x in test_data_dir.listdir()] + [outputname])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+    with rasterio.open(outputname) as out:
+        assert out.count == 1
+        data = out.read_band(1, masked=False)
+        expected = numpy.zeros((10, 10), dtype=rasterio.uint8)
+        expected[0:6, 0:6] = 255
+        expected[4:8, 4:8] = 254
+        assert numpy.all(data == expected)
+
+
+def test_merge_output_exists(tmpdir):
+    outputname = str(tmpdir.join('merged.tif'))
+    runner = CliRunner()
+    result = runner.invoke(
+        merge,
+        ['tests/data/RGB.byte.tif', outputname])
+    assert result.exit_code == 0
+    result = runner.invoke(
+        merge,
+        ['tests/data/RGB.byte.tif', outputname])
+    assert os.path.exists(outputname)
+    with rasterio.open(outputname) as out:
+        assert out.count == 3
+
+
+def test_merge_err():
+    runner = CliRunner()
+    result = runner.invoke(
+        merge,
+        ['tests'])
+    assert result.exit_code == 1
+
+
+def test_format_jpeg(tmpdir):
+    outputname = str(tmpdir.join('stacked.jpg'))
+    runner = CliRunner()
+    result = runner.invoke(
+        merge,
+        ['tests/data/RGB.byte.tif', outputname, '--format', 'JPEG'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)


### PR DESCRIPTION
This fixes two bugs in ```merge```:

* ```verbosity``` was not always defined, and thus broke tests once they were created
* the shape of the destination image was hardcoded to always have 3 bands regardless of input number of bands

This also adds tests for 100% coverage.  Includes a test fixture for generating test data files; we may want to consider this pattern for other tests as well.

I'm getting flakey results from travis-ci for a simple array equality test; some python versions pass sometimes and others do not.  It should be an all or nothing proposition.  All tests pass locally (Linux Mint 17, Python 2.7.6).