### PR TITLE
Fix calculation with Numpy <1.9

### DIFF
--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -120,6 +120,9 @@ def calc(ctx, command, files, output, name, dtype, masked):
 
             res = snuggs.eval(command, **ctxkwds)
 
+            if type(res) is np.ma.core.MaskedArray:
+                res = res.filled(kwargs['nodata'])
+
             if len(res.shape) == 3:
                 results = np.ndarray.astype(res, dtype, copy=False)
             else:


### PR DESCRIPTION
This is a possible solution for #380 : Some failing tests when building using Numpy 1.8. After the calculation in snuggs, also the masked values are changed. 

When writing the data set, the changed values were written rather than the nodata values. 
One can argue that this fix should go into snuggs instead, and a check for the numpy version could be added (to avoid large copies when using 1.9), but with this change in place at least all tests return the right result using Numpy 1.8.