### PR TITLE
More info

### DIFF
--- a/rasterio/_base.pxd
+++ b/rasterio/_base.pxd
@@ -23,3 +23,4 @@ cdef class DatasetReader:
 
     cdef void *band(self, int bidx)
 
+cdef void *_osr_from_crs(object crs)

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -390,7 +390,9 @@ cdef class DatasetReader(object):
             'count': self.count,
             'crs': self.crs,
             'transform': self.affine.to_gdal(),
-            'affine': self.affine }
+            'affine': self.affine,
+            'res', self.res,
+            'lnglat': self.lnglat() }
         self._read = True
         return m
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -391,12 +391,19 @@ cdef class DatasetReader(object):
             'crs': self.crs,
             'transform': self.affine.to_gdal(),
             'affine': self.affine,
-            'res', self.res,
+            'res': self.res,
             'lnglat': self.lnglat() }
         self._read = True
         return m
 
-    
+    def lnglat(self):
+        w, s, e, n = self.bounds
+        cx = (w + e)/2.0
+        cy = (s + n)/2.0
+        lng, lat = _transform(
+                self.crs, {'init': 'epsg:4326'}, [cx], [cy], None)
+        return lng.pop(), lat.pop()
+
     def get_crs(self):
         # _read tells us that the CRS was read before and really is
         # None.
@@ -592,6 +599,7 @@ cpdef eval_window(object window, int height, int width):
             "invalid window: col range (%d, %d)" % (c_start, c_stop))
     return (r_start, r_stop), (c_start, c_stop)
 
