### PR TITLE
Sync CLI docs with current options

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -18,6 +18,8 @@ Rasterio's new command line interface is a program named "rio".
 
     Commands:
       bounds     Write bounding boxes to stdout as GeoJSON.
+      calc       Raster data calculator.
+      edit-info  Edit dataset metadata.
       env        Print information about the rio environment.
       info       Print information about a data file.
       insp       Open a data file and start an interpreter.
@@ -25,8 +27,9 @@ Rasterio's new command line interface is a program named "rio".
       merge      Merge a stack of raster datasets.
       rasterize  Rasterize features.
       sample     Sample a dataset.
-      shapes     Write the shapes of features.
+      shapes     Write shapes extracted from bands or masks.
       stack      Stack a number of bands into a multiband dataset.
+      transform  Transform coordinates.
 
 It is developed using `Click <http://click.pocoo.org/3/>`__.
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,7 +1,7 @@
 Command Line Interface
 ======================
 
-Rasterio's new command line interface is a program named "rio".
+Rasterio's command line interface is a program named "rio".
 
 .. code-block:: console
 


### PR DESCRIPTION
Some of the `rio` commands were missing from the options in the `cli.rst` file. This just updates them to the ones from the help message.

I also took the liberty of removing "new" from the description of rio.