### PR TITLE
consistent args throughout transform funcs

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -81,7 +81,7 @@ def transform_geom(
         precision)
 
 
-def transform_bounds(left, bottom, right, top, src_crs, dst_crs, densify_pts=21):
+def transform_bounds(src_crs, dst_crs, left, bottom, right, top, densify_pts=21):
     """
     Transforms bounds from src_crs to dst_crs, optionally densifying the edges
     (to account for nonlinear transformations along these edges) and extracting
@@ -91,13 +91,13 @@ def transform_bounds(left, bottom, right, top, src_crs, dst_crs, densify_pts=21)
 
     Parameters
     ----------
-    left, bottom, right, top: float
-        Bounding coordinates in src_crs, from the bounds property of a raster.
     src_crs: dict
         Source coordinate reference system, in rasterio dict format.
         Example: {'init': 'EPSG:4326'}
     dst_crs: dict
         Target coordinate reference system.
+    left, bottom, right, top: float
+        Bounding coordinates in src_crs, from the bounds property of a raster.
     densify_pts: uint, optional
         Number of points to add to each edge to account for nonlinear
         edges produced by the transform process.  Large numbers will produce
@@ -230,14 +230,14 @@ def reproject(
 
 
 def calculate_default_transform(
+        src_crs,
+        dst_crs,
         left,
         bottom,
         right,
         top,
         width,
         height,
-        src_crs,
-        dst_crs,
         resolution=None,
         densify_pts=21):
     """
@@ -257,13 +257,13 @@ def calculate_default_transform(
 
     Parameters
     ----------
-    left, bottom, right, top: float
-        Bounding coordinates in src_crs, from the bounds property of a raster.
     src_crs: dict
         Source coordinate reference system, in rasterio dict format.
         Example: {'init': 'EPSG:4326'}
     dst_crs: dict
         Target coordinate reference system.
+    left, bottom, right, top: float
+        Bounding coordinates in src_crs, from the bounds property of a raster.
     resolution: tuple (x resolution, y resolution) or float, optional
         Target resolution, in units of target coordinate reference system.
     densify_pts: uint, optional
@@ -277,7 +277,7 @@ def calculate_default_transform(
     """
 
     xmin, ymin, xmax, ymax = transform_bounds(
-        left, bottom, right, top, src_crs, dst_crs, densify_pts)
+        src_crs, dst_crs, left, bottom, right, top, densify_pts)
 
     x_dif = xmax - xmin
     y_dif = ymax - ymin

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -232,12 +232,12 @@ def reproject(
 def calculate_default_transform(
         src_crs,
         dst_crs,
+        width,
+        height,
         left,
         bottom,
         right,
         top,
-        width,
-        height,
         resolution=None,
         densify_pts=21):
     """

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -30,7 +30,7 @@ class ReprojectParams(object):
 
         with rasterio.drivers():
             dt, dw, dh = calculate_default_transform(
-                src_crs, dst_crs, left, bottom, right, top, width, height)
+                src_crs, dst_crs, width, height, left, bottom, right, top)
             self.dst_transform = dt
             self.dst_width = dw
             self.dst_height = dh
@@ -139,7 +139,7 @@ def test_calculate_default_transform():
             l, b, r, t = src.bounds
             wgs84_crs = {'init': 'EPSG:4326'}
             dst_transform, width, height = calculate_default_transform(
-                src.crs, wgs84_crs, l, b, r, t, src.width, src.height)
+                src.crs, wgs84_crs, src.width, src.height, l, b, r, t)
 
             assert dst_transform.almost_equals(target_transform)
             assert width == 824
@@ -156,8 +156,8 @@ def test_calculate_default_transform_single_resolution():
                 0.0, -target_resolution, 25.550873767433984
             )
             dst_transform, width, height = calculate_default_transform(
-                src.crs, {'init': 'EPSG:4326'}, l, b, r, t, src.width,
-                src.height, resolution=target_resolution
+                src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
+                l, b, r, t, resolution=target_resolution
             )
 
             assert dst_transform.almost_equals(target_transform)
