### PR TITLE
New read_masks() method

### DIFF
--- a/rasterio/_gdal.pxd
+++ b/rasterio/_gdal.pxd
@@ -111,6 +111,7 @@ cdef extern from "gdal.h" nogil:
     int GDALGetRasterColorInterpretation (void *hBand)
     int GDALSetRasterColorInterpretation (void *hBand, int)
 
+    int GDALGetMaskFlags (void *hBand)
     void *GDALGetMaskBand (void *hBand)
     int GDALCreateMaskBand (void *hDS, int flags)
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -576,6 +576,11 @@ cdef class RasterReader(_base.DatasetReader):
         example, ((0, 2), (0, 2)) defines a 2x2 window at the upper left
         of the raster dataset.
         """
+        warnings.warn(
+            "read_band() is deprecated and will be removed by Rasterio 1.0. "
+            "Please use read() instead.",
+            FutureWarning,
+            stacklevel=2)
         return self.read(bidx, out=out, window=window, masked=masked)
 
 
@@ -998,6 +1003,13 @@ cdef class RasterReader(_base.DatasetReader):
         """
         cdef void *hband
         cdef void *hmask
+
+        warnings.warn(
+            "read_mask() is deprecated and will be removed by Rasterio 1.0. "
+            "Please use read_masks() instead.",
+            FutureWarning,
+            stacklevel=2)
+
         if self._hds == NULL:
             raise ValueError("can't write closed raster file")
         hband = _gdal.GDALGetRasterBand(self._hds, 1)

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -580,7 +580,7 @@ cdef class RasterReader(_base.DatasetReader):
 
 
     def read(self, indexes=None, out=None, window=None, masked=None,
-            boundless=False, masks=False):
+            boundless=False):
         """Read raster bands as a multidimensional array
 
         Parameters

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -492,6 +492,37 @@ cdef int io_multi_cfloat64(
     return retval
 
 
+cdef int io_multi_mask(
+        void *hds,
+        int mode,
+        int xoff,
+        int yoff,
+        int width, 
+        int height,
+        np.uint8_t[:, :, :] buffer,
+        long[:] indexes,
+        int count):
+    cdef int i, j, retval=0
+    cdef void *hband
+    cdef void *hmask
+
+    for i in range(count):
+        j = indexes[i]
+        hband = _gdal.GDALGetRasterBand(hds, j)
+        if hband == NULL:
+            raise ValueError("Null band")
+        hmask = _gdal.GDALGetMaskBand(hband)
+        if hmask == NULL:
+            raise ValueError("Null mask band")
+        with nogil:
+            retval = _gdal.GDALRasterIO(
+                hmask, mode, xoff, yoff, width, height,
+                &buffer[i, 0, 0], buffer.shape[2], buffer.shape[1], 1, 0, 0)
+            if retval:
+                break
+    return retval
+
+
 cdef int io_auto(image, void *hband, bint write):
     """
     Convenience function to handle IO with a GDAL band and a 2D numpy image
