### PR TITLE
Sampling

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -13,19 +13,21 @@ Rasterio's new command line interface is a program named "rio".
     Options:
       -v, --verbose  Increase verbosity.
       -q, --quiet    Decrease verbosity.
+      --version      Show the version and exit.
       --help         Show this message and exit.
 
     Commands:
       bounds     Write bounding boxes to stdout as GeoJSON.
+      env        Print information about the rio environment.
       info       Print information about a data file.
       insp       Open a data file and start an interpreter.
       merge      Merge a stack of raster datasets.
+      rasterize  Rasterize features.
+      sample     Sample a dataset.
       shapes     Write the shapes of features.
       stack      Stack a number of bands into a multiband dataset.
-      transform  Transform coordinates.
 
-It is developed using the ``click`` package.
-
+It is developed using `Click <http://click.pocoo.org/3/>`__.
 
 bounds
 ------
@@ -84,26 +86,89 @@ Shoot the GeoJSON into a Leaflet map using geojsonio-cli by typing
 info
 ----
 
-Rio's info command intends to serve some of the same uses as gdalinfo.
+Rio's info command prints structured information about a dataset.
 
 .. code-block:: console
 
-    $ rio info tests/data/RGB.byte.tif
-    { 'affine': Affine(300.0379266750948, 0.0, 101985.0,
-           0.0, -300.041782729805, 2826915.0),
-      'count': 3,
-      'crs': { 'init': u'epsg:32618'},
-      'driver': u'GTiff',
-      'dtype': <type 'numpy.uint8'>,
-      'height': 718,
-      'nodata': 0.0,
-      'transform': ( 101985.0,
-                     300.0379266750948,
-                     0.0,
-                     2826915.0,
-                     0.0,
-                     -300.041782729805),
-      'width': 791}
+    $ rio info tests/data/RGB.byte.tif --indent 2
+    {
+      "count": 3,
+      "crs": "EPSG:32618",
+      "dtype": "uint8",
+      "driver": "GTiff",
+      "bounds": [
+        101985.0,
+        2611485.0,
+        339315.0,
+        2826915.0
+      ],
+      "lnglat": [
+        -77.75790625255473,
+        24.561583285327067
+      ],
+      "height": 718,
+      "width": 791,
+      "shape": [
+        718,
+        791
+      ],
+      "res": [
+        300.0379266750948,
+        300.041782729805
+      ],
+      "nodata": 0.0
+    }
+
+More information, such as band statistics, can be had using the `--verbose`
+option.
+
+.. code-block:: console
+
+    $ rio info tests/data/RGB.byte.tif --indent 2
+    {
+      "count": 3,
+      "crs": "EPSG:32618",
+      "stats": [
+        {
+          "max": 255.0,
+          "mean": 44.434478650699106,
+          "min": 1.0
+        },
+        {
+          "max": 255.0,
+          "mean": 66.02203484105824,
+          "min": 1.0
+        },
+        {
+          "max": 255.0,
+          "mean": 71.39316199120559,
+          "min": 1.0
+        }
+      ],
+      "dtype": "uint8",
+      "driver": "GTiff",
+      "bounds": [
+        101985.0,
+        2611485.0,
+        339315.0,
+        2826915.0
+      ],
+      "lnglat": [
+        -77.75790625255473,
+        24.561583285327067
+      ],
+      "height": 718,
+      "width": 791,
+      "shape": [
+        718,
+        791
+      ],
+      "res": [
+        300.0379266750948,
+        300.041782729805
+      ],
+      "nodata": 0.0
+    }
 
 insp
 ----
@@ -113,25 +178,12 @@ The insp command opens a dataset and an interpreter.
 .. code-block:: console
 
     $ rio insp tests/data/RGB.byte.tif
-    Rasterio 0.9 Interactive Inspector (Python 2.7.5)
+    Rasterio 0.18 Interactive Inspector (Python 2.7.9)
     Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
-    >>> import pprint
-    >>> pprint.pprint(src.meta)
-    {'affine': Affine(300.0379266750948, 0.0, 101985.0,
-           0.0, -300.041782729805, 2826915.0),
-     'count': 3,
-     'crs': {'init': u'epsg:32618'},
-     'driver': u'GTiff',
-     'dtype': <type 'numpy.uint8'>,
-     'height': 718,
-     'nodata': 0.0,
-     'transform': (101985.0,
-                   300.0379266750948,
-                   0.0,
-                   2826915.0,
-                   0.0,
-                   -300.041782729805),
-     'width': 791}
+    >>> print src.name
+    tests/data/RGB.byte.tif
+    >>> print src.bounds
+    BoundingBox(left=101985.0, bottom=2611485.0, right=339315.0, top=2826915.0)
 
 merge
 -----
