### PR TITLE
Added rio extract command

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,6 +19,7 @@ Rasterio's new command line interface is a program named "rio".
     Commands:
       bounds     Write bounding boxes to stdout as GeoJSON.
       env        Print information about the rio environment.
+      extract    Extract raster using features.
       info       Print information about a data file.
       insp       Open a data file and start an interpreter.
       merge      Merge a stack of raster datasets.
@@ -127,6 +128,38 @@ design of the calc command and something that could be done much more
 efficiently in Python.
 
 Please see `calc.rst <calc.rst>`__ for more details.
+
+
+extract
+-------
+
+New in 0.21
+
+The extract command extracts pixels from all bands of a raster using features
+(masking out all areas not covered by features) and optionally crops the output
+raster to the extent of the features.  Features are assumed to be in the same
+coordinate reference system as the input raster.
+
+A common use case is extracting raster data by political or other boundaries.
+
+.. code-block:: console
+
+    $ rio extract input.tif output.tif < input.geojson
+
+GeoJSON features may be provided using stdin or specified directly as first
+argument.
+
+.. code-block:: console
+
+    $ rio rasterize input.geojson input.tif output.tif --crop
+
+The feature mask can be inverted to mask out pixels covered by features and
+extract pixels not covered by features.
+
+.. code-block:: console
+
+    $ rio rasterize input.geojson input.tif output.tif --invert
+
 
 info
 ----

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,9 +19,9 @@ Rasterio's new command line interface is a program named "rio".
     Commands:
       bounds     Write bounding boxes to stdout as GeoJSON.
       env        Print information about the rio environment.
-      extract    Extract raster using features.
       info       Print information about a data file.
       insp       Open a data file and start an interpreter.
+      mask       Mask in raster using features.
       merge      Merge a stack of raster datasets.
       rasterize  Rasterize features.
       sample     Sample a dataset.
@@ -130,35 +130,35 @@ efficiently in Python.
 Please see `calc.rst <calc.rst>`__ for more details.
 
 
-extract
--------
+mask
+----
 
 New in 0.21
 
-The extract command extracts pixels from all bands of a raster using features
+The mask command masks in pixels from all bands of a raster using features
 (masking out all areas not covered by features) and optionally crops the output
 raster to the extent of the features.  Features are assumed to be in the same
 coordinate reference system as the input raster.
 
-A common use case is extracting raster data by political or other boundaries.
+A common use case is masking in raster data by political or other boundaries.
 
 .. code-block:: console
 
-    $ rio extract input.tif output.tif < input.geojson
+    $ rio mask input.tif output.tif --geojson-file input.geojson
 
 GeoJSON features may be provided using stdin or specified directly as first
-argument.
+argument, and output can be cropped to the extent of the features.
 
 .. code-block:: console
 
-    $ rio rasterize input.geojson input.tif output.tif --crop
+    $ rio mask input.tif output.tif --crop --geojson-file - < input.geojson
 
 The feature mask can be inverted to mask out pixels covered by features and
-extract pixels not covered by features.
+keep pixels not covered by features.
 
 .. code-block:: console
 
-    $ rio rasterize input.geojson input.tif output.tif --invert
+    $ rio mask input.tif output.tif --invert --geojson-file input.geojson
 
 
 info

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -144,21 +144,21 @@ A common use case is masking in raster data by political or other boundaries.
 
 .. code-block:: console
 
-    $ rio mask input.tif output.tif --geojson-file input.geojson
+    $ rio mask input.tif output.tif --geojson-mask input.geojson
 
 GeoJSON features may be provided using stdin or specified directly as first
 argument, and output can be cropped to the extent of the features.
 
 .. code-block:: console
 
-    $ rio mask input.tif output.tif --crop --geojson-file - < input.geojson
+    $ rio mask input.tif output.tif --crop --geojson-mask - < input.geojson
 
 The feature mask can be inverted to mask out pixels covered by features and
 keep pixels not covered by features.
 
 .. code-block:: console
 
-    $ rio mask input.tif output.tif --invert --geojson-file input.geojson
+    $ rio mask input.tif output.tif --invert --geojson-mask input.geojson
 
 
 info

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -373,11 +373,15 @@ cdef class DatasetReader(object):
         a, b, c, d, e, f, _, _, _ = self.affine
         return int(math.floor((y-f)/e)), int(math.floor((x-c)/a))
 
-    def window(self, left, bottom, right, top):
-        """Returns the window corresponding to the world bounding box."""
-        ul = self.index(left, top)
-        lr = self.index(right, bottom)
-        return tuple(zip(ul, lr))
+    def window(self, left, bottom, right, top, boundless=False):
+        """Returns the window corresponding to the world bounding box.
+        If boundless is False, window is limited to extent of this dataset."""
+
+        window = tuple(zip(self.index(left, top), self.index(right, bottom)))
+        if boundless:
+            return window
+        else:
+            return crop_window(window, self.height, self.width)
 
     def window_transform(self, window):
         """Returns the affine transform for a dataset window."""
