### PR TITLE
Updated handling of CRS and bounds mismatches in rio rasterize

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -712,3 +712,29 @@ def _transform(src_crs, dst_crs, xs, ys, zs):
     _gdal.OSRDestroySpatialReference(src)
     _gdal.OSRDestroySpatialReference(dst)
     return retval
+
+
+def is_geographic_crs(crs):
+    cdef void *osr_crs = _osr_from_crs(crs)
+    cdef int retval = _gdal.OSRIsGeographic(osr_crs)
+    _gdal.OSRDestroySpatialReference(osr_crs)
+
+    return retval == 1
+
+
+def is_projected_crs(crs):
+    cdef void *osr_crs = _osr_from_crs(crs)
+    cdef int retval = _gdal.OSRIsProjected(osr_crs)
+    _gdal.OSRDestroySpatialReference(osr_crs)
+
+    return retval == 1
+
+
+def is_same_crs(crs1, crs2):
+    cdef void *osr_crs1 = _osr_from_crs(crs1)
+    cdef void *osr_crs2 = _osr_from_crs(crs2)
+    cdef int retval = _gdal.OSRIsSame(osr_crs1, osr_crs2)
+    _gdal.OSRDestroySpatialReference(osr_crs1)
+    _gdal.OSRDestroySpatialReference(osr_crs2)
+
+    return retval == 1

--- a/rasterio/_gdal.pxd
+++ b/rasterio/_gdal.pxd
@@ -18,23 +18,28 @@ cdef extern from "cpl_string.h":
     void    CSLDestroy (char **list)
 
 cdef extern from "ogr_srs_api.h":
+    void *  OCTNewCoordinateTransformation (void *source, void *dest)
+    void    OCTDestroyCoordinateTransformation (void *source)
+    int     OCTTransform (void *ct, int nCount, double *x, double *y, double *z)
+
+    int     OSRAutoIdentifyEPSG (void *srs)
     void    OSRCleanup ()
     void *  OSRClone (void *srs)
     void    OSRDestroySpatialReference (void *srs)
     int     OSRExportToProj4 (void *srs, char **params)
     int     OSRExportToWkt (void *srs, char **params)
-    int     OSRImportFromEPSG (void *srs, int code)
-    int     OSRImportFromProj4 (void *srs, char *proj)
-    int     OSRSetFromUserInput (void *srs, char *input)
-    int     OSRAutoIdentifyEPSG (void *srs)
     int     OSRFixup(void *srs)
     const char * OSRGetAuthorityName (void *srs, const char *key)
     const char * OSRGetAuthorityCode (void *srs, const char *key)
+    int     OSRImportFromEPSG (void *srs, int code)
+    int     OSRImportFromProj4 (void *srs, char *proj)
+    int     OSRIsGeographic(void *srs)
+    int     OSRIsProjected(void *srs)
+    int     OSRIsSame(void *srs1, void *srs2)
     void *  OSRNewSpatialReference (char *wkt)
     void    OSRRelease (void *srs)
-    void *  OCTNewCoordinateTransformation (void *source, void *dest)
-    void    OCTDestroyCoordinateTransformation (void *source)
-    int     OCTTransform (void *ct, int nCount, double *x, double *y, double *z)
+    int     OSRSetFromUserInput (void *srs, char *input)
+
 
 cdef extern from "gdal.h" nogil:
     void GDALAllRegister()

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -165,7 +165,7 @@ def shapes(
               'reference system. Pixels assumed to be square if this option is '
               'used once, otherwise use: '
               '--res pixel_width --res pixel_height')
-@click.option('--src_crs', default=None, #'EPSG:4326'
+@click.option('--src_crs', default=None,
               help='Source coordinate reference system.  Limited to EPSG '
               'codes for now.  Used as output coordinate system if output does '
               'not exist or --like option is not used. Default: EPSG:4326')


### PR DESCRIPTION
Resolves #268 

Now raises warning instead of error if bounds are disjunct between geojson input and existing output raster or ```--like``` raster.  

Raises an error if ```--src_crs``` is provided and does not match existing output raster or ```--like``` raster; otherwise it is assumed to match the crs of those.  This allows you to provide GeoJSON in a non-EPSG crs (since ```--src_crs``` is limited to EPSG codes) provided that it matches the existing output raster or ```--like``` raster, rather than always defaulting to ```EPSG:4326```.

Added a few OSR utility functions to check if crs is geographic, projected, or the same between two.  To assist with this, I alphabetized the OSR functions in ```_gdal.pxd```.

While I was at it, I added more tests for ```crs.py```
