### PR TITLE
Removed Cython compile warnings

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -99,13 +99,13 @@ cdef class DatasetReader(object):
 
     def read_crs(self):
         cdef char *proj_c = NULL
-        cdef char *auth_key = NULL
-        cdef char *auth_val = NULL
+        cdef const char * auth_key = NULL
+        cdef const char * auth_val = NULL
         cdef void *osr = NULL
         if self._hds == NULL:
             raise ValueError("Null dataset")
         crs = {}
-        cdef char *wkt = _gdal.GDALGetProjectionRef(self._hds)
+        cdef const char * wkt = _gdal.GDALGetProjectionRef(self._hds)
         if wkt is NULL:
             raise ValueError("Unexpected NULL spatial reference")
         wkt_b = wkt
@@ -166,7 +166,7 @@ cdef class DatasetReader(object):
         cdef char *proj_c = NULL
         cdef char *key_c = NULL
         cdef void *osr = NULL
-        cdef char *wkt = NULL
+        cdef const char * wkt = NULL
         if self._hds == NULL:
             raise ValueError("Null dataset")
         wkt = _gdal.GDALGetProjectionRef(self._hds)
@@ -521,7 +521,7 @@ cdef class DatasetReader(object):
         cdef void *hBand
         cdef void *hTable
         cdef int i
-        cdef _gdal.GDALColorEntry *color
+        cdef const _gdal.GDALColorEntry * color
         if self._hds == NULL:
             raise ValueError("can't read closed raster file")
         if bidx not in self.indexes:

--- a/rasterio/_drivers.pyx
+++ b/rasterio/_drivers.pyx
@@ -129,8 +129,8 @@ cdef class GDALEnv(object):
 
     def drivers(self):
         cdef void *drv = NULL
-        cdef char *key = NULL
-        cdef char *val = NULL
+        cdef const char *key = NULL
+        cdef const char *val = NULL
         cdef int i
         result = {}
         for i in range(GDALGetDriverCount()):

--- a/rasterio/_err.pyx
+++ b/rasterio/_err.pyx
@@ -61,7 +61,7 @@ cdef class GDALErrCtxManager:
     def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
         cdef int err_type = CPLGetLastErrorType()
         cdef int err_no = CPLGetLastErrorNo()