+
 def window_shape(window, height=-1, width=-1):
     """Returns shape of a window.
 
@@ -601,8 +609,100 @@ def window_shape(window, height=-1, width=-1):
     (a, b), (c, d) = eval_window(window, height, width)
     return b-a, d-c
 
+
 def window_index(window):
     return tuple(slice(*w) for w in window)
 
+
 def tastes_like_gdal(t):
     return t[2] == t[4] == 0.0 and t[1] > 0 and t[5] < 0
+
+
+cdef void *_osr_from_crs(object crs):
+    cdef char *proj_c = NULL
+    cdef void *osr = _gdal.OSRNewSpatialReference(NULL)
+    params = []
+    # Normally, we expect a CRS dict.
+    if isinstance(crs, dict):
+        # EPSG is a special case.
+        init = crs.get('init')
+        if init:
+            auth, val = init.split(':')
+            if auth.upper() == 'EPSG':
+                _gdal.OSRImportFromEPSG(osr, int(val))
+        else:
+            crs['wktext'] = True
+            for k, v in crs.items():
+                if v is True or (k in ('no_defs', 'wktext') and v):
+                    params.append("+%s" % k)
+                else:
+                    params.append("+%s=%s" % (k, v))
+            proj = " ".join(params)
+            log.debug("PROJ.4 to be imported: %r", proj)
+            proj_b = proj.encode('utf-8')
+            proj_c = proj_b
+            _gdal.OSRImportFromProj4(osr, proj_c)
+    # Fall back for CRS strings like "EPSG:3857."
+    else:
+        proj_b = crs.encode('utf-8')
+        proj_c = proj_b
+        _gdal.OSRSetFromUserInput(osr, proj_c)
+    return osr
+
+
+def _transform(src_crs, dst_crs, xs, ys, zs):
+    cdef double *x = NULL
+    cdef double *y = NULL
+    cdef double *z = NULL
+    cdef char *proj_c = NULL
+    cdef void *src = NULL
+    cdef void *dst = NULL
+    cdef void *transform = NULL
+    cdef int i
+
+    assert len(xs) == len(ys)
+    assert zs is None or len(xs) == len(zs)
+
+    src = _osr_from_crs(src_crs)
+    dst = _osr_from_crs(dst_crs)
+
+    n = len(xs)
+    x = <double *>_gdal.CPLMalloc(n*sizeof(double))
+    y = <double *>_gdal.CPLMalloc(n*sizeof(double))
+    for i in range(n):
+        x[i] = xs[i]
+        y[i] = ys[i]
+
+    if zs is not None:
+        z = <double *>_gdal.CPLMalloc(n*sizeof(double))
+        for i in range(n):
+            z[i] = zs[i]
+
+    transform = _gdal.OCTNewCoordinateTransformation(src, dst)
+    res = _gdal.OCTTransform(transform, n, x, y, z)
+    #if res:
+    #    raise ValueError("Failed coordinate transformation")
+
+    res_xs = [0]*n
+    res_ys = [0]*n
+
+    for i in range(n):
+        res_xs[i] = x[i]
+        res_ys[i] = y[i]
+
+    if zs is not None:
+        res_zs = [0]*n
+        for i in range(n):
+            res_zs[i] = z[i]
+        _gdal.CPLFree(z)
+
+        retval = (res_xs, res_ys, res_zs)
+    else:
+        retval = (res_xs, res_ys)
+
+    _gdal.CPLFree(x)
+    _gdal.CPLFree(y)
+    _gdal.OCTDestroyCoordinateTransformation(transform)
+    _gdal.OSRDestroySpatialReference(src)
+    _gdal.OSRDestroySpatialReference(dst)
+    return retval

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 cimport numpy as np
 
-from rasterio cimport _gdal, _ogr, _io, _features
+from rasterio cimport _base, _gdal, _ogr, _io, _features
 from rasterio import dtypes
 
 
@@ -76,96 +76,6 @@ def tastes_like_gdal(t):
     return t[2] == t[4] == 0.0 and t[1] > 0 and t[5] < 0
 
 
-cdef void *_osr_from_crs(object crs):
-    cdef char *proj_c = NULL
-    cdef void *osr = _gdal.OSRNewSpatialReference(NULL)
-    params = []
-    # Normally, we expect a CRS dict.
-    if isinstance(crs, dict):
-        # EPSG is a special case.
-        init = crs.get('init')
-        if init:
-            auth, val = init.split(':')
-            if auth.upper() == 'EPSG':
-                _gdal.OSRImportFromEPSG(osr, int(val))
-        else:
-            crs['wktext'] = True
-            for k, v in crs.items():
-                if v is True or (k in ('no_defs', 'wktext') and v):
-                    params.append("+%s" % k)
-                else:
-                    params.append("+%s=%s" % (k, v))
-            proj = " ".join(params)
-            log.debug("PROJ.4 to be imported: %r", proj)
-            proj_b = proj.encode('utf-8')
-            proj_c = proj_b
-            _gdal.OSRImportFromProj4(osr, proj_c)
-    # Fall back for CRS strings like "EPSG:3857."
-    else:
-        proj_b = crs.encode('utf-8')
-        proj_c = proj_b
-        _gdal.OSRSetFromUserInput(osr, proj_c)
-    return osr
-
-
-def _transform(src_crs, dst_crs, xs, ys, zs):
-    cdef double *x = NULL
-    cdef double *y = NULL
-    cdef double *z = NULL
-    cdef char *proj_c = NULL
-    cdef void *src = NULL
-    cdef void *dst = NULL
-    cdef void *transform = NULL
-    cdef int i
-
-    assert len(xs) == len(ys)
-    assert zs is None or len(xs) == len(zs)
-
-    src = _osr_from_crs(src_crs)
-    dst = _osr_from_crs(dst_crs)
-
-    n = len(xs)
-    x = <double *>_gdal.CPLMalloc(n*sizeof(double))
-    y = <double *>_gdal.CPLMalloc(n*sizeof(double))
-    for i in range(n):
-        x[i] = xs[i]
-        y[i] = ys[i]
-
-    if zs is not None:
-        z = <double *>_gdal.CPLMalloc(n*sizeof(double))
-        for i in range(n):
-            z[i] = zs[i]
-
-    transform = _gdal.OCTNewCoordinateTransformation(src, dst)
-    res = _gdal.OCTTransform(transform, n, x, y, z)
-    #if res:
-    #    raise ValueError("Failed coordinate transformation")
-
-    res_xs = [0]*n
-    res_ys = [0]*n
-
-    for i in range(n):
-        res_xs[i] = x[i]
-        res_ys[i] = y[i]
-
-    if zs is not None:
-        res_zs = [0]*n
-        for i in range(n):
-            res_zs[i] = z[i]
-        _gdal.CPLFree(z)
-
-        retval = (res_xs, res_ys, res_zs)
-    else:
-        retval = (res_xs, res_ys)
-
-    _gdal.CPLFree(x)
-    _gdal.CPLFree(y)
-    _gdal.OCTDestroyCoordinateTransformation(transform)
-    _gdal.OSRDestroySpatialReference(src)
-    _gdal.OSRDestroySpatialReference(dst)
-    return retval
-
-
 def _transform_geom(
         src_crs, dst_crs, geom, antimeridian_cutting, antimeridian_offset,
         precision):
@@ -182,8 +92,8 @@ def _transform_geom(
     cdef void *dst_ogr_geom = NULL
     cdef int i
 
-    src = _osr_from_crs(src_crs)
-    dst = _osr_from_crs(dst_crs)
+    src = _base._osr_from_crs(src_crs)
+    dst = _base._osr_from_crs(dst_crs)
     transform = _gdal.OCTNewCoordinateTransformation(src, dst)
 
     # Transform options.

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -65,18 +65,25 @@ def env(ctx, key):
               help="Print pixel width and height.")
 @click.option('--lnglat', 'meta_member', flag_value='lnglat',
               help="Print longitude and latitude at center.")
+@click.option('--stats', 'meta_member', flag_value='stats',
+              help="Print statistics (min, max, mean) of a single band "
+                   "(use --bidx).")
+@click.option('-v', '--tell-me-more', '--verbose', is_flag=True,
+              help="Output extra information.")
+@click.option('--bidx', type=int, default=1,
+              help="Input file band index (default: 1).")
 @click.pass_context
-def info(ctx, input, aspect, indent, namespace, meta_member):
+def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx):
     """Print metadata about the dataset as JSON.
 
     Optionally print a single metadata item as a string.
     """
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')
-    stdout = click.get_text_stream('stdout')
+    mode = 'r' if (verbose or meta_member == 'stats') else 'r-'
     try:
         with rasterio.drivers(CPL_DEBUG=(verbosity > 2)):
-            with rasterio.open(input, 'r-') as src:
+            with rasterio.open(input, mode) as src:
                 info = src.meta
                 del info['affine']
                 del info['transform']
@@ -86,19 +93,28 @@ def info(ctx, input, aspect, indent, namespace, meta_member):
                 if proj4.startswith('+init=epsg'):
                     proj4 = proj4.split('=')[1].upper()
                 info['crs'] = proj4
+                if verbose:
+                    stats = [{'min': float(b.min()),
+                              'max': float(b.max()),
+                              'mean': float(b.mean())} for b in src.read()]
+                    info['stats'] = stats
                 if aspect == 'meta':
-                    if meta_member:
+                    if meta_member == 'stats':
+                        band = src.read(bidx)
+                        click.echo('%f %f %f' % (
+                            float(band.min()),
+                            float(band.max()),
+                            float(band.mean())))
+                    elif meta_member:
                         if isinstance(info[meta_member], (list, tuple)):
-                            print(" ".join(map(str, info[meta_member])))
+                            click.echo(" ".join(map(str, info[meta_member])))
                         else:
-                            print(info[meta_member])
+                            click.echo(info[meta_member])
                     else:
-                        stdout.write(json.dumps(info, indent=indent))
-                        stdout.write("\n")
+                        click.echo(json.dumps(info, indent=indent))
                 elif aspect == 'tags':
-                    stdout.write(json.dumps(src.tags(ns=namespace), 
+                    click.echo(json.dumps(src.tags(ns=namespace), 
                                             indent=indent))
-                    stdout.write("\n")
         sys.exit(0)
     except Exception:
         logger.exception("Failed. Exception caught")

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -61,6 +61,10 @@ def env(ctx, key):
 @click.option('--bounds', 'meta_member', flag_value='bounds',
               help="Print the boundary coordinates "
                    "(left, bottom, right, top).")
+@click.option('--res', 'meta_member', flag_value='res',
+              help="Print pixel width and height.")
+@click.option('--lnglat', 'meta_member', flag_value='lnglat',
+              help="Print longitude and latitude at center.")
 @click.pass_context
 def info(ctx, input, aspect, indent, namespace, meta_member):
     """Print metadata about the dataset as JSON.

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -1,6 +1,7 @@
 """Raster warping and reprojection"""
 
