### PR TITLE
Add affine transform factories from_origin, from_bounds

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -23,3 +23,18 @@ def guard_transform(transform):
         else:
             transform = Affine(*transform)
     return transform
+
+
+def from_origin(west, north, xsize, ysize):
+    """Return an Affine transformation for a georeferenced raster given
+    the coordinates of its upper left corner `west`, `north` and pixel
+    sizes `xsize`, `ysize`."""
+    return Affine.translation(west, north) * Affine.scale(xsize, -ysize)
+
+
+def from_bounds(west, south, east, north, width, height):
+    """Return an Affine transformation for a georeferenced raster given
+    its bounds `west`, `south`, `east`, `north` and its `width` and
+    `height` in number of pixels."""
+    return Affine.translation(west, north) * Affine.scale(
+            (east - west)/width, (south - north)/height)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,6 @@
 import rasterio
+from rasterio import transform
+
 
 def test_window():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
@@ -21,3 +23,18 @@ def test_window_transform():
                 ((-1, None), (-1, None))).c == src.bounds.left - src.res[0]
         assert src.window_transform(
                 ((-1, None), (-1, None))).f == src.bounds.top + src.res[1]
+
+
+def test_from_origin():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        w, n = src.ul(0, 0)
+        xs, ys = src.res
+        tr = transform.from_origin(w, n, xs, ys)
+        assert [round(v, 7) for v in tr] == [round(v, 7) for v in src.affine]
+
+
+def test_from_bounds():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        w, s, e, n = src.bounds
+        tr = transform.from_bounds(w, s, e, n, src.width, src.height)
+        assert [round(v, 7) for v in tr] == [round(v, 7) for v in src.affine]


### PR DESCRIPTION
To simplify and clarify the reprojection example.

Closes #286.