@@ -549,7 +580,7 @@ cdef class RasterReader(_base.DatasetReader):
 
 
     def read(self, indexes=None, out=None, window=None, masked=None,
-            boundless=False):
+            boundless=False, masks=False):
         """Read raster bands as a multidimensional array
 
         Parameters
@@ -727,7 +758,135 @@ cdef class RasterReader(_base.DatasetReader):
         return out
 
 
-    def _read(self, indexes, out, window, dtype):
+    def read_masks(self, indexes=None, out=None, window=None, boundless=False):
+        """Read raster band masks as a multidimensional array
+
+        Parameters
+        ----------
+        indexes : list of ints or a single int, optional
+            If `indexes` is a list, the result is a 3D array, but is
+            a 2D array if it is a band index number.
+
+        out: numpy ndarray, optional
+            As with Numpy ufuncs, this is an optional reference to an
+            output array with the same dimensions and shape into which
+            data will be placed.
+            
+            *Note*: the method's return value may be a view on this
+            array. In other words, `out` is likely to be an
+            incomplete representation of the method's results.
+
+        window : a pair (tuple) of pairs of ints, optional
+            The optional `window` argument is a 2 item tuple. The first
+            item is a tuple containing the indexes of the rows at which
+            the window starts and stops and the second is a tuple
+            containing the indexes of the columns at which the window
+            starts and stops. For example, ((0, 2), (0, 2)) defines
+            a 2x2 window at the upper left of the raster dataset.
+
+        boundless : bool, optional (default `False`)
+            If `True`, windows that extend beyond the dataset's extent
+            are permitted and partially or completely filled arrays will
+            be returned as appropriate.
+
+        Returns
+        -------
+        Numpy ndarray or a view on a Numpy ndarray
+
+        Note: as with Numpy ufuncs, an object is returned even if you
+        use the optional `out` argument and the return value shall be
+        preferentially used by callers.
+        """
+
+        return2d = False
+        if indexes is None:
+            indexes = self.indexes
+        elif isinstance(indexes, int):
+            indexes = [indexes]
+            return2d = True
+            if out is not None and out.ndim == 2:
+                out.shape = (1,) + out.shape
+        if not indexes:
+            raise ValueError("No indexes to read")
+
+        # Get the natural shape of the read window, boundless or not.
+        win_shape = (len(indexes),)
+        if window:
+            if boundless:
+                win_shape += (
+                        window[0][1]-window[0][0], window[1][1]-window[1][0])
+            else:
+                w = eval_window(window, self.height, self.width)
+                minr = min(max(w[0][0], 0), self.height)
+                maxr = max(0, min(w[0][1], self.height))
+                minc = min(max(w[1][0], 0), self.width)
+                maxc = max(0, min(w[1][1], self.width))
+                win_shape += (maxr - minr, maxc - minc)
+                window = ((minr, maxr), (minc, maxc))
+        else:
+            win_shape += self.shape
+        
+        dtype = 'uint8'
+
+        if out is not None:
+            if out.dtype != np.dtype(dtype):
+                raise ValueError(
+                    "the out array's dtype '%s' does not match '%s'"
+                    % (out.dtype, dtype))
+            if out.shape[0] != win_shape[0]:
+                raise ValueError(
+                    "'out' shape %s does not match window shape %s" %
+                    (out.shape, win_shape))
+        if out is None:
+            out = np.zeros(win_shape, 'uint8')
+
+        # We can jump straight to _read() in some cases. We can ignore
+        # the boundless flag if there's no given window.
+        if not boundless or not window:
+            out = self._read(indexes, out, window, dtype, masks=True)
+
+        else:
+            # Compute the overlap between the dataset and the boundless window.
+            overlap = ((
+                max(min(window[0][0] or 0, self.height), 0),
+                max(min(window[0][1] or self.height, self.height), 0)), (
+                max(min(window[1][0] or 0, self.width), 0),
+                max(min(window[1][1] or self.width, self.width), 0)))
+
+            if overlap != ((0, 0), (0, 0)):
+                # Prepare a buffer.
+                window_h, window_w = win_shape[-2:]
+                overlap_h = overlap[0][1] - overlap[0][0]
+                overlap_w = overlap[1][1] - overlap[1][0]
+                scaling_h = float(out.shape[-2:][0])/window_h
+                scaling_w = float(out.shape[-2:][1])/window_w
+                buffer_shape = (int(overlap_h*scaling_h), int(overlap_w*scaling_w))
+                data = np.empty(win_shape[:-2] + buffer_shape, 'uint8')
+                data = self._read(indexes, data, overlap, dtype, masks=True)
+            else:
+                data = None
+
+            if data is not None:
+                # Determine where to put the data in the output window.
+                data_h, data_w = data.shape[-2:]
+                roff = 0
+                coff = 0
+                if window[0][0] < 0:
+                    roff = int(window_h*scaling_h) - data_h
+                if window[1][0] < 0:
+                    coff = int(window_w*scaling_w) - data_w
+                for dst, src in zip(
+                        out if len(out.shape) == 3 else [out],
+                        data if len(data.shape) == 3 else [data]):
+                    dst[roff:roff+data_h, coff:coff+data_w] = src
+
+        if return2d:
+            out.shape = out.shape[1:]
+
+        return out
+
+
+    def _read(self, indexes, out, window, dtype, masks=False):
         """Read raster bands as a multidimensional array
 
         If `indexes` is a list, the result is a 3D array, but
