### PR TITLE
Use IPython for the rio interpreter

### DIFF
--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -43,6 +43,10 @@ warnings.simplefilter('default')
     help="File mode (default 'r').")
 @click.pass_context
 def insp(ctx, input, mode, ipython):
+    """ Open the input file in a Python interpreter.
+
+    IPython will be used as the default interpreter, if available.
+    """
     import rasterio.tool
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')

--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -34,7 +34,7 @@ warnings.simplefilter('default')
 @click.option(
     '--ipython/--no-ipython',
     default=True,
-    help='Use IPython as interpreter.')
+    help='Use IPython as interpreter (default: True).')
 @click.option(
     '-m',
     '--mode',

--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -31,6 +31,7 @@ warnings.simplefilter('default')
 # Insp command.
 @cli.command(short_help="Open a data file and start an interpreter.")
 @file_in_arg
+@click.option('--ipython/--no-ipython', default=True)
 @click.option(
     '-m',
     '--mode',
@@ -38,7 +39,7 @@ warnings.simplefilter('default')
     default='r',
     help="File mode (default 'r').")
 @click.pass_context
-def insp(ctx, input, mode):
+def insp(ctx, input, mode, ipython):
     import rasterio.tool
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')
@@ -51,7 +52,7 @@ def insp(ctx, input, mode):
                     'for more information.' %  (
                         rasterio.__version__,
                         '.'.join(map(str, sys.version_info[:3]))),
-                    src)
+                    src, ipython)
     except Exception:
         logger.exception("Exception caught during processing")
         raise click.Abort()

--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -31,7 +31,10 @@ warnings.simplefilter('default')
 # Insp command.
 @cli.command(short_help="Open a data file and start an interpreter.")
 @file_in_arg
-@click.option('--ipython/--no-ipython', default=True)
+@click.option(
+    '--ipython/--no-ipython',
+    default=True,
+    help='Use IPython as interpreter.')
 @click.option(
     '-m',
     '--mode',

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -50,9 +50,10 @@ def stats(source):
 
 
 def main(banner, dataset):
-    """ Main entry point for use with interpreter """
-    code.interact(
-        banner,
-        local=dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt))
+    """ Main entry point for use with IPython interpreter """
+    import IPython
+
+    locals = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
+    IPython.start_ipython(argv=[], user_ns=locals)
 
     return 0

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -50,11 +50,15 @@ def stats(source):
 
 
 def main(banner, dataset):
-    """ Main entry point for use with IPython interpreter """
-    import IPython
+    """ Main entry point for use with python interpreter """
 
-    locals = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
-    IPython.InteractiveShell.banner1 = banner
-    IPython.start_ipython(argv=[], user_ns=locals)
+    local = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
+    try:
+        import IPython
+    except ImportError:
+        code.interact(banner, local=local)
+    else:
+        IPython.InteractiveShell.banner1 = banner
+        IPython.start_ipython(argv=[], user_ns=local)
 
     return 0

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -54,6 +54,7 @@ def main(banner, dataset):
     import IPython
 
     locals = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
+    IPython.InteractiveShell.banner1 = banner
     IPython.start_ipython(argv=[], user_ns=locals)
 
     return 0

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -2,7 +2,6 @@
 import code
 import collections
 import logging
-import sys
 
 try:
     import matplotlib.pyplot as plt

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -48,16 +48,18 @@ def stats(source):
     return Stats(numpy.min(arr), numpy.max(arr), numpy.mean(arr))
 
 
-def main(banner, dataset):
+def main(banner, dataset, ipython):
     """ Main entry point for use with python interpreter """
-
-    local = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
     try:
         import IPython
     except ImportError:
-        code.interact(banner, local=local)
-    else:
+        ipython = False
+
+    local = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
+    if ipython:
         IPython.InteractiveShell.banner1 = banner
         IPython.start_ipython(argv=[], user_ns=local)
+    else:
+        code.interact(banner, local=local)
 
     return 0


### PR DESCRIPTION
Allows the use of IPython from `rio insp`, with tab completion, history, pretty-printed dictionaries, and all else that gives you.

Falls back to the standard interpreter if the IPython import fails.