### PR TITLE
Generalize the alt interpreter feature.

### DIFF
--- a/rasterio/rio/rio.py
+++ b/rasterio/rio/rio.py
@@ -31,10 +31,8 @@ warnings.simplefilter('default')
 # Insp command.
 @cli.command(short_help="Open a data file and start an interpreter.")
 @file_in_arg
-@click.option(
-    '--ipython/--no-ipython',
-    default=True,
-    help='Use IPython as interpreter (default: True).')
+@click.option('--ipython', 'interpreter', flag_value='ipython',
+              help="Use IPython as interpreter.")
 @click.option(
     '-m',
     '--mode',
@@ -42,7 +40,7 @@ warnings.simplefilter('default')
     default='r',
     help="File mode (default 'r').")
 @click.pass_context
-def insp(ctx, input, mode, ipython):
+def insp(ctx, input, mode, interpreter):
     """ Open the input file in a Python interpreter.
 
     IPython will be used as the default interpreter, if available.
@@ -59,7 +57,7 @@ def insp(ctx, input, mode, ipython):
                     'for more information.' %  (
                         rasterio.__version__,
                         '.'.join(map(str, sys.version_info[:3]))),
-                    src, ipython)
+                    src, interpreter)
     except Exception:
         logger.exception("Exception caught during processing")
         raise click.Abort()

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -48,18 +48,16 @@ def stats(source):
     return Stats(numpy.min(arr), numpy.max(arr), numpy.mean(arr))
 
 
-def main(banner, dataset, ipython):
+def main(banner, dataset, alt_interpreter=None):
     """ Main entry point for use with python interpreter """
-    try:
-        import IPython
-    except ImportError:
-        ipython = False
-
     local = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
-    if ipython:
+    if not alt_interpreter:
+        code.interact(banner, local=local)
+    elif alt_interpreter == 'ipython':
+        import IPython
         IPython.InteractiveShell.banner1 = banner
         IPython.start_ipython(argv=[], user_ns=local)
     else:
-        code.interact(banner, local=local)
+        raise ValueError("Unsupported interpreter '%s'" % interpreter)
 
     return 0

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,9 @@ setup_args = dict(
     include_package_data=True,
     ext_modules=ext_modules,
     zip_safe=False,
-    install_requires=inst_reqs)
+    install_requires=inst_reqs,
+    extras_require={
+        'ipython': ['ipython>=2.0']})
 
 if os.environ.get('PACKAGE_DATA'):
     setup_args['package_data'] = {'rasterio': ['gdal_data/*', 'proj_data/*']}


### PR DESCRIPTION
Someone can now add bpython if they want to do so. I've switched the default interpreter back to the ordinary Python interpreter. Not that it's better, but it has fewer versioning considerations (see https://github.com/mapbox/rasterio/pull/372#issuecomment-107194069).

In setup.py, I've listed ipython as an 'extra' feature.