### PR TITLE
Remove sys.exit() calls.

### DIFF
--- a/rasterio/rio/bands.py
+++ b/rasterio/rio/bands.py
@@ -119,7 +119,6 @@ def stack(ctx, files, output, driver, bidx, photometric):
                             dst.write(data, range(dst_idx, dst_idx+len(index)))
                             dst_idx += len(index)
 
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -135,15 +135,14 @@ def calc(ctx, command, files, output, name, dtype, masked):
             with rasterio.open(output, 'w', **kwargs) as dst:
                 dst.write(results)
 
-        sys.exit(0)
     except snuggs.ExpressionError as err:
         click.echo("Expression Error:")
         click.echo('  %s' % err.text)
         click.echo(' ' +  ' ' * err.offset + "^")
         click.echo(err)
-        sys.exit(1)
+        raise click.Abort()
     except Exception as err:
         t, v, tb = sys.exc_info()
         for line in traceback.format_exception_only(t, v):
             click.echo(line, nl=False)
-        sys.exit(1)
+        raise click.Abort()

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -18,11 +18,9 @@ from rasterio.rio.cli import (
 def get_bands(inputs, d, i=None):
     """Get a rasterio.Band object from calc's inputs"""
     path = inputs[d] if d in dict(inputs) else inputs[int(d)-1][1]
-    if i:
-        return rasterio.band(rasterio.open(path), i)
-    else:
-        src = rasterio.open(path)
-        return [rasterio.band(src, i) for i in src.indexes]
+    src = rasterio.open(path)
+    return (rasterio.band(src, i) if i else 
+            [rasterio.band(src, i) for i in src.indexes])
 
 
 def read_array(ix, subix=None, dtype=None):
@@ -141,8 +139,8 @@ def calc(ctx, command, files, output, name, dtype, masked):
         click.echo(' ' +  ' ' * err.offset + "^")
         click.echo(err)
         raise click.Abort()
-    except Exception as err:
-        t, v, tb = sys.exc_info()
-        for line in traceback.format_exception_only(t, v):
-            click.echo(line, nl=False)
-        raise click.Abort()
+    #except Exception as err:
+    #    t, v, tb = sys.exc_info()
+    #    for line in traceback.format_exception_only(t, v):
+    #        click.echo(line, nl=False)
+    #    raise click.Abort()

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -348,10 +348,9 @@ def shapes(
                 stdout, Collection(), sequence=sequence,
                 geojson_type=geojson_type, use_rs=use_rs,
                 **dump_kwds)
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Rasterize command.

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -210,9 +210,8 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
                     else:
                         click.echo(json.dumps(info, indent=indent))
                 elif aspect == 'tags':
-                    click.echo(json.dumps(src.tags(ns=namespace), 
+                    click.echo(json.dumps(src.tags(ns=namespace),
                                             indent=indent))
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -176,7 +176,6 @@ def merge(ctx, files, output, driver, bounds, res, nodata):
             dst.write(dest)
             dst.close()
 
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -52,10 +52,9 @@ def insp(ctx, input, mode):
                         rasterio.__version__,
                         '.'.join(map(str, sys.version_info[:3]))),
                     src)
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Bounds command.
@@ -149,10 +148,10 @@ def bounds(ctx, input, precision, indent, compact, projection, sequence,
                 stdout, col, sequence=sequence,
                 geojson_type=geojson_type, use_rs=use_rs,
                 **dump_kwds)
-        sys.exit(0)
+
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()
 
 
 # Transform command.
@@ -199,7 +198,6 @@ def transform(ctx, input, src_crs, dst_crs, precision):
                 result[1::2] = ys
                 print(json.dumps(result))
 
-        sys.exit(0)
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -88,7 +88,7 @@ def sample(ctx, files, bidx):
                             (json.loads(line) for line in points),
                             indexes=indexes):
                     click.echo(json.dumps(vals.tolist()))
-        sys.exit(0)
+
     except Exception:
-        logger.exception("Failed. Exception caught")
-        sys.exit(1)
+        logger.exception("Exception caught during processing")
+        raise click.Abort()

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -129,7 +129,6 @@ def test_fillnodata(tmpdir):
                     outfile],
                 catch_exceptions=False)
     assert result.exit_code == 0
-    # import subprocess; subprocess.call(['open', outfile])
     with rasterio.open(outfile) as src:
         assert src.count == 3
         assert src.meta['dtype'] == 'uint8'


### PR DESCRIPTION
Click will do this for us. If we raise click.Abort(), we get the proper return value of 1.

Closes #350.