### PR TITLE
Making CLI commands pluggable

### DIFF
--- a/rasterio/_gdal.pxd
+++ b/rasterio/_gdal.pxd
@@ -17,6 +17,12 @@ cdef extern from "cpl_string.h":
     char ** CSLSetNameValue (char **list, char *name, char *val)
     void    CSLDestroy (char **list)
 
+cdef extern from "cpl_vsi.h":
+    ctypedef int vsi_l_offset
+    unsigned char * VSIGetMemFileBuffer (const char *filename,
+                                         vsi_l_offset *data_len,
+                                         int take_ownership)
+
 cdef extern from "ogr_srs_api.h":
     void *  OCTNewCoordinateTransformation (void *source, void *dest)
     void    OCTDestroyCoordinateTransformation (void *source)

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1945,3 +1945,18 @@ def writer(path, mode, **kwargs):
             return RasterUpdater(path, mode)
         else:
             return IndirectRasterUpdater(path, mode)
+
+
+def virtual_file_to_buffer(filename):
+    """Read content of a virtual file into a Python bytes buffer."""
+    cdef unsigned char *buff = NULL
+    cdef const char *cfilename = NULL
+    cdef _gdal.vsi_l_offset buff_len = 0
+     
+    filename_b = filename if not isinstance(filename, string_types) else filename.encode('utf-8')
+    cfilename = filename_b
+    buff = _gdal.VSIGetMemFileBuffer(cfilename, &buff_len, 0)
+    n = buff_len
+    log.debug("Buffer length: %d bytes", n)
+    cdef np.uint8_t[:] buff_view = <np.uint8_t[:n]>buff
+    return buff_view

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -364,7 +364,10 @@ def _reproject(
 
         eErr = oWarper.Initialize(psWOptions)
         if eErr == 0:
-            _, rows, cols = destination.shape
+
+            log.debug("Destination shape: %r", destination.shape)
+
+            rows, cols = destination.shape[-2:]
             log.debug(
                 "Chunk and warp window: %d, %d, %d, %d",
                 0, 0, cols, rows)

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
+# main: loader of all the command entry points.
 
-from rasterio.rio.calc import calc
+from pkg_resources import iter_entry_points
+
 from rasterio.rio.cli import cli
-from rasterio.rio.bands import stack
-from rasterio.rio.features import mask, shapes, rasterize
-from rasterio.rio.info import env, info
-from rasterio.rio.merge import merge
-from rasterio.rio.rio import bounds, insp, transform
-from rasterio.rio.sample import sample
+
+
+for entry_point in iter_entry_points('rasterio.rio_commands'):
+    cli = entry_point.load()

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -3,8 +3,6 @@
 
 from pkg_resources import iter_entry_points
 
-from rasterio.rio.cli import cli
-
 
 for entry_point in iter_entry_points('rasterio.rio_commands'):
-    cli = entry_point.load()
+    entry_point.load()

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -3,6 +3,8 @@
 
 from pkg_resources import iter_entry_points
 
+from rasterio.rio.cli import cli
+
 
 for entry_point in iter_entry_points('rasterio.rio_commands'):
     entry_point.load()

--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,20 @@ setup_args = dict(
     entry_points='''
         [console_scripts]
         rio=rasterio.rio.main:cli
+        
+        [rasterio.rio_commands]
+        bounds=rasterio.rio.rio:bounds
+        calc=rasterio.rio.calc:calc
+        env=rasterio.rio.info:env
+        info=rasterio.rio.info:info
+        insp=rasterio.rio.rio:insp
+        mask=rasterio.rio.features:mask
+        merge=rasterio.rio.merge:merge
+        rasterize=rasterio.rio.features:rasterize
+        sample=rasterio.rio.sample:sample
+        shapes=rasterio.rio.features:shapes
+        stack=rasterio.rio.bands:stack
+        transform=rasterio.rio.rio:transform
     ''',
     include_package_data=True,
     ext_modules=ext_modules,


### PR DESCRIPTION
Defines a "rasterio.rio_commands" entry points and turns all of the existing commands into entry points that are loaded by main.py.

Adds a virtual_file_to_buffer() function to support MBTiles export.

Fixes a bug in reproject().