### PR TITLE
Add -o/--output option to commands

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
 Changes
 =======
 
-0.22.0 (?)
-----------
+0.22.0 (2015-05-01)
+-------------------
 - Return masked arrays in the boundless read case (#338).
+- Add -o/--output option to rio-calc,merge,stack,mask,shapes,rasterize (#333).
 
 0.21.0 (2015-04-22)
 -------------------

--- a/rasterio/rio/bands.py
+++ b/rasterio/rio/bands.py
@@ -7,7 +7,7 @@ from cligj import files_inout_arg, format_opt
 import rasterio
 
 from rasterio.five import zip_longest
-from rasterio.rio.cli import cli, bidx_mult_opt
+from rasterio.rio.cli import cli, bidx_mult_opt, output_opt, resolve_inout
 
 
 PHOTOMETRIC_CHOICES = [val.lower() for val in [
@@ -24,13 +24,14 @@ PHOTOMETRIC_CHOICES = [val.lower() for val in [
 # Stack command.
 @cli.command(short_help="Stack a number of bands into a multiband dataset.")
 @files_inout_arg
+@output_opt
 @format_opt
 @bidx_mult_opt
 @click.option('--photometric', default=None,
               type=click.Choice(PHOTOMETRIC_CHOICES),
               help="Photometric interpretation")
 @click.pass_context
-def stack(ctx, files, driver, bidx, photometric):
+def stack(ctx, files, output, driver, bidx, photometric):
     """Stack a number of bands from one or more input files into a
     multiband dataset.
 
@@ -68,8 +69,7 @@ def stack(ctx, files, driver, bidx, photometric):
     logger = logging.getLogger('rio')
     try:
         with rasterio.drivers(CPL_DEBUG=verbosity>2):
-            output = files[-1]
-            files = files[:-1]
+            output, files = resolve_inout(files=files, output=output)
             output_count = 0
             indexes = []
             for path, item in zip_longest(files, bidx, fillvalue=None):

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -11,7 +11,8 @@ from cligj import files_inout_arg
 import rasterio
 from rasterio.fill import fillnodata
 from rasterio.features import sieve
-from rasterio.rio.cli import cli, dtype_opt, masked_opt
+from rasterio.rio.cli import (
+    cli, dtype_opt, masked_opt, output_opt, resolve_inout)
 
 
 def get_bands(inputs, d, i=None):
@@ -35,6 +36,7 @@ def read_array(ix, subix=None, dtype=None):
 @cli.command(short_help="Raster data calculator.")
 @click.argument('command')
 @files_inout_arg
+@output_opt
 @click.option('--name', multiple=True,
               help='Specify an input file with a unique short (alphas only) '
                    'name for use in commands like '
@@ -42,7 +44,7 @@ def read_array(ix, subix=None, dtype=None):
 @dtype_opt
 @masked_opt
 @click.pass_context
-def calc(ctx, command, files, name, dtype, masked):
+def calc(ctx, command, files, output, name, dtype, masked):
     """A raster data calculator
 
     Evaluates an expression using input datasets and writes the result
@@ -89,10 +91,10 @@ def calc(ctx, command, files, name, dtype, masked):
 
     try:
         with rasterio.drivers(CPL_DEBUG=verbosity > 2):
-            output = files[-1]
+            output, files = resolve_inout(files=files, output=output)
 
             inputs = ([tuple(n.split('=')) for n in name] +
-                      [(None, n) for n in files[:-1]])
+                      [(None, n) for n in files])
 
             with rasterio.open(inputs[0][1]) as first:
                 kwargs = first.meta

--- a/rasterio/rio/cli.py
+++ b/rasterio/rio/cli.py
@@ -78,6 +78,14 @@ masked_opt = click.option(
     help="Evaluate expressions using masked arrays (the default) or ordinary "
          "numpy arrays.")
 
+output_opt = click.option(
+    '-o', '--output',
+    default=None,
+    type=click.Path(resolve_path=True),
+    help="Path to output file (optional alternative to a positional arg "
+         "for some commands).")
+
+
 resolution_opt = click.option(
     '-r', '--res',
     multiple=True, type=float, default=None,
@@ -122,9 +130,6 @@ Registry of command line options (also see cligj options):
 --with-nodata/--without-nodata: include nodata regions or not.  In rio-shapes.
 -v, --tell-me-more, --verbose
 """
-
-
-
 
 
 def coords(obj):
@@ -183,3 +188,14 @@ def write_features(
                 'features': features},
                 **dump_kwds))
         fobj.write('\n')
+
+
+def resolve_inout(input=None, output=None, files=None):
+    """Resolves inputs and outputs from standard args and options.
+    
+    Returns `output_filename, [input_filename0, ...]`."""
+    resolved_output = output or (files[-1] if files else None)
+    resolved_inputs = (
+        [input] if input else [] + 
+        list(files[:-1 if not output else None]) if files else [])
+    return resolved_output, resolved_inputs

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -80,6 +80,7 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')
     mode = 'r' if (verbose or meta_member == 'stats') else 'r-'
+
     try:
         with rasterio.drivers(CPL_DEBUG=(verbosity > 2)):
             with rasterio.open(input, mode) as src:

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -10,12 +10,13 @@ import click
 from cligj import files_inout_arg, format_opt
 
 import rasterio
-from rasterio.rio.cli import cli, bounds_opt
+from rasterio.rio.cli import cli, bounds_opt, output_opt, resolve_inout
 from rasterio.transform import Affine
 
 
 @cli.command(short_help="Merge a stack of raster datasets.")
 @files_inout_arg
+@output_opt
 @format_opt
 @bounds_opt
 @click.option('-r', '--res', nargs=2, type=float, default=None,
@@ -23,7 +24,7 @@ from rasterio.transform import Affine
 @click.option('--nodata', type=float, default=None,
               help="Override nodata values defined in input datasets")
 @click.pass_context
-def merge(ctx, files, driver, bounds, res, nodata):
+def merge(ctx, files, output, driver, bounds, res, nodata):
     """Copy valid pixels from input files to an output file.
 
     All files must have the same number of bands, data type, and
@@ -44,8 +45,7 @@ def merge(ctx, files, driver, bounds, res, nodata):
 
     try:
         with rasterio.drivers(CPL_DEBUG=verbosity>2):
-            output = files[-1]
-            files = files[:-1]
+            output, files = resolve_inout(files=files, output=output)
 
             with rasterio.open(files[0]) as first:
                 first_res = first.res

--- a/tests/test_rio_cli.py
+++ b/tests/test_rio_cli.py
@@ -1,0 +1,18 @@
+from rasterio.rio import cli
+
+
+def test_resolve_files_inout__output():
+    assert cli.resolve_inout(input='in', output='out') == ('out', ['in'])
+
+
+def test_resolve_files_inout__input():
+    assert cli.resolve_inout(input='in') == (None, ['in'])
+
+
+def test_resolve_files_inout__inout_files():
+    assert cli.resolve_inout(files=('a', 'b', 'c')) == ('c', ['a', 'b'])
+
+
+def test_resolve_files_inout__inout_files_output_o():
+    assert cli.resolve_inout(
+        files=('a', 'b', 'c'), output='out') == ('out', ['a', 'b', 'c'])

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -306,3 +306,26 @@ def test_merge_tiny(tiffs):
         assert (data[0][0:2,3] == 90).all()
         assert data[0][2][1] == 60
         assert data[0][3][0] == 40
+
+
+def test_merge_tiny_output_opt(tiffs):
+    outputname = str(tiffs.join('merged.tif'))
+    inputs = [str(x) for x in tiffs.listdir()]
+    inputs.sort()
+    runner = CliRunner()
+    result = runner.invoke(merge, inputs + ['-o', outputname])
+    assert result.exit_code == 0
+
+    # Output should be
+    #
+    # [[  0 120 120  90]
+    #  [  0 120 120  90]
+    #  [  0  60   0   0]
+    #  [ 40   0   0   0]]
+
+    with rasterio.open(outputname) as src:
+        data = src.read()
+        assert (data[0][0:2,1:3] == 120).all()
+        assert (data[0][0:2,3] == 90).all()
+        assert data[0][2][1] == 60
+        assert data[0][3][0] == 40


### PR DESCRIPTION
Plus a function to resolve the standard args and options to a standard `output, [inputs]` pair.

Closes #333.