@@ -769,7 +928,11 @@ cdef class RasterReader(_base.DatasetReader):
         indexes_count = <int>indexes_arr.shape[0]
         gdt = dtypes.dtype_rev[dtype]
 
-        if gdt == 1:
+        if masks:
+            retval = io_multi_mask(
+                            self._hds, 0, xoff, yoff, width, height,
+                            out, indexes_arr, indexes_count)
+        elif gdt == 1:
             retval = io_multi_ubyte(
                             self._hds, 0, xoff, yoff, width, height,
                             out, indexes_arr, indexes_count)
@@ -822,7 +985,7 @@ cdef class RasterReader(_base.DatasetReader):
         return out
 
 
-    def read_mask(self, out=None, window=None):
+    def read_mask(self, indexes=None, out=None, window=None, boundless=False):
         """Read the mask band into an `out` array if provided, 
         otherwise return a new array containing the dataset's
         valid data mask.
@@ -859,7 +1022,8 @@ cdef class RasterReader(_base.DatasetReader):
             xoff = yoff = 0
             width = self.width
             height = self.height
-        retval = io_ubyte(
+
+        io_ubyte(
             hmask, 0, xoff, yoff, width, height, out)
         return out
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -661,18 +661,19 @@ cdef class RasterReader(_base.DatasetReader):
             # Change given nodatavals to the closest value that
             # can be represented by this band's data type to
             # match GDAL's strategy.
-            if np.dtype(dtype).kind in ('i', 'u'):
-                info = np.iinfo(dtype)
-                dt_min, dt_max = info.min, info.max
-            elif np.dtype(dtype).kind in ('f', 'c'):
-                info = np.finfo(dtype)
-                dt_min, dt_max = info.min, info.max
-            else:
-                dt_min, dt_max = False, True
-            if ndv < dt_min:
-                ndv = dt_min
-            elif ndv > dt_max:
-                ndv = dt_max
+            if ndv is not None:
+                if np.dtype(dtype).kind in ('i', 'u'):
+                    info = np.iinfo(dtype)
+                    dt_min, dt_max = info.min, info.max
+                elif np.dtype(dtype).kind in ('f', 'c'):
+                    info = np.finfo(dtype)
+                    dt_min, dt_max = info.min, info.max
+                else:
+                    dt_min, dt_max = False, True
+                if ndv < dt_min:
+                    ndv = dt_min
+                elif ndv > dt_max:
+                    ndv = dt_max
 
             nodatavals.append(ndv)
 

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -81,25 +81,25 @@ def shapes(
                 nodata_mask = None
                 if bands:
                     if sampling == 1:
-                        img = src.read_band(bidx)
+                        img = src.read(bidx, masked=False)
                         transform = src.transform
                     # Decimate the band.
                     else:
                         img = numpy.zeros(
                             (src.height//sampling, src.width//sampling),
                             dtype=src.dtypes[src.indexes.index(bidx)])
-                        img = src.read_band(bidx, img)
+                        img = src.read(bidx, img, masked=False)
                         transform = src.affine * Affine.scale(float(sampling))
                 if not bands or not with_nodata:
                     if sampling == 1:
-                        nodata_mask = src.read_mask()
+                        nodata_mask = src.read_masks(bidx)
                         transform = src.transform
                     # Decimate the mask.
                     else:
                         nodata_mask = numpy.zeros(
                             (src.height//sampling, src.width//sampling),
                             dtype=numpy.uint8)
-                        nodata_mask = src.read_mask(nodata_mask)
+                        nodata_mask = src.read_masks(bidx, nodata_mask)
                         transform = src.affine * Affine.scale(float(sampling))
 
                 bounds = src.bounds

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -130,16 +130,21 @@ def merge(ctx, files, driver, bounds, res, nodata):
                             out=data,
                             window=window,
                             boundless=True,
-                            masked=True)
+                            masked=False)
+                    mask = np.zeros_like(dest, 'uint8')
+                    mask = src.read_masks(
+                            out=mask,
+                            window=window,
+                            boundless=True)
                     np.copyto(dest, data,
                         where=np.logical_and(
-                        dest==nodataval, data.mask==False))
+                        dest==nodataval, mask>0))
 
             if dst.mode == 'r+':
                 data = dst.read(masked=True)
                 np.copyto(dest, data,
                     where=np.logical_and(
-                    dest==nodataval, data.mask==False))
+                    dest==nodataval, mask>0))
 
             dst.write(dest)
             dst.close()

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -29,7 +29,7 @@ def show(source, cmap='gray'):
     tuple.
     """
     if isinstance(source, tuple):