-from rasterio._warp import _reproject, _transform, _transform_geom, RESAMPLING
+from rasterio._base import _transform
+from rasterio._warp import _transform_geom, _reproject, RESAMPLING
 from rasterio.transform import guard_transform
 
 

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -77,6 +77,37 @@ def test_info_res():
     runner = CliRunner()
     result = runner.invoke(
         info.info,
-        ['tests/data/RGB.byte.tif', '--res])
+        ['tests/data/RGB.byte.tif', '--res'])
     assert result.exit_code == 0
-    assert result.output == '300.0 300.0\n'
+    assert result.output.startswith('300.037')
+
+
+def test_info_lnglat():
+    runner = CliRunner()
+    result = runner.invoke(
+        info.info,
+        ['tests/data/RGB.byte.tif', '--lnglat'])
+    assert result.exit_code == 0
+    assert result.output.startswith('-77.757')
+
+
+def test_mo_info():
+    runner = CliRunner()
+    result = runner.invoke(info.info, ['tests/data/RGB.byte.tif'])
+    assert result.exit_code == 0
+    assert '"res": [300.037' in result.output
+    assert '"lnglat": [-77.757' in result.output
+
+
+def test_info_stats():
+    runner = CliRunner()
+    result = runner.invoke(info.info, ['tests/data/RGB.byte.tif', '--tell-me-more'])
+    assert result.exit_code == 0
+    assert '"stats": [{"max": 255.0, "mean": 44.4344' in result.output
+
+
+def test_info_stats_only():
+    runner = CliRunner()
+    result = runner.invoke(info.info, ['tests/data/RGB.byte.tif', '--stats', '--bidx', '2'])
+    assert result.exit_code == 0
+    assert result.output.startswith('1.000000 255.000000 66.02')

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -103,7 +103,9 @@ def test_info_stats():
     runner = CliRunner()
     result = runner.invoke(info.info, ['tests/data/RGB.byte.tif', '--tell-me-more'])
     assert result.exit_code == 0
-    assert '"stats": [{"max": 255.0, "mean": 44.4344' in result.output
+    assert '"max": 255.0' in result.output
+    assert '"min": 1.0' in result.output
+    assert '"mean": 44.4344' in result.output
 
 
 def test_info_stats_only():

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -71,3 +71,12 @@ def test_info_tags():
         ['tests/data/RGB.byte.tif', '--tags'])
     assert result.exit_code == 0
     assert result.output == '{"AREA_OR_POINT": "Area"}\n'
+
+
+def test_info_res():
+    runner = CliRunner()
+    result = runner.invoke(
+        info.info,
+        ['tests/data/RGB.byte.tif', '--res])
+    assert result.exit_code == 0
+    assert result.output == '300.0 300.0\n'


### PR DESCRIPTION
This PR adds `res` and `lnglat` items to the standard rio-info output.

Also adds `stats` if you use the `--verbose` option. That option is aliased to `--tell-me-more` for the amusement of @celoyd and myself.

Closes #269.