@@ -189,6 +241,22 @@ Other options are available, see:
 
     $ rio rasterize --help
 
+sample
+------
+
+New in 0.18.
+
+The sample command reads ``x, y`` positions from stdin and writes the dataset
+values at that position to stdout.
+
+.. code-block:: console
+
+    $ cat << EOF | rio sample tests/data/RGB.byte.tif
+    > [220649.99999832606, 2719199.999999095]
+    > EOF
+    [18, 25, 14]
+
+The output of the transform command (see below) makes good input for sample.
 
 shapes
 ------

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -863,6 +863,29 @@ cdef class RasterReader(_base.DatasetReader):
             hmask, 0, xoff, yoff, width, height, out)
         return out
 
+    def sample(self, xy, indexes=None):
+        """Get the values of a dataset at certain positions
+
+        Parameters
+        ----------
+        xy : iterable, pairs of floats
+            A sequence or generator of (x, y) pairs.
+
+        indexes : list of ints or a single int, optional
+            If `indexes` is a list, the result is a 3D array, but is
+            a 2D array if it is a band index number.
+
+        Returns
+        -------
+        Iterable, yielding dataset values for the specified `indexes`
+        as an ndarray.
+        """
+        for x, y in xy:
+            r, c = self.index(x, y)
+            window = ((r, r+1), (c, c+1))
+            data = self.read(
+                    indexes, window=window, masked=False, boundless=True)
+            yield data[:,0,0]
 
 cdef class RasterUpdater(RasterReader):
     # Read-write access to raster data and metadata.

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -6,3 +6,4 @@ from rasterio.rio.features import shapes, rasterize
 from rasterio.rio.info import env, info
 from rasterio.rio.merge import merge
 from rasterio.rio.rio import bounds, insp, transform
+from rasterio.rio.sample import sample

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -1,0 +1,94 @@
+import json
+import logging
+import sys
+import warnings
+
+import click
+
+import rasterio
+from rasterio.rio.cli import cli
+
+
+warnings.simplefilter('default')
+
+
+@cli.command(short_help="Sample a dataset.")
+@click.argument('files', nargs=-1, required=True, metavar='FILE "[x, y]"')
+@click.option('--bidx', default=None, help="Indexes of input file bands.")
+@click.pass_context
+def sample(ctx, files, bidx):
+    """Sample a dataset at one or more points
+
+    Sampling points (x, y) encoded as JSON arrays, in the coordinate
+    reference system of the dataset, are read from the second
+    positional argument or stdin. Values of the dataset's bands
+    are also encoded as JSON arrays and are written to stdout.
+
+    Example:
+
+    \b
+        $ cat << EOF | rio sample tests/data/RGB.byte.tif
+        > [220650, 2719200]
+        > [219650, 2718200]
+        > EOF
+        [28, 29, 27]
+        [25, 29, 19]
+
+    By default, rio-sample will sample all bands. Optionally, bands
+    may be specified using a simple syntax:
+
+      --bidx N samples the Nth band (first band is 1).
+
+      --bidx M,N,0 samples bands M, N, and O.
+
+      --bidx M..O samples bands M-O, inclusive.
+
+      --bidx ..N samples all bands up to and including N.
+
+      --bidx N.. samples all bands from N to the end.
+
+    Example:
+
+    \b
+        $ cat << EOF | rio sample tests/data/RGB.byte.tif --bidx ..2
+        > [220650, 2719200]
+        > [219650, 2718200]
+        > EOF
+        [28, 29]
+        [25, 29]
+
+    """
+    verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
+    logger = logging.getLogger('rio')
+
+    files = list(files)
+    source = files.pop(0)
+    input = files.pop(0) if files else '-'
+
+    # Handle the case of file, stream, or string input.
+    try:
+        points = click.open_file(input).readlines()
+    except IOError:
+        points = [input]
+
+    try:
+        with rasterio.drivers(CPL_DEBUG=verbosity>2):
+            with rasterio.open(source) as src:
+                if bidx is None:
+                    indexes = src.indexes
+                elif '..' in bidx:
+                    start, stop = map(
+                        lambda x: int(x) if x else None, bidx.split('..'))
+                    if start is None:
+                        start = 1
+                    indexes = src.indexes[slice(start-1, stop)]
+                else:
+                    indexes = list(map(int, bidx.split(',')))
+                for vals in src.sample(
+                            (json.loads(line) for line in points),
+                            indexes=indexes):
+                    click.echo(json.dumps(vals.tolist()))
+        sys.exit(0)
+    except Exception:
+        logger.exception("Failed. Exception caught")
+        sys.exit(1)

