### PR TITLE
Fix masked `out` parameter in `read`

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -588,7 +588,8 @@ cdef class RasterReader(_base.DatasetReader):
         Numpy ndarray
 
         """
-
+        orig_out = out
+        
         return2d = False
         if indexes is None:
             indexes = self.indexes
@@ -703,6 +704,10 @@ cdef class RasterReader(_base.DatasetReader):
                     out = np.ma.masked_where(np.isnan(out), out, copy=False)
                 else:
                     out = np.ma.masked_equal(out, nodatavals[0], copy=False)
+                # Update orig_out
+                if hasattr(orig_out, 'mask'):
+                  orig_out.mask = out.mask
+                  orig_out.fill_value = out.fill_value
             else:
                 out = np.ma.masked_array(out, copy=False)
                 for aix in range(len(indexes)):


### PR DESCRIPTION
See #261.

It looks like `returned = np.ma.masked_equal(out, nodatavals[0], copy=False)` updates the values of `out`, but not the masking details (fill_value, actual mask and maybe more?). `returned` seems to be a view of `out` with different mask and fill_value.

Implementation details should be ironed out before merging.