### PR TITLE
add dst_crs to rio-bounds

### DIFF
--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -611,7 +611,9 @@ def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
     geojsonio
 
       $ rio bounds *.tif | geojsonio
-
+    
+    If a destination crs is passed via dst_crs, it takes precedence over
+    the projection parameter.
     """
     import rasterio.warp
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -12,7 +12,7 @@ from cligj import (
     use_rs_opt, geojson_type_feature_opt, geojson_type_bbox_opt,
     files_inout_arg, format_opt, geojson_type_collection_opt)
 
-from .helpers import coords, resolve_inout, write_features
+from .helpers import coords, resolve_inout, write_features, to_lower
 from . import options
 import rasterio
 from rasterio.transform import Affine
@@ -598,7 +598,7 @@ def rasterize(
 @projection_geographic_opt
 @projection_projected_opt
 @projection_mercator_opt
-@click.option('--dst_crs', default=None, metavar="EPSG:NNNN", help="Destination CRS.")
+@click.option('--dst-crs', default='epsg:4326', metavar="EPSG:NNNN", callback=to_lower, help="Destination CRS.")
 @sequence_opt
 @use_rs_opt
 @geojson_type_collection_opt(True)
@@ -640,15 +640,12 @@ def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
                     bounds = src.bounds
                     xs = [bounds[0], bounds[2]]
                     ys = [bounds[1], bounds[3]]
-                    if dst_crs:
-                        xs, ys = rasterio.warp.transform(
-                            src.crs, {'init': dst_crs}, xs, ys)
-                    elif projection == 'geographic':
-                        xs, ys = rasterio.warp.transform(
-                            src.crs, {'init': 'epsg:4326'}, xs, ys)
-                    elif projection == 'mercator':
+                    if projection == 'mercator':
                         xs, ys = rasterio.warp.transform(
                             src.crs, {'init': 'epsg:3857'}, xs, ys)
+                    else:
+                        xs, ys = rasterio.warp.transform(
+                            src.crs, {'init': dst_crs}, xs, ys)
 
                 if precision >= 0:
                     xs = [round(v, precision) for v in xs]
@@ -692,3 +689,4 @@ def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
 def _disjoint_bounds(bounds1, bounds2):
     return (bounds1[0] > bounds2[2] or bounds1[2] < bounds2[0] or
             bounds1[1] > bounds2[3] or bounds1[3] < bounds2[1])
+

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -598,7 +598,7 @@ def rasterize(
 @projection_geographic_opt
 @projection_projected_opt
 @projection_mercator_opt
-@click.option('--dst-crs', default='epsg:4326', metavar="EPSG:NNNN", callback=to_lower, help="Destination CRS.")
+@click.option('--dst-crs', default='', metavar="EPSG:NNNN", callback=to_lower, help="Output in specified coordinates.")
 @sequence_opt
 @use_rs_opt
 @geojson_type_collection_opt(True)
@@ -640,12 +640,15 @@ def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
                     bounds = src.bounds
                     xs = [bounds[0], bounds[2]]
                     ys = [bounds[1], bounds[3]]
-                    if projection == 'mercator':
-                        xs, ys = rasterio.warp.transform(
-                            src.crs, {'init': 'epsg:3857'}, xs, ys)
-                    else:
+                    if dst_crs:
                         xs, ys = rasterio.warp.transform(
                             src.crs, {'init': dst_crs}, xs, ys)
+                    elif projection == 'mercator':
+                        xs, ys = rasterio.warp.transform(
+                            src.crs, {'init': 'epsg:3857'}, xs, ys)
+                    elif projection == 'geographic':
+                        xs, ys = rasterio.warp.transform(
+                            src.crs, {'init': 'epsg:4326'}, xs, ys)
 
                 if precision >= 0:
                     xs = [round(v, precision) for v in xs]

--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -73,3 +73,7 @@ def resolve_inout(input=None, output=None, files=None):
         [input] if input else [] +
         list(files[:-1 if not output else None]) if files else [])
     return resolved_output, resolved_inputs
+
+
+def to_lower(ctx, param, value):
+    return value.lower()

--- a/tests/test_rio_helpers.py
+++ b/tests/test_rio_helpers.py
@@ -16,3 +16,8 @@ def test_resolve_files_inout__inout_files():
 def test_resolve_files_inout__inout_files_output_o():
     assert helpers.resolve_inout(
         files=('a', 'b', 'c'), output='out') == ('out', ['a', 'b', 'c'])
+
+
+def test_to_lower():
+    
+    assert helpers.to_lower(None, None, 'EPSG:3857') == 'epsg:3857'

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -386,6 +386,19 @@ def test_bounds_obj_bbox_projected():
     assert result.output.strip() == '[101985.0, 2611485.0, 339315.0, 2826915.0]'
 
 
+def test_bounds_crs_bbox():
+    runner = CliRunner()
+    result = runner.invoke(main_group, [
+        'bounds',
+        'tests/data/RGB.byte.tif',
+        '--bbox',
+        '--dst-crs', 'EPSG:32618',
+        '--precision', '3'
+    ])
+    assert result.exit_code == 0
+    assert result.output.strip() == '[101985.0, 2611485.0, 339315.0, 2826915.0]'
+
+
 def test_bounds_seq():
     runner = CliRunner()
     result = runner.invoke(main_group, [


### PR DESCRIPTION
Adds a `--dst_crs` option to `rio-bounds`.

Two questions, both very minor.

 * The `dst_crs` cli option is now common between Fiona and Rasterio. How about adding it to cligj?
 * `rasterio.warp.transform_bounds` accepts arguments in a different order than `rasterio.warp.transform` and `rasterio.warp.transform_geom`, both accepting `src.crs` and `dst.crs` as the first two arguments. How about doing the same for `transform_bounds`? This would permit:

```
rasterio.warp.transform_bounds(src.crs, dst.crs, *src.bounds)
```

/cc @sgillies @brendan-ward 