### PR TITLE
Investigate whether using gdal 1.10.1 on ubuntu precise breaks tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.3"
   - "3.4"
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntugis/ppa
+  - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get update -qq
   - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
 install:


### PR DESCRIPTION
This is not a pull request - no need to merge:

This is a followup of the bug report #380. Since one  of the only differences between the travis tests and my environment are newer versions of gdal and proj,  I want to force travis to use those versions at least once to see whether the tests fail here. Accidentely debian jessie and ubuntugis unstable (for precise) have the same version.