### PR TITLE
Import all modules from Python space to help cx_Freeze et al.

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -14,6 +14,10 @@ from rasterio.dtypes import (
 from rasterio.five import string_types
 from rasterio.transform import Affine, guard_transform
 
+# These modules are imported from the Cython extensions, but are also import
+# here to help tools like cx_Freeze find them automatically
+from rasterio import _err, coords, enums
+
 # Classes in rasterio._io are imported below just before we need them.
 
 __all__ = [


### PR DESCRIPTION
See https://github.com/Toblerity/Fiona/pull/219

To build an executable from a Python script using cx_Freeze, you do something like this:

```
pip3 install cx_Freeze
cxfreeze test.py
dist/./test
```

If we try to do this for a simple script that imports rasterio, it raises an error as not all of the modules used are detected automatically. This can be worked around by manually telling cx_Freeze which modules to import. http://cx-freeze.readthedocs.org/en/latest/faq.html#problems-with-running-frozen-programs

This happens because some of the modules are only called from the Cython extensions, which cx_Freeze can't parse. We could make this easier for the user by making sure all of the modules used are imported from Python space. This shouldn't add any overhead, as the modules are already imported elsewhere.

This should help similar tools, such as PyInstaller and py2exe, although I've not tested them.