### PR TITLE
Handle plugin load errors in a helpful way

### DIFF
--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -1,5 +1,8 @@
 # main: loader of all the command entry points.
 
+import sys
+import traceback
+
 from pkg_resources import iter_entry_points
 
 from rasterio.rio.cli import cli
@@ -19,4 +22,19 @@ from rasterio.rio.cli import cli
 #       ...
 
 for entry_point in iter_entry_points('rasterio.rio_commands'):
-    entry_point.load()
+    try:
+        entry_point.load()
+    except ImportError:
+        # Catch this so a busted plugin doesn't take down the CLI.
+        # Handled by registering a stub that does nothing other than
+        # explain the error.
+        msg = (
+            "Warning: plugin module could not be loaded. Contact "
+            "its author for help.\n\n\b\n"
+            + traceback.format_exc())
+        short_msg = (
+            "Warning: plugin module could not be loaded. See "
+            "`rio %s --help` for details." % entry_point.name)
+        @cli.command(entry_point.name, help=msg, short_help=short_msg)
+        def cmd_stub():
+            sys.exit(0)

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -24,7 +24,7 @@ from rasterio.rio.cli import cli
 for entry_point in iter_entry_points('rasterio.rio_commands'):
     try:
         entry_point.load()
-    except ImportError:
+    except Exception:
         # Catch this so a busted plugin doesn't take down the CLI.
         # Handled by registering a stub that does nothing other than
         # explain the error.


### PR DESCRIPTION
On catching an ImportError, we make a dummy/stub subcommand that sits in the list of subcommands as expected and reports the error there. Example (after breaking, locally, the rio-mbtiles plugin):

```
$ rio --help
Usage: rio [OPTIONS] COMMAND [ARGS]...

  Rasterio command line interface.

Options:
  -v, --verbose  Increase verbosity.
  -q, --quiet    Decrease verbosity.
  --version      Show the version and exit.
  --help         Show this message and exit.

Commands:
  bounds     Write bounding boxes to stdout as GeoJSON.
  calc       Raster data calculator.
  env        Print information about the rio environment.
  info       Print information about a data file.
  insp       Open a data file and start an interpreter.
  mask       Mask in raster using features.
  mbtiles    Warning: plugin module could not be loaded. See `rio mbtiles
             --help` for details.
  merge      Merge a stack of raster datasets.
  rasterize  Rasterize features.
  sample     Sample a dataset.
  shapes     Write shapes extracted from bands or masks.
  stack      Stack a number of bands into a multiband dataset.
  transform  Transform coordinates.
```

and

```
$ rio mbtiles --help
Usage: rio mbtiles [OPTIONS]

  Warning: plugin module could not be loaded. Contact its author for help.

  Traceback (most recent call last):
    File "/Users/sean/code/rasterio/rasterio/rio/main.py", line 26, in <module>
      entry_point.load()
    File "/Users/sean/envs/pydotorg27/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2312, in load
      return self.resolve()
    File "/Users/sean/envs/pydotorg27/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2318, in resolve
      module = __import__(self.module_name, fromlist=['__name__'], level=0)
    File "/Users/sean/code/rio-mbtiles/rio_mbtiles/__init__.py", line 3, in <module>
      import mercantilen
  ImportError: No module named mercantilen

Options:
  --help  Show this message and exit.
```

This approach could also work for https://github.com/Toblerity/Fiona/pull/225.

Comments, @geowurster?