### PR TITLE
Add a default GTiff profile and factory for keyword args

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -165,3 +165,18 @@ def pad(array, transform, pad_width, mode=None, **kwargs):
     padded_trans[2] -= pad_width*padded_trans[0]
     padded_trans[5] -= pad_width*padded_trans[4]
     return padded_array, Affine(*padded_trans[:6])
+
+
+def default_gtiff_profile(**kwds):
+    """Return a mapping suitable for writing new GeoTIFF datasets."""
+    profile = {
+        'driver': 'GTiff',
+        'interleave': 'band',
+        'tiled': True,
+        'blockxsize': 256,
+        'blockysize': 256,
+        'compress': 'lzw',
+        'nodata': 0,
+        'dtype': uint8 }
+    profile.update(**kwds)
+    return profile

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -12,6 +12,7 @@ from rasterio.dtypes import (
     bool_, ubyte, uint8, uint16, int16, uint32, int32, float32, float64,
     complex_)
 from rasterio.five import string_types
+from rasterio.profiles import default_gtiff_profile
 from rasterio.transform import Affine, guard_transform
 
 # These modules are imported from the Cython extensions, but are also import
@@ -165,18 +166,3 @@ def pad(array, transform, pad_width, mode=None, **kwargs):
     padded_trans[2] -= pad_width*padded_trans[0]
     padded_trans[5] -= pad_width*padded_trans[4]
     return padded_array, Affine(*padded_trans[:6])
-
-
-def default_gtiff_profile(**kwds):
-    """Return a mapping suitable for writing new GeoTIFF datasets."""
-    profile = {
-        'driver': 'GTiff',
-        'interleave': 'band',
-        'tiled': True,
-        'blockxsize': 256,
-        'blockysize': 256,
-        'compress': 'lzw',
-        'nodata': 0,
-        'dtype': uint8 }
-    profile.update(**kwds)
-    return profile

--- a/rasterio/profiles.py
+++ b/rasterio/profiles.py
@@ -13,7 +13,15 @@ class Profile:
     defaults = {}
 
     def __call__(self, **kwargs):
-        """Return a mapping suitable for writing new GeoTIFF datasets."""
+        """Returns a mapping of keyword args for writing a new datasets.
+
+        Example:
+
+            profile = SomeProfile()
+            with rasterio.open('foo.tif', 'w', **profile()) as dst:
+                # Write data ...
+
+        """
         if kwargs.get('driver', self.driver) != self.driver:
             raise ValueError(
                 "Overriding this profile's driver is not allowed.")

--- a/rasterio/profiles.py
+++ b/rasterio/profiles.py
@@ -1,0 +1,40 @@
+"""Raster dataset profiles."""
+
+from rasterio.dtypes import uint8
+
+
+class Profile:
+    """Base class for Rasterio dataset profiles.
+
+    Subclasses will declare a format driver and driver-specific
+    creation options.
+    """
+    driver = None
+    defaults = {}
+
+    def __call__(self, **kwargs):
+        """Return a mapping suitable for writing new GeoTIFF datasets."""
+        if kwargs.get('driver', self.driver) != self.driver:
+            raise ValueError(
+                "Overriding this profile's driver is not allowed.")
+        profile = self.defaults.copy()
+        profile.update(**kwargs)
+        profile['driver'] = self.driver
+        return profile
+
+
+class DefaultGTiffProfile(Profile):
+    """A tiled, band-interleaved, LZW-compressed, 8-bit GTiff profile."""
+    driver = 'GTiff'
+    defaults = {
+        'interleave': 'band',
+        'tiled': True,
+        'blockxsize': 256,
+        'blockysize': 256,
+        'compress': 'lzw',
+        'nodata': 0,
+        'dtype': uint8
+    }
+
+
+default_gtiff_profile = DefaultGTiffProfile()

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,48 @@
+import rasterio
+
+
+def test_profile_format():
+    assert rasterio.default_gtiff_profile()['driver'] == 'GTiff'
+
+
+def test_profile_interleave():
+    assert rasterio.default_gtiff_profile()['interleave'] == 'band'
+
+
+def test_profile_tiled():
+    assert rasterio.default_gtiff_profile()['tiled'] == True
+
+
+def test_profile_blockxsize():
+    assert rasterio.default_gtiff_profile()['blockxsize'] == 256
+
+
+def test_profile_blockysize():
+    assert rasterio.default_gtiff_profile()['blockysize'] == 256
+
+
+def test_profile_compress():
+    assert rasterio.default_gtiff_profile()['compress'] == 'lzw'
+
+
+def test_profile_nodata():
+    assert rasterio.default_gtiff_profile()['nodata'] == 0
+
+
+def test_profile_dtype():
+    assert rasterio.default_gtiff_profile()['dtype'] == rasterio.uint8
+
+
+def test_profile_other():
+    assert rasterio.default_gtiff_profile(count=3)['count'] == 3
+
+
+def test_open_with_profile(tmpdir):
+        tiffname = str(tmpdir.join('foo.tif'))
+        with rasterio.open(
+                tiffname,
+                'w',
+                **rasterio.default_gtiff_profile(
+                    count=1, width=1, height=1)) as dst:
+            data = dst.read()
+            assert data.flatten().tolist() == [0]

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,40 +1,62 @@
+import pytest
+
 import rasterio
