### PR TITLE
Tag equality

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -498,7 +498,7 @@ cdef class DatasetReader(object):
             item_c = papszStrList[i]
             item_b = item_c
             item = item_b.decode('utf-8')
-            key, value = item.split('=')
+            key, value = item.split('=', 1)
             retval[key] = value
         return retval
     

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -54,3 +54,11 @@ def test_tags_update_twice():
         assert dst.tags() == {'a': '1', 'b': '2'}
         dst.update_tags(c=3)
         assert dst.tags() == {'a': '1', 'b': '2', 'c': '3'}
+
+
+def test_tags_eq():
+    with rasterio.open(
+            'test.tif', 'w', 
+            'GTiff', 3, 4, 1, dtype=rasterio.ubyte) as dst:
+        dst.update_tags(a="foo=bar")
+        assert dst.tags() == {'a': "foo=bar"}


### PR DESCRIPTION
GDALs metadata items are encoded like `"KEY=VALUE"`. Making sure that when there's an equal sign in `VALUE` (like `FOO=BAR`), we get tags like `"KEY": "FOO=BAR"`.