### PR TITLE
Added DatasetReader.window_bounds() to compute window corner coordinates

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -397,6 +397,13 @@ cdef class DatasetReader(object):
         (r, _), (c, _) = window
         return self.affine * Affine.translation(c or 0, r or 0)
 
+    def window_bounds(self, window):
+        """Returns the bounds of a window as x_min, y_min, x_max, y_max."""
+        ((row_min, row_max), (col_min, col_max)) = window
+        x_min, y_min = (col_min, row_max) * self.affine
+        x_max, y_max = (col_max, row_min) * self.affine
+        return x_min, y_min, x_max, y_max
+
     @property
     def meta(self):
         m = {

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -2,7 +2,6 @@ import rasterio
 from rasterio import transform
 
 
-
 def test_window_transform():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src.window_transform(((0, None), (0, None))) == src.affine
@@ -30,3 +29,48 @@ def test_from_bounds():
         w, s, e, n = src.bounds
         tr = transform.from_bounds(w, s, e, n, src.width, src.height)
         assert [round(v, 7) for v in tr] == [round(v, 7) for v in src.affine]
+
+
+def test_window_bounds():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+
+        rows = src.height
+        cols = src.width
+
+        # Test window for entire DS and each window in the DS
+        assert src.window_bounds(((0, rows), (0, cols))) == src.bounds
+        for _, window in src.block_windows():
+            ds_x_min, ds_y_min, ds_x_max, ds_y_max = src.bounds
+            w_x_min, w_y_min, w_x_max, w_y_max = src.window_bounds(window)
+            assert ds_x_min <= w_x_min <= w_x_max <= ds_x_max
+            assert ds_y_min <= w_y_min <= w_y_max <= ds_y_max
+
+        # Test a small window in each corner, both in and slightly out of bounds
+        p = 10
+        for window in (
+                # In bounds (UL, UR, LL, LR)
+                ((0, p), (0, p)),
+                ((0, p), (cols - p, p)),
+                ((rows - p, p), (0, p)),
+                ((rows - p, p), (cols - p, p)),
+
+                # Out of bounds (UL, UR, LL, LR)
+                ((-1, p), (-1, p)),
+                ((-1, p), (cols - p, p + 1)),
+                ((rows - p, p + 1), (-1, p)),
+                ((rows - p, p + 1), (cols - p, p + 1))):
+
+            # Alternate formula
+
+            ((row_min, row_max), (col_min, col_max)) = window
+            win_aff = src.window_transform(window)
+
+            x_min, y_max = win_aff.c, win_aff.f
+            x_max = win_aff.c + (src.res[0] * (col_max - col_min))
+            y_min = win_aff.f - (src.res[1] * (row_max - row_min))
+
+            expected = (x_min, y_min, x_max, y_max)
+            actual = src.window_bounds(window)
+
+            for e, a in zip(expected, actual):
+                assert round(e, 7) == round(a, 7)


### PR DESCRIPTION
I often find myself computing window corner coordinates when working with rasters and vectors in the same spatial context:

```python
with rio.open(infile) as src:
    for _, window in src.block_windows():

        ((row_min, row_max), (col_min, col_max)) = window
        x_min, y_min = (col_min, row_max) * src.affine
        x_max, y_max = (col_max, row_min) * src.affine

        # Some spatial comparison or filtering ...
```

and thought others might be doing the same so I added it as a method to `DatasetReader()`.

Example usage:

```python
import rasterio as rio

with rio.open('tests/data/RGB.byte.tif') as src:
    
    rows, cols = src.shape
    ds_window = ((0, rows), (0, cols))
    print(src.window_bounds(ds_window))

    _, first_window = next(src.block_windows())
    print(src.window_bounds(first_window))
```

Output:

```console
(101985.0, 2611485.0, 339315.0, 2826915.0)
(101985.0, 2826014.8746518106, 339315.0, 2826915.0)
```