+from rasterio.profiles import Profile, DefaultGTiffProfile
+from rasterio.profiles import default_gtiff_profile
 
 
-def test_profile_format():
-    assert rasterio.default_gtiff_profile()['driver'] == 'GTiff'
+def test_base_profile():
+    assert Profile()()['driver'] is None
 
 
-def test_profile_interleave():
-    assert rasterio.default_gtiff_profile()['interleave'] == 'band'
+def test_base_profile_kwarg():
+    assert Profile()(foo='bar')['foo'] == 'bar'
 
 
-def test_profile_tiled():
-    assert rasterio.default_gtiff_profile()['tiled'] == True
+def test_gtiff_profile_format():
+    assert DefaultGTiffProfile()()['driver'] == 'GTiff'
 
 
-def test_profile_blockxsize():
-    assert rasterio.default_gtiff_profile()['blockxsize'] == 256
+def test_gtiff_profile_interleave():
+    assert DefaultGTiffProfile()()['interleave'] == 'band'
 
 
-def test_profile_blockysize():
-    assert rasterio.default_gtiff_profile()['blockysize'] == 256
+def test_gtiff_profile_tiled():
+    assert DefaultGTiffProfile()()['tiled'] == True
 
 
-def test_profile_compress():
-    assert rasterio.default_gtiff_profile()['compress'] == 'lzw'
+def test_gtiff_profile_blockxsize():
+    assert DefaultGTiffProfile()()['blockxsize'] == 256
 
 
-def test_profile_nodata():
-    assert rasterio.default_gtiff_profile()['nodata'] == 0
+def test_gtiff_profile_blockysize():
+    assert DefaultGTiffProfile()()['blockysize'] == 256
 
 
-def test_profile_dtype():
-    assert rasterio.default_gtiff_profile()['dtype'] == rasterio.uint8
+def test_gtiff_profile_compress():
+    assert DefaultGTiffProfile()()['compress'] == 'lzw'
 
 
-def test_profile_other():
-    assert rasterio.default_gtiff_profile(count=3)['count'] == 3
+def test_gtiff_profile_nodata():
+    assert DefaultGTiffProfile()()['nodata'] == 0
+
+
+def test_gtiff_profile_dtype():
+    assert DefaultGTiffProfile()()['dtype'] == rasterio.uint8
+
+
+def test_gtiff_profile_other():
+    assert DefaultGTiffProfile()(count=3)['count'] == 3
+
+
+def test_gtiff_profile_dtype_override():
+    assert DefaultGTiffProfile()(dtype='uint16')['dtype'] == rasterio.uint16
+
+
+def test_gtiff_profile_protected_driver():
+    """Overriding the driver is not allowed."""
+    with pytest.raises(ValueError):
+        DefaultGTiffProfile()(driver='PNG')
 
 
 def test_open_with_profile(tmpdir):
@@ -42,7 +64,16 @@ def test_open_with_profile(tmpdir):
         with rasterio.open(
                 tiffname,
                 'w',
-                **rasterio.default_gtiff_profile(
+                **default_gtiff_profile(
                     count=1, width=1, height=1)) as dst:
             data = dst.read()
             assert data.flatten().tolist() == [0]
+
+
+def test_profile_overlay():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        kwds = src.meta
+    kwds.update(**default_gtiff_profile())
+    assert kwds['tiled']
+    assert kwds['compress'] == 'lzw'
+    assert kwds['count'] == 3


### PR DESCRIPTION
Goal: reduce boilerplate and promote interoperability and best practices. The `default_gtiff_profile()` function reduces the number of keyword args you'll need to pass to `open()` for creation of new files to 5: `count, width, height, transform, crs`.

```python
>>> import rasterio
>>> rasterio.default_gtiff_profile(count=1, width=1, height=1)
{'count': 1, 'width': 1, 'dtype': 'uint8', 'driver': 'GTiff', 'height': 1, 'interleave': 'band', 'blockxsize': 256, 'tiled': True, 'blockysize': 256, 'nodata': 0, 'compress': 'lzw'}
```

To be used like

```python
with rasterio.open(
        'example.tif', 'w',
        **rasterio.default_gtiff_profile(
            count=1, width=1, height=1, transform=..., crs=...)) as dst:
    # write data ...
```

You could also overlay this profile on keyword args taken from another file:

```python
with rasterio.open('example.tif') as src:
    kwds = src.meta
    kwds.update(**rasterio.default_gtiff_profile())
    ...
```

It wouldn't overwrite count, width, height, transform, or crs.