### PR TITLE
reproject within rio-mask

### DIFF
--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -1,5 +1,3 @@
-import IPython
-
 import json
 import logging
 from math import ceil

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -133,16 +133,7 @@ def mask(
             (left, right), (bottom, top) = rasterio.warp.transform(from_crs, src.crs, x, y)
             bounds = BoundingBox(left, bottom, right, top)
             
-            def transform(feature):
-                x, y = zip(*feature.get('coordinates')[0])
-                feature['coordinates'] = [
-                    zip(*rasterio.warp.transform(from_crs, src.crs, x, y))
-                ]
-                
-                return feature
-            
-            # TODO: Use Rasterio's facility for this. I can't find it ...
-            geometries = map(transform, geometries)
+            geometries = map(lambda g: rasterio.warp.transform_geom(from_crs, src.crs, g), geometries)
             
             disjoint_bounds = _disjoint_bounds(bounds, src.bounds)
             

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -117,7 +117,7 @@ def mask(
             raise click.BadParameter('Invalid GeoJSON', param=input,
                                      param_hint='input')
         bounds = geojson.get('bbox', calculate_bounds(geojson))
-        
+
         with rasterio.open(input) as src:
             
             # Determine the projection of the GeoJSON mask
@@ -134,7 +134,7 @@ def mask(
             geometries = map(lambda g: rasterio.warp.transform_geom(from_crs, src.crs, g), geometries)
             
             disjoint_bounds = _disjoint_bounds(bounds, src.bounds)
-            
+
             if crop:
                 if disjoint_bounds:
                     raise click.BadParameter('not allowed for GeoJSON outside '
@@ -154,7 +154,7 @@ def mask(
                 window = None
                 transform = src.affine
                 mask_shape = src.shape
-            
+
             mask = geometry_mask(
                 geometries,
                 out_shape=mask_shape,
@@ -174,7 +174,6 @@ def mask(
                 for bidx in range(1, src.count + 1):
                     img = src.read(bidx, masked=True, window=window)
                     img.mask = img.mask | mask
-                    
                     out.write_band(bidx, img.filled(src.nodatavals[bidx-1]))
 
 

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -30,6 +30,12 @@ TEST_FEATURES = """{
 }"""
 
 TEST_MERC_FEATURES = """{
+  "crs": {
+      "type": "name",
+      "properties": {
+          "name": "EPSG:3857"
+      }
+  },
   "geometry": {
       "coordinates": [
           [
@@ -51,6 +57,12 @@ TEST_MERC_FEATURES = """{
 # > rio shapes tests/data/shade.tif --mask --sampling 500 --projected --precision 0
 TEST_MERC_FEATURECOLLECTION = """{
     "bbox": [-11858135.0, 4803914.0, -11848351.0, 4813698.0],
+    "crs": {
+        "type": "name",
+        "properties": {
+            "name": "urn:ogc:def:crs:EPSG::3857"
+        }
+    },
     "features": [{
         "bbox": [-11853357.504145855, 4808920.97837715,
                  -11848580.189878704, 4813698.2926443005],


### PR DESCRIPTION
@sgillies I opted to transform the geojson crs to that of the input image. When the crs property is not present, WGS84 is used.

My only concern is whether `rasterio.warp.transform` is able to handle the variety of crs formats allowed by the geojson spec. You'll notice I only accept named crs, ignoring linked crs.

This allows for operations such as:

    rio bounds epsg-32754.tif | rio mask epsg-32654.tif --geojson-mask - output.tif --crop

#385 