-        cdef char *msg = CPLGetLastErrorMsg()
+        cdef const char *msg = CPLGetLastErrorMsg()
         # TODO: warn for err_type 2?
         if err_type >= 3:
             raise exception_map[err_no](msg)

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -50,12 +50,12 @@ def _shapes(image, mask, connectivity, transform):
     """
 
     cdef int retval, rows, cols
-    cdef void *hband
-    cdef void *hmaskband
-    cdef void *hfdriver
-    cdef void *hfs
-    cdef void *hlayer
-    cdef void *fielddefn
+    cdef void *hband = NULL
+    cdef void *hmaskband = NULL
+    cdef void *hfdriver = NULL
+    cdef void *hfs = NULL
+    cdef void *hlayer = NULL
+    cdef void *fielddefn = NULL
     cdef _io.RasterReader rdr
     cdef _io.RasterReader mrdr
     cdef char **options = NULL
@@ -162,9 +162,9 @@ def _sieve(image, size, output, mask, connectivity):
     cdef InMemoryRaster in_mem_ds = None
     cdef InMemoryRaster out_mem_ds = None
     cdef InMemoryRaster mask_mem_ds = None
-    cdef void *in_band
-    cdef void *out_band
-    cdef void *mask_band
+    cdef void *in_band = NULL
+    cdef void *out_band = NULL
+    cdef void *mask_band = NULL
     cdef _io.RasterReader rdr
     cdef _io.RasterUpdater udr
     cdef _io.RasterReader mask_reader
@@ -414,12 +414,6 @@ cdef class GeomBuilder:
         result = self.build(cogr_geometry)
         _deleteOgrGeom(cogr_geometry)
         return result
-
-
-cdef geometry(void *geom):
-    """Returns a GeoJSON object from an OGR geometry object."""
-
-    return GeomBuilder().build(geom)
 
 
 cdef class OGRGeomBuilder:

--- a/rasterio/_gdal.pxd
+++ b/rasterio/_gdal.pxd
@@ -101,7 +101,7 @@ cdef extern from "gdal.h" nogil:
         short c3
         short c4
 
-    const GDALColorEntry *GDALGetColorEntry (void *hTable, int)
+    const GDALColorEntry * GDALGetColorEntry (void *hTable, int)
     void GDALSetColorEntry (void *hTable, int i, const GDALColorEntry *poEntry)
     int GDALSetRasterColorTable (void *hBand, void *hTable)
     void *GDALGetRasterColorTable (void *hBand)

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -911,7 +911,8 @@ cdef class RasterUpdater(RasterReader):
     def start(self):
         cdef const char *drv_name = NULL
         cdef char **options = NULL
-        cdef char *key_c, *val_c = NULL
+        cdef char *key_c = NULL
+        cdef char *val_c = NULL
         cdef void *drv = NULL
         cdef void *hband = NULL
         cdef int success
@@ -1308,7 +1309,7 @@ cdef class RasterUpdater(RasterReader):
 
     def write_colormap(self, bidx, colormap):
         """Write a colormap for a band to the dataset."""
-        cdef void *hBand
+        cdef void *hBand = NULL
         cdef void *hTable
         cdef _gdal.GDALColorEntry color
         if self._hds == NULL:
@@ -1412,6 +1413,7 @@ cdef class InMemoryRaster:
         self.dataset = NULL
 
         cdef void *memdriver = _gdal.GDALGetDriverByName("MEM")
+        cdef int i = 0  # avoids Cython warning in for loop below
 
         # Several GDAL operations require the array of band IDs as input
         self.band_ids[0] = 1
@@ -1548,7 +1550,8 @@ cdef class IndirectRasterUpdater(RasterUpdater):
     def close(self):
         cdef const char *drv_name = NULL
         cdef char **options = NULL
-        cdef char *key_c, *val_c = NULL
+        cdef char *key_c = NULL
+        cdef char *val_c = NULL
         cdef void *drv = NULL
         cdef void *temp = NULL
         cdef int success
@@ -1598,7 +1601,7 @@ def writer(path, mode, **kwargs):
     # format driver's capabilities.
     cdef void *hds = NULL
     cdef void *drv = NULL
-    cdef char *drv_name = NULL
+    cdef const char *drv_name = NULL
     cdef const char *fname = NULL
 
     if mode == 'w' and 'driver' in kwargs:

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -80,8 +80,7 @@ def tastes_like_gdal(t):
 
 cdef void *_osr_from_crs(object crs):
     cdef char *proj_c = NULL
-    cdef void *osr
-    osr = _gdal.OSRNewSpatialReference(NULL)
+    cdef void *osr = _gdal.OSRNewSpatialReference(NULL)
     params = []
     # Normally, we expect a CRS dict.
     if isinstance(crs, dict):
@@ -112,10 +111,13 @@ cdef void *_osr_from_crs(object crs):
 
 
 def _transform(src_crs, dst_crs, xs, ys, zs):
-    cdef double *x, *y, *z = NULL
+    cdef double *x = NULL
+    cdef double *y = NULL
+    cdef double *z = NULL
     cdef char *proj_c = NULL
-    cdef void *src, *dst
-    cdef void *transform
+    cdef void *src = NULL
+    cdef void *dst = NULL
+    cdef void *transform = NULL
     cdef int i
 
     assert len(xs) == len(ys)
@@ -174,11 +176,12 @@ def _transform_geom(
     cdef char *key_c = NULL
     cdef char *val_c = NULL
     cdef char **options = NULL
-    cdef void *src, *dst
-    cdef void *transform
-    cdef OGRGeometryFactory *factory
-    cdef void *src_ogr_geom
-    cdef void *dst_ogr_geom
+    cdef void *src = NULL
+    cdef void *dst = NULL
+    cdef void *transform = NULL
+    cdef OGRGeometryFactory *factory = NULL
+    cdef void *src_ogr_geom = NULL
+    cdef void *dst_ogr_geom = NULL
     cdef int i
 
     src = _osr_from_crs(src_crs)
@@ -259,7 +262,7 @@ def _reproject(
     bands of datasets on disk, the coordinate reference systems and
     transforms will be read from the appropriate datasets.
     """
-    cdef int retval, rows, cols
+    cdef int retval=0, rows, cols
     cdef void *hrdriver
     cdef void *hdsin
     cdef void *hdsout

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ if os.path.exists("MANIFEST.in") and "clean" not in sys.argv:
             'rasterio._err', ['rasterio/_err.pyx'], **ext_options),
         Extension(
             'rasterio._example', ['rasterio/_example.pyx'], **ext_options),
-            ])
+        ], quiet=True)
 
 # If there's no manifest template, as in an sdist, we just specify .c files.
 else:


### PR DESCRIPTION
Resolves #257 

This should remove the Cython compile warnings that originate from rasterio.  There are still some that originate from GDAL and Numpy.

Most warnings were due to using ```char *``` when we should have been using ```const char *```.

Others were mostly due to uninitialized variables.

A few were due to multiple declarations of variables in one statement; Cython usually wants them to be on separate lines.