@@ -176,8 +176,8 @@ def test_calculate_default_transform_multiple_resolutions():
             )
 
             dst_transform, width, height = calculate_default_transform(
-                src.crs, {'init': 'EPSG:4326'}, l, b, r, t, src.width,
-                src.height, resolution=target_resolution
+                src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
+                l, b, r, t, resolution=target_resolution
             )
 
             assert dst_transform.almost_equals(target_transform)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -30,7 +30,7 @@ class ReprojectParams(object):
 
         with rasterio.drivers():
             dt, dw, dh = calculate_default_transform(
-                left, bottom, right, top, width, height, src_crs, dst_crs)
+                src_crs, dst_crs, left, bottom, right, top, width, height)
             self.dst_transform = dt
             self.dst_width = dw
             self.dst_height = dh
@@ -68,7 +68,7 @@ def test_transform_bounds():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             l, b, r, t = src.bounds
             assert numpy.allclose(
-                transform_bounds(l, b, r, t, src.crs, {'init': 'EPSG:4326'}),
+                transform_bounds(src.crs, {'init': 'EPSG:4326'}, l, b, r, t),
                 (
                     -78.95864996545055, 23.564991210854686,
                     -76.57492370013823, 25.550873767433984
@@ -83,9 +83,9 @@ def test_transform_bounds_densify():
     dst_crs = {'init': 'EPSG:32610'}
     assert numpy.allclose(
         transform_bounds(
-            -120, 40, -80, 64,
             src_crs,
             dst_crs,
+            -120, 40, -80, 64,
             densify_pts=0
         ),
         (
@@ -96,9 +96,9 @@ def test_transform_bounds_densify():
 
     assert numpy.allclose(
         transform_bounds(
-            -120, 40, -80, 64,
             src_crs,
             dst_crs,
+            -120, 40, -80, 64,
             densify_pts=100
         ),
         (
@@ -114,7 +114,7 @@ def test_transform_bounds_no_change():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             l, b, r, t = src.bounds
             assert numpy.allclose(
-                transform_bounds(l, b, r, t, src.crs, src.crs),
+                transform_bounds(src.crs, src.crs, l, b, r, t),
                 src.bounds
             )
 
@@ -122,9 +122,9 @@ def test_transform_bounds_no_change():
 def test_transform_bounds_densify_out_of_bounds():
     with pytest.raises(ValueError):
         transform_bounds(
-            -120, 40, -80, 64,
             {'init': 'EPSG:4326'},
             {'init': 'EPSG:32610'},
+            -120, 40, -80, 64,
             densify_pts=-10
         )
 
@@ -139,7 +139,7 @@ def test_calculate_default_transform():
             l, b, r, t = src.bounds
             wgs84_crs = {'init': 'EPSG:4326'}
             dst_transform, width, height = calculate_default_transform(
-                l, b, r, t, src.width, src.height, src.crs, wgs84_crs)
+                src.crs, wgs84_crs, l, b, r, t, src.width, src.height)
 
             assert dst_transform.almost_equals(target_transform)
             assert width == 824
@@ -156,8 +156,8 @@ def test_calculate_default_transform_single_resolution():
                 0.0, -target_resolution, 25.550873767433984
             )
             dst_transform, width, height = calculate_default_transform(
-                l, b, r, t, src.width, src.height, src.crs,
-                {'init': 'EPSG:4326'}, resolution=target_resolution
+                src.crs, {'init': 'EPSG:4326'}, l, b, r, t, src.width,
+                src.height, resolution=target_resolution
             )
 
             assert dst_transform.almost_equals(target_transform)
@@ -176,8 +176,8 @@ def test_calculate_default_transform_multiple_resolutions():
             )
 
             dst_transform, width, height = calculate_default_transform(
-                l, b, r, t, src.width, src.height, src.crs,
-                {'init': 'EPSG:4326'}, resolution=target_resolution
+                src.crs, {'init': 'EPSG:4326'}, l, b, r, t, src.width,
+                src.height, resolution=target_resolution
             )
 
             assert dst_transform.almost_equals(target_transform)


### PR DESCRIPTION
@sgillies @brendan-ward As promised, here's a PR to make args for `rasterio.warp.transform`s funcs more consistent. `src_crs` and `dst_crs` are always the 1st args.