### PR TITLE
gdal-config and GDAL_DATA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,19 +108,19 @@ except Exception as e:
 if os.environ.get('PACKAGE_DATA'):
     destdir = 'rasterio/gdal_data'
     if gdal_output[2]:
-        log.info("Copying gdal data from %s..." % gdal_ouput[2])
+        log.info("Copying gdal data from %s" % gdal_ouput[2])
         copy_data_tree(gdal_output[2], destdir)
     else:
         # check to see if GDAL_DATA is defined
         gdal_data = os.environ.get('GDAL_DATA', None)
         if gdal_data:
-            log.info("Copying gdal_data from %s..." % gdal_data)
+            log.info("Copying gdal_data from %s" % gdal_data)
             copy_data_tree(gdal_data, destdir)
 
     # Conditionally copy PROJ.4 data.
     projdatadir = os.environ.get('PROJ_LIB', '/usr/local/share/proj')
     if os.path.exists(projdatadir):
-        log.info("Copying proj_data from %s..." % projdatadir)
+        log.info("Copying proj_data from %s" % projdatadir)
         copy_data_tree(projdatadir, 'rasterio/proj_data')
 
 ext_options = dict(

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,25 @@ log = logging.getLogger()
 if 'all' in sys.warnoptions:
     log.level = logging.DEBUG
 
+def check_output(cmd):
+    # since subprocess.check_output doesn't exist in 2.6
+    # we wrap it here.
+    try:
+        return subprocess.check_output(cmd)
+    except AttributeError:
+        # For some reasone check_output doesn't exist
+        # So fall back on Popen
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        out, err = p.communicate()
+        return out
+
+def copy_data_tree(datadir, destdir):
+    try:
+        shutil.rmtree(destdir)
+    except OSError:
+        pass
+    shutil.copytree(datadir, destdir)
+
 # Parse the version from the fiona module.
 with open('rasterio/__init__.py') as f:
     for line in f:
@@ -50,6 +69,7 @@ include_dirs = []
 library_dirs = []
 libraries = []
 extra_link_args = []
+gdal_output = [None]*3
 
 try:
     import numpy
@@ -60,18 +80,13 @@ except ImportError:
 
 try:
     gdal_config = os.environ.get('GDAL_CONFIG', 'gdal-config')
-    with open("gdal-config.txt", "w") as gcfg:
-        subprocess.call([gdal_config, "--cflags"], stdout=gcfg)
-        subprocess.call([gdal_config, "--libs"], stdout=gcfg)
-        subprocess.call([gdal_config, "--datadir"], stdout=gcfg)
-    with open("gdal-config.txt", "r") as gcfg:
-        cflags = gcfg.readline().strip()
-        libs = gcfg.readline().strip()
-        datadir = gcfg.readline().strip()
-    for item in cflags.split():
+    for i, flag in enumerate(("--cflags", "--libs", "--datadir")):
+        gdal_output[i] = check_output([gdal_config, flag]).strip()
+
+    for item in gdal_output[0].split():
         if item.startswith("-I"):
             include_dirs.extend(item[2:].split(":"))
-    for item in libs.split():
+    for item in gdal_output[1].split():
         if item.startswith("-L"):
             library_dirs.extend(item[2:].split(":"))
         elif item.startswith("-l"):
@@ -80,27 +95,29 @@ try:
             # e.g. -framework GDAL
             extra_link_args.append(item)
 
-    # Conditionally copy the GDAL data. To be used in conjunction with
-    # the bdist_wheel command to make self-contained binary wheels.
-    if os.environ.get('PACKAGE_DATA'):
-        try:
-            shutil.rmtree('rasterio/gdal_data')
-        except OSError:
-            pass
-        shutil.copytree(datadir, 'rasterio/gdal_data')
-
 except Exception as e:
     log.warning("Failed to get options via gdal-config: %s", str(e))
 
-# Conditionally copy PROJ.4 data.
+
+# Conditionally copy the GDAL data. To be used in conjunction with
+# the bdist_wheel command to make self-contained binary wheels.
 if os.environ.get('PACKAGE_DATA'):
+    destdir = 'rasterio/gdal_data'
+    if gdal_output[2]:
+        log.info("Copying gdal data from %s..." % gdal_ouput[2])
+        copy_data_tree(gdal_output[2], destdir)
+    else:
+        # check to see if GDAL_DATA is defined
+        gdal_data = os.environ.get('GDAL_DATA', None)
+        if gdal_data:
+            log.info("Copying gdal_data from %s..." % gdal_data)
+            copy_data_tree(gdal_data, destdir)
+
+    # Conditionally copy PROJ.4 data.
     projdatadir = os.environ.get('PROJ_LIB', '/usr/local/share/proj')
     if os.path.exists(projdatadir):
-        try:
-            shutil.rmtree('rasterio/proj_data')
-        except OSError:
-            pass
-        shutil.copytree(projdatadir, 'rasterio/proj_data')
+        log.info("Copying proj_data from %s..." % projdatadir)
+        copy_data_tree(projdatadir, 'rasterio/proj_data')
 
 ext_options = dict(
     include_dirs=include_dirs,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ def check_output(cmd):
     # since subprocess.check_output doesn't exist in 2.6
     # we wrap it here.
     try:
-        return subprocess.check_output(cmd)
+        out = subprocess.check_output(cmd)
+        return out.decode('utf')
     except AttributeError:
         # For some reasone check_output doesn't exist
         # So fall back on Popen


### PR DESCRIPTION
This PR makes two changes.
1) get the output of gdal-config directly and parse instead of writing and reading it from a file.
2) Check for the existence of a GDAL_DATA (https://trac.osgeo.org/gdal/wiki/FAQInstallationAndBuilding#WhatisGDAL_DATAenvironmentvariable).
GDAL_DATA is equivalent to gdal-config --datadir, so I check both (as determined by PACKAGE_DATA).

Still need to test the changes, so don't merge yet.  Feedback welcome.