### PR TITLE
Standardized rio flags

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -400,7 +400,7 @@ following.
 
 .. code-block:: console
 
-    $ echo "[-78.0, 23.0]" | rio transform - --dst_crs EPSG:32618 --precision 2
+    $ echo "[-78.0, 23.0]" | rio transform - --dst-crs EPSG:32618 --precision 2
     [192457.13, 2546667.68]
 
 To transform a longitude, latitude bounding box to the coordinate system of
@@ -408,7 +408,7 @@ a raster dataset, do the following.
 
 .. code-block:: console
 
-    $ echo "[-78.0, 23.0, -76.0, 25.0]" | rio transform - --dst_crs tests/data/RGB.byte.tif --precision 2
+    $ echo "[-78.0, 23.0, -76.0, 25.0]" | rio transform - --dst-crs tests/data/RGB.byte.tif --precision 2
     [192457.13, 2546667.68, 399086.97, 2765319.94]
 
 Suggestions for other commands are welcome!

--- a/rasterio/rio/bands.py
+++ b/rasterio/rio/bands.py
@@ -7,7 +7,7 @@ from cligj import files_inout_arg, format_opt
 import rasterio
 
 from rasterio.five import zip_longest
-from rasterio.rio.cli import cli
+from rasterio.rio.cli import cli, bidx_mult_opt
 
 
 PHOTOMETRIC_CHOICES = [val.lower() for val in [
@@ -25,9 +25,8 @@ PHOTOMETRIC_CHOICES = [val.lower() for val in [
 @cli.command(short_help="Stack a number of bands into a multiband dataset.")
 @files_inout_arg
 @format_opt
-@click.option('-b', '--bidx', multiple=True,
-              help="Indexes of input file bands.")
-@click.option('-p', '--photometric', default=None,
+@bidx_mult_opt
+@click.option('--photometric', default=None,
               type=click.Choice(PHOTOMETRIC_CHOICES),
               help="Photometric interpretation")
 @click.pass_context

--- a/rasterio/rio/bands.py
+++ b/rasterio/rio/bands.py
@@ -1,5 +1,4 @@
 import logging
-import os.path
 import sys
 
 import click
@@ -26,9 +25,9 @@ PHOTOMETRIC_CHOICES = [val.lower() for val in [
 @cli.command(short_help="Stack a number of bands into a multiband dataset.")
 @files_inout_arg
 @format_opt
-@click.option('--bidx', multiple=True,
+@click.option('-b', '--bidx', multiple=True,
               help="Indexes of input file bands.")
-@click.option('--photometric', default=None,
+@click.option('-p', '--photometric', default=None,
               type=click.Choice(PHOTOMETRIC_CHOICES),
               help="Photometric interpretation")
 @click.pass_context

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -11,7 +11,7 @@ from cligj import files_inout_arg
 import rasterio
 from rasterio.fill import fillnodata
 from rasterio.features import sieve
-from rasterio.rio.cli import cli
+from rasterio.rio.cli import cli, dtype_opt, masked_opt
 
 
 def get_bands(inputs, d, i=None):
@@ -35,19 +35,12 @@ def read_array(ix, subix=None, dtype=None):
 @cli.command(short_help="Raster data calculator.")
 @click.argument('command')
 @files_inout_arg
-@click.option('-nm', '--name', multiple=True,
+@click.option('--name', multiple=True,
               help='Specify an input file with a unique short (alphas only) '
                    'name for use in commands like '
                    '"a=tests/data/RGB.byte.tif".')
-@click.option('-dt', '--dtype',
-              type=click.Choice(['ubyte', 'uint8', 'uint16', 'int16', 'uint32',
-                                'int32', 'float32', 'float64']),
-              default=None,
-              help="Output data type (default: float64).")
-@click.option('--masked/--not-masked',
-              default=True,
-              help="Evaluate expressions using masked arrays (the default) "
-                   "or ordinary numpy arrays.")
+@dtype_opt
+@masked_opt
 @click.pass_context
 def calc(ctx, command, files, name, dtype, masked):
     """A raster data calculator

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -1,15 +1,12 @@
 # Calc command.
 
 import logging
-import math
-import os.path
-import re
 import sys
 import traceback
-import warnings
 
 import click
 import snuggs
+from cligj import files_inout_arg
 
 import rasterio
 from rasterio.fill import fillnodata
@@ -37,17 +34,12 @@ def read_array(ix, subix=None, dtype=None):
 
 @cli.command(short_help="Raster data calculator.")
 @click.argument('command')
-@click.argument(
-    'files',
-    nargs=-1,
-    type=click.Path(resolve_path=False),
-    required=True,
-    metavar="INPUTS... OUTPUT")
-@click.option('--name', multiple=True,
+@files_inout_arg
+@click.option('-nm', '--name', multiple=True,
               help='Specify an input file with a unique short (alphas only) '
                    'name for use in commands like '
                    '"a=tests/data/RGB.byte.tif".')
-@click.option('--dtype',
+@click.option('-dt', '--dtype',
               type=click.Choice(['ubyte', 'uint8', 'uint16', 'int16', 'uint32',
                                 'int32', 'float32', 'float64']),
               default=None,

--- a/rasterio/rio/cli.py
+++ b/rasterio/rio/cli.py
@@ -26,6 +26,107 @@ def cli(ctx, verbose, quiet):
     ctx.obj['verbosity'] = verbosity
 
 
+# Common arguments and options
+
+# TODO: move file_in_arg and file_out_arg to cligj
+
+# Singular input file
+file_in_arg = click.argument(
+    'INPUT',
+    type=click.Path(exists=True, resolve_path=True))
+
+# Singular output file
+file_out_arg = click.argument(
+    'OUTPUT',
+    type=click.Path(resolve_path=True))
+
+bidx_opt = click.option(
+    '-b', '--bidx',
+    type=int,
+    default=1,
+    help="Input file band index (default: 1)")
+
+bidx_mult_opt = click.option(
+    '-b', '--bidx',
+    multiple=True,
+    help="Indexes of input file bands.")
+
+# TODO: may be better suited to cligj
+bounds_opt = click.option(
+    '--bounds',
+    nargs=4, type=float, default=None,
+    help='Output bounds: left, bottom, right, top.')
+
+dtype_opt = click.option(
+    '-t', '--dtype',
+    type=click.Choice([
+        'ubyte', 'uint8', 'uint16', 'int16', 'uint32', 'int32',
+        'float32', 'float64']),
+    default=None,
+    help="Output data type (default: float64).")
+
+like_file_opt = click.option(
+    '--like',
+    type=click.Path(exists=True),
+    help='Raster dataset to use as a template for obtaining affine '
+         'transform (bounds and resolution), crs, data type, and driver '
+         'used to create the output.')
+
+masked_opt = click.option(
+    '--masked/--not-masked',
+    default=True,
+    help="Evaluate expressions using masked arrays (the default) or ordinary "
+         "numpy arrays.")
+
+resolution_opt = click.option(
+    '-r', '--res',
+    multiple=True, type=float, default=None,
+    help='Output dataset resolution in units of coordinate '
+         'reference system. Pixels assumed to be square if this option '
+         'is used once, otherwise use: '
+         '--res pixel_width --res pixel_height')
+
+"""
+Registry of command line options (also see cligj options):
+-a, --all: Use all pixels touched by features.  In rio-mask, rio-rasterize
+--as-mask/--not-as-mask: interpret band as mask or not.  In rio-shapes
+--band/--mask: use band or mask.  In rio-shapes
+--bbox:
+-b, --bidx: band index(es) (singular or multiple value versions).  In rio-info, rio-sample, rio-shapes, rio-stack (different usages)
+--bounds: bounds in world coordinates.  In rio-info, rio-rasterize (different usages)
+--count: count of bands.  In rio-info
+--crop: Crop raster to extent of features.  In rio-mask
+--crs: CRS of input raster.  In rio-info
+--default-value: default for rasterized pixels.  In rio-rasterize
+--dimensions: Output width, height.  In rio-rasterize
+--dst-crs: destination CRS.  In rio-transform
+--fill: fill value for pixels not covered by features.  In rio-rasterize
+--formats: list available formats.  In rio-info
+--height: height of raster.  In rio-info
+-i, --invert: Invert mask created from features: In rio-mask
+-j, --geojson-mask: GeoJSON for masking raster.  In rio-mask
+--lnglat: geograhpic coordinates of center of raster.  In rio-info
+--masked/--not-masked: read masked data from source file.  In rio-calc, rio-info
+-m, --mode: output file mode (r, r+).  In rio-insp
+--name: input file name alias.  In rio-calc
+--nodata: nodata value.  In rio-info, rio-merge (different usages)
+--photometric: photometric interpretation.  In rio-stack
+--property: GeoJSON property to use as values for rasterize.  In rio-rasterize
+-r, --res: output resolution.  In rio-info, rio-rasterize (different usages.  TODO: try to combine usages, prefer rio-rasterize version)
+--sampling: Inverse of sampling fraction.  In rio-shapes
+--shape: shape (width, height) of band.  In rio-info
+--src-crs: source CRS.  In rio-insp, rio-rasterize (different usages.  TODO: consolidate usages)
+--stats: print raster stats.  In rio-inf
+-t, --dtype: data type.  In rio-calc, rio-info (different usages)
+--width: width of raster.  In rio-info
+--with-nodata/--without-nodata: include nodata regions or not.  In rio-shapes.
+-v, --tell-me-more, --verbose
+"""
+
+
+
+
+
 def coords(obj):
     """Yield all coordinate coordinate tuples from a geometry or feature.
     From python-geojson package."""

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -8,7 +8,7 @@ import click
 
 import rasterio
 import rasterio.crs
-from rasterio.rio.cli import cli
+from rasterio.rio.cli import cli, bidx_opt, file_in_arg, masked_opt
 
 
 @cli.command(short_help="Print information about the rio environment.")
@@ -30,7 +30,8 @@ def env(ctx, key):
 
 
 @cli.command(short_help="Print information about a data file.")
-@click.argument('INPUT', type=click.Path(exists=True))
+# @click.argument('INPUT', type=click.Path(exists=True))
+@file_in_arg
 @click.option('--meta', 'aspect', flag_value='meta', default=True,
               help="Show data file structure (default).")
 @click.option('--tags', 'aspect', flag_value='tags',
@@ -40,23 +41,23 @@ def env(ctx, key):
               help="Indentation level for pretty printed output")
 # Options to pick out a single metadata item and print it as
 # a string.
-@click.option('-ct', '--count', 'meta_member', flag_value='count',
+@click.option('--count', 'meta_member', flag_value='count',
               help="Print the count of bands.")
-@click.option('-dt', '--dtype', 'meta_member', flag_value='dtype',
+@click.option('-t', '--dtype', 'meta_member', flag_value='dtype',
               help="Print the dtype name.")
-@click.option('-nd', '--nodata', 'meta_member', flag_value='nodata',
+@click.option('--nodata', 'meta_member', flag_value='nodata',
               help="Print the nodata value.")
 @click.option('-f', '--format', '--driver', 'meta_member', flag_value='driver',
               help="Print the format driver.")
-@click.option('-shp', '--shape', 'meta_member', flag_value='shape',
+@click.option('--shape', 'meta_member', flag_value='shape',
               help="Print the (height, width) shape.")
-@click.option('-h', '--height', 'meta_member', flag_value='height',
+@click.option('--height', 'meta_member', flag_value='height',
               help="Print the height (number of rows).")
-@click.option('-w', '--width', 'meta_member', flag_value='width',
+@click.option('--width', 'meta_member', flag_value='width',
               help="Print the width (number of columns).")
-@click.option('-c', '--crs', 'meta_member', flag_value='crs',
+@click.option('--crs', 'meta_member', flag_value='crs',
               help="Print the CRS as a PROJ.4 string.")
-@click.option('-bd', '--bounds', 'meta_member', flag_value='bounds',
+@click.option('--bounds', 'meta_member', flag_value='bounds',
               help="Print the boundary coordinates "
                    "(left, bottom, right, top).")
 @click.option('-r', '--res', 'meta_member', flag_value='res',
@@ -68,12 +69,8 @@ def env(ctx, key):
                    "(use --bidx).")
 @click.option('-v', '--tell-me-more', '--verbose', is_flag=True,
               help="Output extra information.")
-@click.option('-b', '--bidx', type=int, default=1,
-              help="Input file band index (default: 1).")
-@click.option('--masked/--not-masked',
-              default=True,
-              help="Evaluate expressions using masked arrays (the default) "
-                   "or ordinary numpy arrays.")
+@bidx_opt
+@masked_opt
 @click.pass_context
 def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
         masked):

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -2,8 +2,6 @@
 
 import json
 import logging
-import os.path
-import pprint
 import sys
 
 import click
@@ -32,7 +30,7 @@ def env(ctx, key):
 
 
 @cli.command(short_help="Print information about a data file.")
-@click.argument('input', type=click.Path(exists=True))
+@click.argument('INPUT', type=click.Path(exists=True))
 @click.option('--meta', 'aspect', flag_value='meta', default=True,
               help="Show data file structure (default).")
 @click.option('--tags', 'aspect', flag_value='tags',
@@ -42,26 +40,26 @@ def env(ctx, key):
               help="Indentation level for pretty printed output")
 # Options to pick out a single metadata item and print it as
 # a string.
-@click.option('--count', 'meta_member', flag_value='count',
+@click.option('-ct', '--count', 'meta_member', flag_value='count',
               help="Print the count of bands.")
-@click.option('--dtype', 'meta_member', flag_value='dtype',
+@click.option('-dt', '--dtype', 'meta_member', flag_value='dtype',
               help="Print the dtype name.")
-@click.option('--nodata', 'meta_member', flag_value='nodata',
+@click.option('-nd', '--nodata', 'meta_member', flag_value='nodata',
               help="Print the nodata value.")
 @click.option('-f', '--format', '--driver', 'meta_member', flag_value='driver',
               help="Print the format driver.")
-@click.option('--shape', 'meta_member', flag_value='shape',
+@click.option('-shp', '--shape', 'meta_member', flag_value='shape',
               help="Print the (height, width) shape.")
-@click.option('--height', 'meta_member', flag_value='height',
+@click.option('-h', '--height', 'meta_member', flag_value='height',
               help="Print the height (number of rows).")
-@click.option('--width', 'meta_member', flag_value='width',
+@click.option('-w', '--width', 'meta_member', flag_value='width',
               help="Print the width (number of columns).")
-@click.option('--crs', 'meta_member', flag_value='crs',
+@click.option('-c', '--crs', 'meta_member', flag_value='crs',
               help="Print the CRS as a PROJ.4 string.")
-@click.option('--bounds', 'meta_member', flag_value='bounds',
+@click.option('-bd', '--bounds', 'meta_member', flag_value='bounds',
               help="Print the boundary coordinates "
                    "(left, bottom, right, top).")
-@click.option('--res', 'meta_member', flag_value='res',
+@click.option('-r', '--res', 'meta_member', flag_value='res',
               help="Print pixel width and height.")
 @click.option('--lnglat', 'meta_member', flag_value='lnglat',
               help="Print longitude and latitude at center.")
@@ -70,7 +68,7 @@ def env(ctx, key):
                    "(use --bidx).")
 @click.option('-v', '--tell-me-more', '--verbose', is_flag=True,
               help="Output extra information.")
-@click.option('--bidx', type=int, default=1,
+@click.option('-b', '--bidx', type=int, default=1,
               help="Input file band index (default: 1).")
 @click.option('--masked/--not-masked',
               default=True,

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -30,7 +30,6 @@ def env(ctx, key):
 
 
 @cli.command(short_help="Print information about a data file.")
-# @click.argument('INPUT', type=click.Path(exists=True))
 @file_in_arg
 @click.option('--meta', 'aspect', flag_value='meta', default=True,
               help="Show data file structure (default).")

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -17,11 +17,11 @@ from rasterio.transform import Affine
 @cli.command(short_help="Merge a stack of raster datasets.")
 @files_inout_arg
 @format_opt
-@click.option('--bounds', nargs=4, type=float, default=None,
+@click.option('-bd', '--bounds', nargs=4, type=float, default=None,
               help="Output bounds: left, bottom, right, top.")
-@click.option('--res', nargs=2, type=float, default=None,
+@click.option('-r', '--res', nargs=2, type=float, default=None,
               help="Output dataset resolution: pixel width, pixel height")
-@click.option('--nodata', '-n', type=float, default=None,
+@click.option('-nd', '--nodata', type=float, default=None,
               help="Override nodata values defined in input datasets")
 @click.pass_context
 def merge(ctx, files, driver, bounds, res, nodata):

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -10,18 +10,17 @@ import click
 from cligj import files_inout_arg, format_opt
 
 import rasterio
-from rasterio.rio.cli import cli
+from rasterio.rio.cli import cli, bounds_opt
 from rasterio.transform import Affine
 
 
 @cli.command(short_help="Merge a stack of raster datasets.")
 @files_inout_arg
 @format_opt
-@click.option('-bd', '--bounds', nargs=4, type=float, default=None,
-              help="Output bounds: left, bottom, right, top.")
+@bounds_opt
 @click.option('-r', '--res', nargs=2, type=float, default=None,
               help="Output dataset resolution: pixel width, pixel height")
-@click.option('-nd', '--nodata', type=float, default=None,
+@click.option('--nodata', type=float, default=None,
               help="Override nodata values defined in input datasets")
 @click.pass_context
 def merge(ctx, files, driver, bounds, res, nodata):

--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -30,8 +30,9 @@ warnings.simplefilter('default')
 
 # Insp command.
 @cli.command(short_help="Open a data file and start an interpreter.")
-@click.argument('input', type=click.Path(exists=True))
+@click.argument('INPUT', type=click.Path(exists=True))
 @click.option(
+    '-m',
     '--mode',
     type=click.Choice(['r', 'r+']),
     default='r',
@@ -61,7 +62,7 @@ def insp(ctx, input, mode):
 @cli.command(short_help="Write bounding boxes to stdout as GeoJSON.")
 # One or more files, the bounds of each are a feature in the collection
 # object or feature sequence.
-@click.argument('input', nargs=-1, type=click.Path(exists=True))
+@click.argument('INPUT', nargs=-1, type=click.Path(exists=True))
 @precision_opt
 @indent_opt
 @compact_opt
@@ -156,9 +157,9 @@ def bounds(ctx, input, precision, indent, compact, projection, sequence,
 
 # Transform command.
 @cli.command(short_help="Transform coordinates.")
-@click.argument('input', default='-', required=False)
-@click.option('--src_crs', default='EPSG:4326', help="Source CRS.")
-@click.option('--dst_crs', default='EPSG:4326', help="Destination CRS.")
+@click.argument('INPUT', default='-', required=False)
+@click.option('--src-crs', '--src_crs', default='EPSG:4326', help="Source CRS.")
+@click.option('--dst-crs', '--dst_crs', default='EPSG:4326', help="Destination CRS.")
 @precision_opt
 @click.pass_context
 def transform(ctx, input, src_crs, dst_crs, precision):

--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -16,7 +16,7 @@ from cligj import (
     geojson_type_feature_opt, geojson_type_bbox_opt)
 
 import rasterio
-from rasterio.rio.cli import cli, write_features
+from rasterio.rio.cli import cli, write_features, file_in_arg
 
 
 warnings.simplefilter('default')
@@ -30,7 +30,7 @@ warnings.simplefilter('default')
 
 # Insp command.
 @cli.command(short_help="Open a data file and start an interpreter.")
-@click.argument('INPUT', type=click.Path(exists=True))
+@file_in_arg
 @click.option(
     '-m',
     '--mode',

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -14,7 +14,7 @@ warnings.simplefilter('default')
 
 @cli.command(short_help="Sample a dataset.")
 @click.argument('files', nargs=-1, required=True, metavar='FILE "[x, y]"')
-@click.option('--bidx', default=None, help="Indexes of input file bands.")
+@click.option('-b', '--bidx', default=None, help="Indexes of input file bands.")
 @click.pass_context
 def sample(ctx, files, bidx):
     """Sample a dataset at one or more points

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -93,7 +93,7 @@ def test_merge_warn(test_data_dir_1):
     inputs = [str(x) for x in test_data_dir_1.listdir()]
     inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(merge, inputs + [outputname] + ['-n', '-1'])
+    result = runner.invoke(merge, inputs + [outputname] + ['-nd', '-1'])
     assert result.exit_code == 0
     assert "using the --nodata option for better results" in result.output
 
@@ -236,7 +236,7 @@ def test_merge_float(test_data_dir_float):
     inputs = [str(x) for x in test_data_dir_float.listdir()]
     inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(merge, inputs + [outputname] + ['-n', '-1.5'])
+    result = runner.invoke(merge, inputs + [outputname] + ['-nd', '-1.5'])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
     with rasterio.open(outputname) as out:

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -93,7 +93,7 @@ def test_merge_warn(test_data_dir_1):
     inputs = [str(x) for x in test_data_dir_1.listdir()]
     inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(merge, inputs + [outputname] + ['-nd', '-1'])
+    result = runner.invoke(merge, inputs + [outputname] + ['--nodata', '-1'])
     assert result.exit_code == 0
     assert "using the --nodata option for better results" in result.output
 
@@ -236,7 +236,7 @@ def test_merge_float(test_data_dir_float):
     inputs = [str(x) for x in test_data_dir_float.listdir()]
     inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(merge, inputs + [outputname] + ['-nd', '-1.5'])
+    result = runner.invoke(merge, inputs + [outputname] + ['--nodata', '-1.5'])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
     with rasterio.open(outputname) as out:

--- a/tests/test_rio_rio.py
+++ b/tests/test_rio_rio.py
@@ -137,7 +137,7 @@ def test_transform_point():
     runner = CliRunner()
     result = runner.invoke(
         rio.transform,
-        ['--dst_crs', 'EPSG:32618', '--precision', '2'],
+        ['--dst-crs', 'EPSG:32618', '--precision', '2'],
         "[-78.0, 23.0]", catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.strip() == '[192457.13, 2546667.68]'
@@ -147,7 +147,7 @@ def test_transform_point_dst_file():
     runner = CliRunner()
     result = runner.invoke(
         rio.transform,
-        ['--dst_crs', 'tests/data/RGB.byte.tif', '--precision', '2'],
+        ['--dst-crs', 'tests/data/RGB.byte.tif', '--precision', '2'],
         "[-78.0, 23.0]")
     assert result.exit_code == 0
     assert result.output.strip() == '[192457.13, 2546667.68]'
@@ -157,7 +157,7 @@ def test_transform_point_src_file():
     runner = CliRunner()
     result = runner.invoke(
         rio.transform,
-        ['--src_crs', 'tests/data/RGB.byte.tif', '--precision', '2'],
+        ['--src-crs', 'tests/data/RGB.byte.tif', '--precision', '2'],
         "[192457.13, 2546667.68]")
     assert result.exit_code == 0
     assert result.output.strip() == '[-78.0, 23.0]'
@@ -167,7 +167,7 @@ def test_transform_point_2():
     runner = CliRunner()
     result = runner.invoke(
         rio.transform,
-        ['[-78.0, 23.0]', '--dst_crs', 'EPSG:32618', '--precision', '2'])
+        ['[-78.0, 23.0]', '--dst-crs', 'EPSG:32618', '--precision', '2'])
     assert result.exit_code == 0
     assert result.output.strip() == '[192457.13, 2546667.68]'
 
@@ -176,7 +176,7 @@ def test_transform_point_multi():
     runner = CliRunner()
     result = runner.invoke(
         rio.transform,
-        ['--dst_crs', 'EPSG:32618', '--precision', '2'],
+        ['--dst-crs', 'EPSG:32618', '--precision', '2'],
         "[-78.0, 23.0]\n[-78.0, 23.0]", catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.strip() == '[192457.13, 2546667.68]\n[192457.13, 2546667.68]'


### PR DESCRIPTION
Standardized snake case to GNU stye flags, added short flags where appropriate, standardized use of 'input' argument, and removed unused imports in rio modules.

Resolves #324 except for parts already handled by #323