### PR TITLE
Correct indexing and merging

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -371,7 +371,7 @@ cdef class DatasetReader(object):
     def index(self, x, y):
         """Returns the (row, col) index of the pixel containing (x, y)."""
         a, b, c, d, e, f, _, _, _ = self.affine
-        return int(round((y-f)/e)), int(round((x-c)/a))
+        return int(math.floor((y-f)/e)), int(math.floor((x-c)/a))
 
     def window(self, left, bottom, right, top):
         """Returns the window corresponding to the world bounding box."""

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -682,21 +682,25 @@ cdef class RasterReader(_base.DatasetReader):
                 overlap_w = overlap[1][1] - overlap[1][0]
                 scaling_h = float(out.shape[-2:][0])/window_h
                 scaling_w = float(out.shape[-2:][1])/window_w
-                buffer_shape = (int(overlap_h*scaling_h), int(overlap_w*scaling_w))
+                buffer_shape = (
+                        int(round(overlap_h*scaling_h)),
+                        int(round(overlap_w*scaling_w)))
                 data = np.empty(win_shape[:-2] + buffer_shape, dtype)
                 data = self._read(indexes, data, overlap, dtype)
+
             else:
                 data = None
 
             if data is not None:
                 # Determine where to put the data in the output window.
-                data_h, data_w = data.shape[-2:]
+                data_h, data_w = buffer_shape
                 roff = 0
                 coff = 0
                 if window[0][0] < 0:
-                    roff = int(window_h*scaling_h) - data_h
+                    roff = int(round(window_h*scaling_h)) - data_h
                 if window[1][0] < 0:
-                    coff = int(window_w*scaling_w) - data_w
+                    coff = int(round(window_w*scaling_w)) - data_w
+
                 for dst, src in zip(
                         out if len(out.shape) == 3 else [out],
                         data if len(data.shape) == 3 else [data]):
@@ -865,6 +869,8 @@ cdef class RasterReader(_base.DatasetReader):
 
     def sample(self, xy, indexes=None):
         """Get the values of a dataset at certain positions
+
+        Values are from the nearest pixel. They are not interpolated.
 
         Parameters
         ----------

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,4 +1,3 @@
-
 import rasterio
 
 def test_bounds():
@@ -17,18 +16,3 @@ def test_ul():
 def test_res():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert tuple(round(v, 6) for v in src.res) == (300.037927, 300.041783)
-
-def test_index():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        assert src.index(101985.0, 2826915.0) == (0, 0)
-        assert src.index(101985.0+400.0, 2826915.0) == (0, 1)
-        assert src.index(101985.0+400.0, 2826915.0-700.0) == (2, 1)
-
-def test_window():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        left, bottom, right, top = src.bounds
-        assert src.window(left, bottom, right, top) == ((0, src.height), 
-                                                        (0, src.width))
-        assert src.window(left, top-400, left+400, top) == ((0, 1), (0, 1))
-        assert src.window(left, top-500, left+500, top) == ((0, 2), (0, 2))
-

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,5 +1,5 @@
-
 import rasterio
+
 
 def test_index():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
@@ -9,13 +9,37 @@ def test_index():
         assert src.index(right, bottom) == (src.height, src.width)
         assert src.index(left, bottom) == (src.height, 0)
 
+
 def test_full_window():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        assert src.window(*src.bounds) == tuple(zip((0, 0), src.shape))
+        left, bottom, right, top = src.bounds
+        assert src.window(left, bottom, right, top) == tuple(zip((0, 0), src.shape))
+
 
 def test_window_no_exception():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds
         left -= 1000.0
+        eps = 1.0e-8
         assert src.window(left, bottom, right, top) == (
-                (0, src.height), (-3, src.width))
+                (0, src.height), (-4, src.width))
+
+
+def test_index():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        assert src.index(101985.0, 2826915.0) == (0, 0)
+        assert src.index(101985.0+400.0, 2826915.0) == (0, 1)
+        assert src.index(101985.0+400.0, 2826915.0-700.0) == (2, 1)
+
+
+def test_window():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        left, bottom, right, top = src.bounds
+        dx, dy = src.res
+        eps = 1.0e-8
+        assert src.window(left+eps, bottom+eps, right-eps, top-eps) == ((0, src.height-1), 
+                                                        (0, src.width-1))
+        assert src.index(left+400, top-400) == (1, 1)
+        assert src.index(left+dx+eps, top-dy-eps) == (1, 1)
+        assert src.window(left, top-400, left+400, top) == ((0, 1), (0, 1))
+        assert src.window(left, top-2*dy-eps, left+2*dx+eps, top) == ((0, 2), (0, 2))

--- a/tests/test_rio_sample.py
+++ b/tests/test_rio_sample.py
@@ -28,7 +28,7 @@ def test_sample_stdin():
         "[220650.0, 2719200.0]\n[220650.0, 2719200.0]",
         catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output.strip() == '[28, 29, 27]\n[28, 29, 27]'
+    assert result.output.strip() == '[18, 25, 14]\n[18, 25, 14]'
 
 
 def test_sample_arg():
@@ -38,7 +38,7 @@ def test_sample_arg():
         ['tests/data/RGB.byte.tif', "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output.strip() == '[28, 29, 27]'
+    assert result.output.strip() == '[18, 25, 14]'
 
 
 def test_sample_bidx():
@@ -48,7 +48,7 @@ def test_sample_bidx():
         ['tests/data/RGB.byte.tif', '--bidx', '1,2', "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output.strip() == '[28, 29]'
+    assert result.output.strip() == '[18, 25]'
 
 
 def test_sample_bidx2():
@@ -58,7 +58,7 @@ def test_sample_bidx2():
         ['tests/data/RGB.byte.tif', '--bidx', '1..2', "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output.strip() == '[28, 29]'
+    assert result.output.strip() == '[18, 25]'
 
 
 def test_sample_bidx3():
@@ -68,7 +68,7 @@ def test_sample_bidx3():
         ['tests/data/RGB.byte.tif', '--bidx', '..2', "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output.strip() == '[28, 29]'
+    assert result.output.strip() == '[18, 25]'
 
 
 def test_sample_bidx4():
@@ -78,4 +78,4 @@ def test_sample_bidx4():
         ['tests/data/RGB.byte.tif', '--bidx', '3', "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output.strip() == '[27]'
+    assert result.output.strip() == '[14]'

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -4,7 +4,7 @@ import rasterio
 def test_sampling():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         data = next(src.sample([(220650.0, 2719200.0)]))
-        assert list(data) == [28, 29, 27]
+        assert list(data) == [18, 25, 14]
 
 def test_sampling_beyond_bounds():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
@@ -14,4 +14,4 @@ def test_sampling_beyond_bounds():
 def test_sampling_indexes():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         data = next(src.sample([(220650.0, 2719200.0)], indexes=[2]))
-        assert list(data) == [29]
+        assert list(data) == [25]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,13 +1,5 @@
 import rasterio
 
-def test_window():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        left, bottom, right, top = src.bounds
-        assert src.window(left, bottom, right, top) == ((0, src.height),
-                                                        (0, src.width))
-        assert src.window(left, top-src.res[1], left+src.res[0], top) == (
-            (0, 1), (0, 1))
-
 
 def test_window_transform():
     with rasterio.open('tests/data/RGB.byte.tif') as src:


### PR DESCRIPTION
Closes #282.

At the heart of this was a subtle indexing error due to calling
round() instead of math.floor(). Fixing that needed a cascade of
fixes to expectated values in various tests.

Finally, core logic in the merge command was rewritten for
correctness and clarity.