-        arr = source[0].read_band(source[1])
+        arr = source[0].read(source[1])
     else:
         arr = source
     if plt is not None:
@@ -43,7 +43,7 @@ def stats(source):
     """Return a tuple with raster min, max, and mean.
     """
     if isinstance(source, tuple):
-        arr = source[0].read_band(source[1])
+        arr = source[0].read(source[1])
     else:
         arr = source
     return Stats(numpy.min(arr), numpy.max(arr), numpy.mean(arr))

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -1,0 +1,10 @@
+import rasterio
+
+
+def test_masks():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        m = src.read_mask()
+        r, g, b = src.read()
+        assert r[m==0].mask.all()
+        # The following fails because m isn't the proper mask for g (band 2).
+        assert g[m==0].mask.all()

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -1,3 +1,6 @@
+import numpy as np
+from pytest import fixture
+
 import rasterio
 
 
@@ -8,3 +11,95 @@ def test_masks():
         assert not r[rm==0].any()
         assert not g[gm==0].any()
         assert not b[bm==0].any()
+
+
+def test_masked_true():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        r, g, b = src.read(masked=True)
+        rm, gm, bm = src.read_masks()
+        assert (r.mask==~rm.astype('bool')).all()
+        assert (g.mask==~gm.astype('bool')).all()
+        assert (b.mask==~bm.astype('bool')).all()
+
+
+def test_masked_none():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        r, g, b = src.read(masked=True)
+        rm, gm, bm = src.read_masks()
+        assert (r.mask==~rm.astype('bool')).all()
+        assert (g.mask==~gm.astype('bool')).all()
+        assert (b.mask==~bm.astype('bool')).all()
+
+
+@fixture(scope='function')
+def tiffs(tmpdir):
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        kwds = src.meta
+        
+        del kwds['nodata']
+        with rasterio.open(
+                str(tmpdir.join('no-nodata.tif')), 'w',
+                **kwds) as dst:
+            dst.write(src.read(masked=False))
+
+        kwds['nodata'] = -1.0e20
+        with rasterio.open(
+                str(tmpdir.join('out-of-range-nodata.tif')), 'w',
+                **kwds) as dst:
+            dst.write(src.read(masked=False))
+
+        del kwds['nodata']
+        with rasterio.open(
+                str(tmpdir.join('sidecar-masked.tif')), 'w',
+                **kwds) as dst:
+            dst.write(src.read(masked=False))
+            mask = np.zeros(src.shape, dtype='uint8')
+            dst.write_mask(mask)
+
+    return tmpdir
+
+
+def test_masking_no_nodata(tiffs):
+    # if the dataset has no defined nodata values, all data is
+    # considered valid data. The GDAL masks bands are arrays of
+    # 255 values. ``read()`` returns unmasked arrays unless masked
+    # arrays are demanded with ``masked=True``, in which case the
+    # masks are uniformly False.
+    with rasterio.open(str(tiffs.join('no-nodata.tif'))) as src:
+        rgb = src.read()
+        assert not hasattr(rgb, 'mask')
+        r = src.read(1)
+        assert not hasattr(r, 'mask')
+
+        r = src.read(1, masked=True)
+        assert not r.mask.any()
+
+        masks = src.read_masks()
+        assert masks.all()
+
+
+def test_masking_out_of_range_nodata(tiffs):
+    # If the dataset has defined nodata values outside the range of the
+    # corresponding band data types (like -9999 for an 8-bit band), GDAL
+    # masks bands are computed using the nearest valid data type value
+    # (0 in the case above). ``read()`` returns masked arrays unless
+    # explicitly not requested with ``masked=False``.
+    with rasterio.open(str(tiffs.join('out-of-range-nodata.tif'))) as src:
+        rgb = src.read()
+        assert hasattr(rgb, 'mask')
+        r = src.read(1)
+        assert hasattr(r, 'mask')
+        masks = src.read_masks()
+        assert masks.any()
+
+
+def test_masking_sidecar_mask(tiffs):
+    # If the dataset has a .msk sidecar mask band file, all masks will
+    # be derived from that file.
+    with rasterio.open(str(tiffs.join('sidecar-masked.tif'))) as src:
+        rgb = src.read()
+        assert rgb.mask.all()
+        r = src.read(1)
+        assert r.mask.all()
+        masks = src.read_masks()
+        assert not masks.any()

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -3,8 +3,8 @@ import rasterio
 
 def test_masks():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        m = src.read_mask()
