### PR TITLE
Omit cython extra_compile_args on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,11 +125,15 @@ if os.environ.get('PACKAGE_DATA'):
         copy_data_tree(projdatadir, 'rasterio/proj_data')
 
 ext_options = dict(
-    extra_compile_args=['-Wno-unused-parameter', '-Wno-unused-function'],
     include_dirs=include_dirs,
     library_dirs=library_dirs,
     libraries=libraries,
     extra_link_args=extra_link_args)
+
+if not os.name == "nt":
+    # These options fail on Windows if using Visual Studio
+    ext_options['extra_compile_args'] = ['-Wno-unused-parameter',
+                                         '-Wno-unused-function']
 
 log.debug('ext_options:\n%s', pprint.pformat(ext_options))
 


### PR DESCRIPTION
I goofed when suppressing Cython compile-time warnings; those compiler flags do not work for Microsoft's Visual Studio when building on Windows.

This omits those flags if running on Windows.  Maybe not a perfect fit for those compiling with mingw or in Cygwin or somesuch, but the only downside is more compiler warnings (which we had until very recently anyway).