### PR TITLE
Upgrade to Cython 0.22

### DIFF
--- a/rasterio/_features.pxd
+++ b/rasterio/_features.pxd
@@ -16,14 +16,14 @@ cdef class GeomBuilder:
 
 
 cdef class OGRGeomBuilder:
-    cdef void * _createOgrGeometry(self, int geom_type)
+    cdef void * _createOgrGeometry(self, int geom_type) except NULL
     cdef _addPointToGeometry(self, void *cogr_geometry, object coordinate)
-    cdef void * _buildPoint(self, object coordinates)
-    cdef void * _buildLineString(self, object coordinates)
-    cdef void * _buildLinearRing(self, object coordinates)
-    cdef void * _buildPolygon(self, object coordinates)
-    cdef void * _buildMultiPoint(self, object coordinates)
-    cdef void * _buildMultiLineString(self, object coordinates)
-    cdef void * _buildMultiPolygon(self, object coordinates)
-    cdef void * _buildGeometryCollection(self, object coordinates)
-    cdef void * build(self, object geom)
+    cdef void * _buildPoint(self, object coordinates) except NULL
+    cdef void * _buildLineString(self, object coordinates) except NULL
+    cdef void * _buildLinearRing(self, object coordinates) except NULL
+    cdef void * _buildPolygon(self, object coordinates) except NULL
+    cdef void * _buildMultiPoint(self, object coordinates) except NULL
+    cdef void * _buildMultiLineString(self, object coordinates) except NULL
+    cdef void * _buildMultiPolygon(self, object coordinates) except NULL
+    cdef void * _buildGeometryCollection(self, object coordinates) except NULL
+    cdef void * build(self, object geom) except NULL

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -38,7 +38,16 @@ log.addHandler(NullHandler())
 cdef bint in_dtype_range(value, dtype):
     """Returns True if value is in the range of dtype, else False."""
     infos = {
-            'c': np.finfo, 'f': np.finfo, 'i': np.iinfo, 'u': np.iinfo}
+        'c': np.finfo,
+        'f': np.finfo,
+        'i': np.iinfo,
+        'u': np.iinfo,
+        # Cython 0.22 returns dtype.kind as an int and will not cast to a char
+        99: np.finfo,
+        102: np.finfo,
+        105: np.iinfo,
+        117: np.iinfo
+    }
     rng = infos[np.dtype(dtype).kind](dtype)
     return rng.min <= value <= rng.max
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 affine
 cligj
 coveralls>=0.4
-cython==0.21.2
+cython>=0.21.2
 delocate
 enum34
 numpy>=1.8.0

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ if os.environ.get('PACKAGE_DATA'):
         copy_data_tree(projdatadir, 'rasterio/proj_data')
 
 ext_options = dict(
+    extra_compile_args=['-Wno-unused-parameter', '-Wno-unused-function'],
     include_dirs=include_dirs,
     library_dirs=library_dirs,
     libraries=libraries,


### PR DESCRIPTION
Resolves #371 and #276 

Function declarations, including ```except NULL``` need to match between ```.pyx``` and ```.pxd``` files now.

For reasons that are not immediately clear, Cython now returns ```np.dytpe(some_dtype).kind``` as an integer, and does not cast to a ```char```, instead of returning it as a character that matches our dictionary keys for these.  I added the integer codes to the dictionary in addition to the characters.  This same fix is not needed apparently in pure Python code.

I also turned off a couple of the Cython compile time warnings; these didn't appear to be giving us useful information that we could use to cleanup the code.