--- a/tests/test_rio_sample.py
+++ b/tests/test_rio_sample.py
@@ -1,0 +1,81 @@
+import logging
+import sys
+
+import click
+from click.testing import CliRunner
+
+import rasterio
+from rasterio.rio import sample
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+def test_sample_err():
+    runner = CliRunner()
+    result = runner.invoke(
+        sample.sample,
+        ['bogus.tif'],
+        "[220650.0, 2719200.0]")
+    assert result.exit_code == 1
+
+
+def test_sample_stdin():
+    runner = CliRunner()
+    result = runner.invoke(
+        sample.sample,
+        ['tests/data/RGB.byte.tif'],
+        "[220650.0, 2719200.0]\n[220650.0, 2719200.0]",
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.strip() == '[28, 29, 27]\n[28, 29, 27]'
+
+
+def test_sample_arg():
+    runner = CliRunner()
+    result = runner.invoke(
+        sample.sample,
+        ['tests/data/RGB.byte.tif', "[220650.0, 2719200.0]"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.strip() == '[28, 29, 27]'
+
+
+def test_sample_bidx():
+    runner = CliRunner()
+    result = runner.invoke(
+        sample.sample,
+        ['tests/data/RGB.byte.tif', '--bidx', '1,2', "[220650.0, 2719200.0]"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.strip() == '[28, 29]'
+
+
+def test_sample_bidx2():
+    runner = CliRunner()
+    result = runner.invoke(
+        sample.sample,
+        ['tests/data/RGB.byte.tif', '--bidx', '1..2', "[220650.0, 2719200.0]"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.strip() == '[28, 29]'
+
+
+def test_sample_bidx3():
+    runner = CliRunner()
+    result = runner.invoke(
+        sample.sample,
+        ['tests/data/RGB.byte.tif', '--bidx', '..2', "[220650.0, 2719200.0]"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.strip() == '[28, 29]'
+
+
+def test_sample_bidx4():
+    runner = CliRunner()
+    result = runner.invoke(
+        sample.sample,
+        ['tests/data/RGB.byte.tif', '--bidx', '3', "[220650.0, 2719200.0]"],
+        catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output.strip() == '[27]'

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,17 @@
+import rasterio
+
+
+def test_sampling():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        data = next(src.sample([(220650.0, 2719200.0)]))
+        assert list(data) == [28, 29, 27]
+
+def test_sampling_beyond_bounds():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        data = next(src.sample([(-10, 2719200.0)]))
+        assert list(data) == [0, 0, 0]
+
+def test_sampling_indexes():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        data = next(src.sample([(220650.0, 2719200.0)], indexes=[2]))
+        assert list(data) == [29]


### PR DESCRIPTION
Here's the help for rio-sample:

```
$ rio sample --help
Usage: rio sample [OPTIONS] FILE "[x, y]"

  Sample a dataset at one or more points

  Sampling points (x, y) encoded as JSON arrays, in the coordinate reference
  system of the dataset, are read from the second positional argument or
  stdin. Values of the dataset bands are also encoded as JSON arrays and
  are written to stdout.

  Example:

      $ cat << EOF | rio sample tests/data/RGB.byte.tif
      > [220650, 2719200]
      > [219650, 2718200]
      > EOF
      [28, 29, 27]
      [25, 29, 19]

  By default, rio-sample will sample all bands. Optionally, bands may be
  specified using a simple syntax:

    --bidx N samples the Nth band (first band is 1).

    --bidx M,N,0 samples bands M, N, and O.

    --bidx M..O samples bands M-O, inclusive.

    --bidx ..N samples all bands up to and including N.

    --bidx N.. samples all bands from N to the end.

  Example:

      $ cat << EOF | rio sample tests/data/RGB.byte.tif --bidx ..2
      > [220650, 2719200]
      > [219650, 2718200]
      > EOF
      [28, 29]
      [25, 29]

Options:
  --bidx TEXT  Indexes of input file bands.
  --help       Show this message and exit.
```

Closes #251.