### PR TITLE
make setup.py work on all platforms (specifically non-unix platforms).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,10 +240,10 @@ You can download a binary distribution of GDAL from `here
 <http://www.gisinternals.com/release.php>`_.  You will also need to download
 the compiled libraries and headers (include files).
 
-When building from source on Windows, it is important to note that gdal-config
-only exists on UNIX platforms.  The setup.py scripts uses gdal-config discover
-the places to include files and libraries that rasterio needs to compile its
-C extensions.  On Windows, these paths need to be provided by the user.
+When building from source on Windows, it is important to know that setup.py
+cannot rely on gdal-config, which is only present on UNIX systems, to discover 
+the locations of header files and libraries that rasterio needs to compile its 
+C extensions. On Windows, these paths need to be provided by the user. 
 You will need to find the include files and the library files for gdal and 
 use setup.py as follows.
 

--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,25 @@ Windows
 Windows binary packages created by Christoph Gohlke are available `here
 <http://www.lfd.uci.edu/~gohlke/pythonlibs/#rasterio>`_.
 
+You can download a binary distribution of GDAL from `here
+<http://www.gisinternals.com/release.php>`_.  You will also need to download
+the compiled libraries and headers (include files).
+
+When building from source on Windows, it is important to note that gdal-config
+only exists on UNIX platforms.  The setup.py scripts uses gdal-config discover
+the places to include files and libraries that rasterio needs to compile its
+C extensions.  On Windows, these paths need to be provided by the user.
+You will need to find the include files and the library files for gdal and 
+use setup.py as follows.
+
+.. code-block:: console
+
+    $ python setup.py build_ext -I<path to gdal include files> -lgdal_i -L<path to gdal library>
+    $ python setup.py install
+
+Note: The GDAL dll (gdal111.dll) and gdal-data directory need to be in your 
+Windows PATH otherwise rasterio will fail to work.
+
 Testing
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ log = logging.getLogger()
 if 'all' in sys.warnoptions:
     log.level = logging.DEBUG
 
-# Parse the version from the fiona module.
+# Parse the version from the rasterio module.
 with open('rasterio/__init__.py') as f:
     for line in f:
         if line.find("__version__") >= 0:
@@ -90,7 +90,11 @@ try:
         shutil.copytree(datadir, 'rasterio/gdal_data')
 
 except Exception as e:
-    log.warning("Failed to get options via gdal-config: %s", str(e))
+    if os.name == "nt":
+        log.info(("Building on Windows requires extra options to setup.py to locate needed GDAL files.\n"
+                 "More information is available in the README."))
+    else:
+        log.warning("Failed to get options via gdal-config: %s", str(e))
 
 # Conditionally copy PROJ.4 data.
 if os.environ.get('PACKAGE_DATA'):


### PR DESCRIPTION
gdal-config only exists on unix systems.  When building on windows, a call to gdal-config will always fail, and the compilation of the extension modules will subsequently fail.  

This change will look for a gdal-config.txt file first, and if that is not available, hope that we are running on a unix system.  This allows the builder to still specify the library paths so that the extension modules can be compiled successfully on windows.  The format of gdal-config.txt is unchanged (first line: include directories; second line: library directories; third line: gdal data directory).  There is no change in the build process for unix systems (except for possibly making sure that gdal-config.txt does not exist).  On windows, the user will need to create a gdal-config.txt file that contains the needed paths.

As an added bonus, this method avoids writing an unnecessary file during compilation.

Successful compilation tested on Windows and Linux.