### PR TITLE
Use setuptools>=0.9.8 since earlier versions don't Cythonize C files

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,5 @@ delocate
 enum34
 numpy>=1.8.0
 pytest
-setuptools
+setuptools>=0.9.8
 wheel

--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,22 @@
 # source or binary distribution. This is essential when creating self-contained
 # binary wheels.
 
-import logging
 import os
-import shutil
-import subprocess
 import sys
-from setuptools import setup
+import pprint
+import shutil
+import logging
+import subprocess
 
-from distutils.extension import Extension
+from setuptools import setup
+from setuptools.extension import Extension
 
 logging.basicConfig()
 log = logging.getLogger()
+
+# python -W all setup.py ...
+if 'all' in sys.warnoptions:
+    log.level = logging.DEBUG
 
 # Parse the version from the fiona module.
 with open('rasterio/__init__.py') as f:
@@ -103,6 +108,8 @@ ext_options = dict(
     library_dirs=library_dirs,
     libraries=libraries,
     extra_link_args=extra_link_args)
+
+log.debug('ext_options:\n%s', pprint.pformat(ext_options))
 
 # When building from a repo, Cython is required.
 if os.path.exists("MANIFEST.in") and "clean" not in sys.argv:

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@
 # source or binary distribution. This is essential when creating self-contained
 # binary wheels.
 
+import logging
 import os
-import sys
 import pprint
 import shutil
-import logging
 import subprocess
+import sys
 
 from setuptools import setup
 from setuptools.extension import Extension


### PR DESCRIPTION
My CentOS 6.6 console, managed by someone else, has setuptools version 0.6.10-3.el6, and runs into trouble Cythonizing from setup.py, since it doesn't generate the .c files:
```
$ python setup.py build_ext --inplace
running build_ext
building 'rasterio._base' extension
creating build
creating build/temp.linux-x86_64-2.6
creating build/temp.linux-x86_64-2.6/rasterio
gcc -pthread -fno-strict-aliasing -O2 -g <snip> -c rasterio/_base.c -o build/temp.linux-x86_64-2.6/rasterio/_base.o
gcc: rasterio/_base.c: No such file or directory
gcc: no input files
error: command 'gcc' failed with exit status 1
```

Upgrading the setuptools minimum version fixes the issue.

Change Extension import from distutils to setuptools.

Also add "-W all" debug output to setup.py logger