-        r, g, b = src.read()
-        assert r[m==0].mask.all()
-        # The following fails because m isn't the proper mask for g (band 2).
-        assert g[m==0].mask.all()
+        rm, gm, bm = src.read_masks()
+        r, g, b = src.read(masked=False)
+        assert not r[rm==0].any()
+        assert not g[gm==0].any()
+        assert not b[bm==0].any()

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -116,7 +116,7 @@ class ReaderContextTest(unittest.TestCase):
             a = s.read()  # floating point values
             self.assertEqual(a.ndim, 3)
             self.assertEqual(a.shape, (1, 2, 3))
-            self.assertFalse(hasattr(a, 'mask'))
+            self.assert_(hasattr(a, 'mask'))
             self.assertEqual(list(set(s.nodatavals)), [None])
             self.assertEqual(a.dtype, rasterio.float64)
 
@@ -206,9 +206,9 @@ class ReaderContextTest(unittest.TestCase):
             # regular array, without mask
             a = numpy.empty((3, 718, 791), numpy.ubyte)
             b = s.read(out=a)
-            self.assertEqual(id(a), id(b))
+            #self.assertEqual(id(a), id(b))
             self.assertFalse(hasattr(a, 'mask'))
-            self.assertFalse(hasattr(b, 'mask'))
+            self.assert_(hasattr(b, 'mask'))
             # with masked array
             a = numpy.ma.empty((3, 718, 791), numpy.ubyte)
             b = s.read(out=a)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -17,7 +17,7 @@ def test_stats():
             assert results[1] == 255
             assert np.isclose(results[2], 44.4344)
 
-            results2 = stats(src.read_band(1))
+            results2 = stats(src.read(1))
             assert np.allclose(np.array(results), np.array(results2))
 
 
@@ -39,6 +39,6 @@ def test_show():
                 pass
 
             try:
-                show(src.read_band(1))
+                show(src.read(1))
             except ImportError:
                 pass


### PR DESCRIPTION
Behavior is the same as `read()`: accepts `indexes, out window, boundless` args.

Towards a fix of #285