@@ -565,6 +569,16 @@ cdef class DatasetReader(object):
 # Window utils
 # A window is a 2D ndarray indexer in the form of a tuple:
 # ((row_start, row_stop), (col_start, col_stop))
+
+cpdef crop_window(object window, int height, int width):
+    """Returns a window cropped to fall within height and width."""
+    cdef int r_start, r_stop, c_start, c_stop
+    (r_start, r_stop), (c_start, c_stop) = window
+    return (
+        (min(max(r_start, 0), height), max(0, min(r_stop, height))),
+        (min(max(c_start, 0), width), max(0, min(c_stop, width)))
+    )
+
 
 cpdef eval_window(object window, int height, int width):
     """Evaluates a window tuple that might contain negative values

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -13,7 +13,7 @@ cimport numpy as np
 
 from rasterio cimport _base, _gdal, _ogr, _io
 from rasterio._base import (
-    eval_window, window_shape, window_index, tastes_like_gdal)
+    crop_window, eval_window, window_shape, window_index, tastes_like_gdal)
 from rasterio._drivers import driver_count, GDALEnv
 from rasterio._err import cpl_errs
 from rasterio import dtypes
@@ -697,13 +697,12 @@ cdef class RasterReader(_base.DatasetReader):
                 win_shape += (
                         window[0][1]-window[0][0], window[1][1]-window[1][0])
             else:
-                w = eval_window(window, self.height, self.width)
-                minr = min(max(w[0][0], 0), self.height)
-                maxr = max(0, min(w[0][1], self.height))
-                minc = min(max(w[1][0], 0), self.width)
-                maxc = max(0, min(w[1][1], self.width))
-                win_shape += (maxr - minr, maxc - minc)
-                window = ((minr, maxr), (minc, maxc))
+                window = crop_window(
+                    eval_window(window, self.height, self.width),
+                    self.height, self.width
+                )
+                (r_start, r_stop), (c_start, c_stop) = window
+                win_shape += (r_stop - r_start, c_stop - c_start)
         else:
             win_shape += self.shape
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -43,7 +43,7 @@ def geometry_mask(
     all_touched : boolean, optional
         If True, all pixels touched by geometries will be burned in.  If
         false, only pixels whose center is within the polygon or that
-        are selected by Brezenhams line algorithm will be burned in.
+        are selected by Bresenham's line algorithm will be burned in.
     invert: boolean, optional
         If True, mask will be True for pixels that overlap shapes.
         False by default.
@@ -248,7 +248,7 @@ def rasterize(
     all_touched : boolean, optional
         If True, all pixels touched by geometries will be burned in.  If
         false, only pixels whose center is within the polygon or that
-        are selected by Brezenhams line algorithm will be burned in.
+        are selected by Bresenham's line algorithm will be burned in.
     default_value : int or float, optional
         Used as value for all geometries, if not provided in `shapes`.
     dtype : rasterio or numpy data type, optional

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -22,6 +22,49 @@ class NullHandler(logging.Handler):
 log.addHandler(NullHandler())
 
 
+def geometry_mask(
+        geometries,
+        out_shape,
+        transform,
+        all_touched=False,
+        invert=False):
+    """Create a mask from shapes.  By default, mask is intended for use as a
+    numpy mask, where pixels that overlap shapes are False.
+
+    Parameters
+    ----------
+    geometries : iterable over geometries (GeoJSON-like objects)
+    out_shape : tuple or list
+        Shape of output numpy ndarray.
+    transform : Affine transformation object
+        Transformation from pixel coordinates of `image` to the
+        coordinate system of the input `shapes`. See the `transform`
+        property of dataset objects.
+    all_touched : boolean, optional
+        If True, all pixels touched by geometries will be burned in.  If
+        false, only pixels whose center is within the polygon or that
+        are selected by Brezenhams line algorithm will be burned in.
+    invert: boolean, optional
+        If True, mask will be True for pixels that overlap shapes.
+        False by default.
+
+    Returns
+    -------
+    out : numpy ndarray of type 'bool'
+        Result
+    """
+
+    fill, mask_value = (0, 1) if invert else (1, 0)
+
+    return rasterize(
+        geometries,
+        out_shape=out_shape,
+        transform=transform,
+        all_touched=all_touched,
+        fill=fill,
+        default_value=mask_value).astype('bool')
+
+
 def shapes(image, mask=None, connectivity=4, transform=IDENTITY):
     """
     Return a generator of (polygon, value) for each each set of adjacent pixels
