### PR TITLE
Remove cython profiling from _features and _warp.

### DIFF
--- a/rasterio/_example.pyx
+++ b/rasterio/_example.pyx
@@ -1,3 +1,5 @@
+# cython: boundscheck=False
+
 import numpy
 cimport numpy
 

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -1,4 +1,3 @@
-# cython: profile=True
 
 import logging
 import json

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -1,6 +1,4 @@
 # distutils: language = c++
-# cython: profile=True
-#
 
 from collections import namedtuple
 import logging


### PR DESCRIPTION
Should get a little speedup there. Also remove bounds check from the _example module.