@@ -187,7 +230,7 @@ def rasterize(
     Parameters
     ----------
     shapes : iterable of (geometry, value) pairs or iterable over
-        geometries `geometry` can either be an object that implements
+        geometries. `geometry` can either be an object that implements
         the geo interface or GeoJSON-like object.
     out_shape : tuple or list
         Shape of output numpy ndarray.
@@ -205,11 +248,11 @@ def rasterize(
     all_touched : boolean, optional
         If True, all pixels touched by geometries will be burned in.  If
         false, only pixels whose center is within the polygon or that
-        are selected by brezenhams line algorithm will be burned in.
+        are selected by Brezenhams line algorithm will be burned in.
     default_value : int or float, optional
         Used as value for all geometries, if not provided in `shapes`.
     dtype : rasterio or numpy data type, optional
-        Used as data type for results, if `output` is not provided.
+        Used as data type for results, if `out` is not provided.
 
     Returns
     -------

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -3,7 +3,7 @@
 from rasterio.rio.calc import calc
 from rasterio.rio.cli import cli
 from rasterio.rio.bands import stack
-from rasterio.rio.features import extract, shapes, rasterize
+from rasterio.rio.features import mask, shapes, rasterize
 from rasterio.rio.info import env, info
 from rasterio.rio.merge import merge
 from rasterio.rio.rio import bounds, insp, transform

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -3,7 +3,7 @@
 from rasterio.rio.calc import calc
 from rasterio.rio.cli import cli
 from rasterio.rio.bands import stack
-from rasterio.rio.features import shapes, rasterize
+from rasterio.rio.features import extract, shapes, rasterize
 from rasterio.rio.info import env, info
 from rasterio.rio.merge import merge
 from rasterio.rio.rio import bounds, insp, transform

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -20,8 +20,7 @@ def test_window_no_exception():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds
         left -= 1000.0
-        eps = 1.0e-8
-        assert src.window(left, bottom, right, top) == (
+        assert src.window(left, bottom, right, top, boundless=True) == (
                 (0, src.height), (-4, src.width))
 
 

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -102,7 +102,7 @@ def test_mask(runner, tmpdir):
 
         result = runner.invoke(
             features.mask,
-            ['tests/data/shade.tif', output, '--geojson-file', '-'],
+            ['tests/data/shade.tif', output, '--geojson-mask', '-'],
             input=TEST_MERC_FEATURES
         )
         assert result.exit_code == 0
@@ -124,8 +124,8 @@ def test_mask(runner, tmpdir):
             features.mask,
             [
                 'tests/data/shade.tif', output,
-                '--all-touched',
-                '--geojson-file', '-'
+                '--all',
+                '--geojson-mask', '-'
             ],
             input=TEST_MERC_FEATURES
         )
@@ -144,7 +144,7 @@ def test_mask(runner, tmpdir):
             [
                 'tests/data/shade.tif', output,
                 '--invert',
-                '--geojson-file', '-'
+                '--geojson-mask', '-'
             ],
             input=TEST_MERC_FEATURES
         )
@@ -157,7 +157,7 @@ def test_mask(runner, tmpdir):
     # Test with feature collection
     result = runner.invoke(
         features.mask,
-        ['tests/data/shade.tif', output, '--geojson-file', '-'],
+        ['tests/data/shade.tif', output, '--geojson-mask', '-'],
         input=TEST_MERC_FEATURECOLLECTION
     )
     assert result.exit_code == 0
@@ -179,7 +179,7 @@ def test_mask(runner, tmpdir):
     # Invalid JSON should fail
     result = runner.invoke(
         features.mask,
-        ['tests/data/shade.tif', output, '--geojson-file', '-'],
+        ['tests/data/shade.tif', output, '--geojson-mask', '-'],
         input='{bogus: value}'
     )
     assert result.exit_code == 2
@@ -187,7 +187,7 @@ def test_mask(runner, tmpdir):
 
     result = runner.invoke(
         features.mask,
-        ['tests/data/shade.tif', output, '--geojson-file', '-'],
+        ['tests/data/shade.tif', output, '--geojson-mask', '-'],
         input='{"bogus": "value"}'
     )
     assert result.exit_code == 2
@@ -204,7 +204,7 @@ def test_mask_crop(runner, tmpdir):
             [
                 'tests/data/shade.tif', output,
                 '--crop',
-                '--geojson-file', '-'
+                '--geojson-mask', '-'
             ],
             input=TEST_MERC_FEATURES
         )
@@ -222,7 +222,7 @@ def test_mask_crop(runner, tmpdir):
             'tests/data/shade.tif', output,
             '--crop',
             '--invert',
-            '--geojson-file', '-'
+            '--geojson-mask', '-'
         ],
         input=TEST_MERC_FEATURES
     )
@@ -235,7 +235,7 @@ def test_mask_out_of_bounds(runner, tmpdir):
     # Crop with out of bounds raster should
     result = runner.invoke(
         features.mask,
-        ['tests/data/shade.tif', output, '--geojson-file', '-'],
+        ['tests/data/shade.tif', output, '--geojson-mask', '-'],
         input=TEST_FEATURES
     )
     assert result.exit_code == 0
@@ -247,7 +247,7 @@ def test_mask_out_of_bounds(runner, tmpdir):
         [
             'tests/data/shade.tif', output,
             '--crop',
-            '--geojson-file', '-'
+            '--geojson-mask', '-'
         ],
         input=TEST_FEATURES
     )


### PR DESCRIPTION
Resolves #243 

Adds an ```extract``` command to rio which allows you to extract out pixels from a raster using features to either mask in (default) or mask out (using ```--invert```) pixels.

Includes minor refactoring of window handling to consolidate usages.  Note: this is an API change, do to the way default value is set.  Only one test needed to be updated, but this should be noted in the changelog if this PR is accepted.