### PR TITLE
Add a --like option to rio-edit-info

### DIFF
--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -28,7 +28,7 @@ def like_dataset(ctx, param, value):
 
 def nodata_handler(ctx, param, value):
     """Get nodata value from a template file or command line."""
-    if ctx.obj and ctx.obj.get('like'):
+    if value and ctx.obj and ctx.obj.get('like'):
         value = ctx.obj.get('like')['nodata']
     elif value:
         value = float(value)
@@ -37,7 +37,7 @@ def nodata_handler(ctx, param, value):
 
 def transform_handler(ctx, param, value):
     """Get transform value from a template file or command line."""
-    if ctx.obj and ctx.obj.get('like'):
+    if value and ctx.obj and ctx.obj.get('like'):
         value = ctx.obj.get('like')['affine']
     elif value:
         try:
@@ -56,7 +56,7 @@ def transform_handler(ctx, param, value):
 
 def crs_handler(ctx, param, value):
     """Get crs value from a template file or command line."""
-    if ctx.obj and ctx.obj.get('like'):
+    if value and ctx.obj and ctx.obj.get('like'):
         value = ctx.obj.get('like')['crs']
     elif value:
         try:

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -29,7 +29,7 @@ def from_like_context(ctx, param, value):
 
 def all_handler(ctx, param, value):
     """Get tags from a template file or command line."""
-    if ctx.obj and ctx.obj.get('like'):
+    if ctx.obj and ctx.obj.get('like') and value is not None:
         ctx.obj['all_like'] = value
         value = ctx.obj.get('like')
     return value
@@ -43,8 +43,7 @@ def crs_handler(ctx, param, value):
             retval = json.loads(value)
         except ValueError:
             retval = value
-        if not (rasterio.crs.is_geographic_crs(retval) or
-                rasterio.crs.is_projected_crs(retval)):
+        if not rasterio.crs.is_valid_crs(retval):
             raise click.BadParameter(
                 "'%s' is not a recognized CRS." % retval,
                 param=param, param_hint='crs')

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -15,16 +15,81 @@ import rasterio.crs
 from rasterio.transform import guard_transform
 
 
+def like_dataset(ctx, param, value):
+    """Copy a dataset's meta property to the command context for access
+    from other callbacks."""
+    if ctx.obj is None:
+        ctx.obj = {}
+    if value:
+        with rasterio.open(value) as src:
+            metadata = src.meta
+            ctx.obj['like'] = metadata
+
+
+def nodata_handler(ctx, param, value):
+    """Get nodata value from a template file or command line."""
+    if ctx.obj and ctx.obj.get('like'):
+        value = ctx.obj.get('like')['nodata']
+    elif value:
+        value = float(value)
+    return value
+
+
+def transform_handler(ctx, param, value):
+    """Get transform value from a template file or command line."""
+    if ctx.obj and ctx.obj.get('like'):
+        value = ctx.obj.get('like')['affine']
+    elif value:
+        try:
+            value = json.loads(value)
+        except ValueError:
+            pass
+        try:
+            value = guard_transform(value)
+        except:
+            raise click.BadParameter(
+                "'%s' is not recognized as an Affine or GDAL "
+                "geotransform array." % value,
+                param=param, param_hint='transform')
+    return value
+
+
+def crs_handler(ctx, param, value):
+    """Get crs value from a template file or command line."""
+    if ctx.obj and ctx.obj.get('like'):
+        value = ctx.obj.get('like')['crs']
+    elif value:
+        try:
+            value = json.loads(value)
+        except ValueError:
+            pass
+        if not (rasterio.crs.is_geographic_crs(value) or
+                rasterio.crs.is_projected_crs(value)):
+            raise click.BadParameter(
+                "'%s' is not a recognized CRS." % value,
+                param=param, param_hint='crs')
+    return value
+
+
 @click.command('edit-info', short_help="Edit dataset metadata.")
 @options.file_in_arg
-@click.option('--nodata', type=float, default=None,
+@click.option('--nodata', callback=nodata_handler, default=None,
               help="New nodata value")
-@click.option('--crs', help="New coordinate reference system")
-@click.option('--transform', help="New affine transform matrix")
+@click.option('--crs', callback=crs_handler,
+              help="New coordinate reference system")
+@click.option('--transform', callback=transform_handler,
+              help="New affine transform matrix")
 @click.option('--tag', 'tags', multiple=True, metavar='KEY=VAL',
               help="New tag.")
+@click.option(
+    '--like',
+    type=click.Path(exists=True),
+    callback=like_dataset,
+    is_eager=True,
+    help="Raster dataset to use as a template for obtaining affine "
+         "transform (bounds and resolution), crs, and nodata values.")
 @click.pass_context
-def edit(ctx, input, nodata, crs, transform, tags):
+def edit(ctx, input, nodata, crs, transform, tags, like):
     """Edit a dataset's metadata: coordinate reference system, affine
     transformation matrix, nodata value, and tags.
 
@@ -51,58 +116,24 @@ def edit(ctx, input, nodata, crs, transform, tags):
         return rng.min <= value <= rng.max
 
     with rasterio.drivers(CPL_DEBUG=(verbosity > 2)) as env:
+
         with rasterio.open(input, 'r+') as dst:
 
-            # Update nodata.
-            if nodata is not None:
-
+            if nodata:
                 dtype = dst.dtypes[0]
                 if not in_dtype_range(nodata, dtype):
                     raise click.BadParameter(
                         "outside the range of the file's "
                         "data type (%s)." % dtype,
                         param=nodata, param_hint='nodata')
-
                 dst.nodata = nodata
 
-            # Update CRS. Value might be a PROJ.4 string or a JSON
-            # encoded dict.
             if crs:
-                new_crs = crs.strip()
-                try:
-                    new_crs = json.loads(crs)
-                except ValueError:
-                    pass
+                dst.crs = crs
 
-                if not (rasterio.crs.is_geographic_crs(new_crs) or 
-                        rasterio.crs.is_projected_crs(new_crs)):
-                    raise click.BadParameter(
-                        "'%s' is not a recognized CRS." % crs,
-                        param=crs, param_hint='crs')
-
-                dst.crs = new_crs
-
-            # Update transform. Value might be a JSON encoded
-            # Affine object or a GDAL geotransform array.
             if transform:
-                try:
-                    transform_obj = json.loads(transform)
-                except ValueError:
-                    raise click.BadParameter(
-                        "'%s' is not a JSON array." % transform,
-                        param=transform, param_hint='transform')
+                dst.transform = transform
 
-                try:
-                    transform_obj = guard_transform(transform_obj)
-                except:
-                    raise click.BadParameter(
-                        "'%s' is not recognized as an Affine or GDAL "
-                        "geotransform array." % transform,
-                        param=transform, param_hint='transform')
-
-                dst.transform = transform_obj
-
-            # Update tags.
             if tags:
                 tags = dict(p.split('=') for p in tags)
                 dst.update_tags(**tags)
@@ -169,7 +200,7 @@ def env(ctx, key):
 @options.masked_opt
 @click.pass_context
 def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
-        masked):
+         masked):
     """Print metadata about the dataset as JSON.
 
     Optionally print a single metadata item as a string.
@@ -213,8 +244,8 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
                     else:
                         click.echo(json.dumps(info, indent=indent))
                 elif aspect == 'tags':
-                    click.echo(json.dumps(src.tags(ns=namespace),
-                                            indent=indent))
+                    click.echo(
+                        json.dumps(src.tags(ns=namespace), indent=indent))
     except Exception:
         logger.exception("Exception caught during processing")
         raise click.Abort()
@@ -241,12 +272,12 @@ def insp(ctx, input, mode, interpreter):
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')
     try:
-        with rasterio.drivers(CPL_DEBUG=verbosity>2):
+        with rasterio.drivers(CPL_DEBUG=verbosity > 2):
             with rasterio.open(input, mode) as src:
                 rasterio.tool.main(
-                    "Rasterio %s Interactive Inspector (Python %s)\n"
+                    'Rasterio %s Interactive Inspector (Python %s)\n'
                     'Type "src.meta", "src.read_band(1)", or "help(src)" '
-                    'for more information.' %  (
+                    'for more information.' % (
                         rasterio.__version__,
                         '.'.join(map(str, sys.version_info[:3]))),
                     src, interpreter)
@@ -258,8 +289,10 @@ def insp(ctx, input, mode, interpreter):
 # Transform command.
 @click.command(short_help="Transform coordinates.")
 @click.argument('INPUT', default='-', required=False)
-@click.option('--src-crs', '--src_crs', default='EPSG:4326', help="Source CRS.")
-@click.option('--dst-crs', '--dst_crs', default='EPSG:4326', help="Destination CRS.")
+@click.option('--src-crs', '--src_crs', default='EPSG:4326',
+              help="Source CRS.")
+@click.option('--dst-crs', '--dst_crs', default='EPSG:4326',
+              help="Destination CRS.")
 @precision_opt
 @click.pass_context
 def transform(ctx, input, src_crs, dst_crs, precision):
@@ -275,7 +308,7 @@ def transform(ctx, input, src_crs, dst_crs, precision):
         src = [input]
 
     try:
-        with rasterio.drivers(CPL_DEBUG=verbosity>2):
+        with rasterio.drivers(CPL_DEBUG=verbosity > 2):
             if src_crs.startswith('EPSG'):
                 src_crs = {'init': src_crs}
             elif os.path.exists(src_crs):

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -183,7 +183,7 @@ def edit(ctx, input, nodata, crs, transform, tags, allmd, like):
                 transform = allmd['transform']
                 tags = allmd['tags']
 
-            if nodata:
+            if nodata is not None:
                 dtype = dst.dtypes[0]
                 if not in_dtype_range(nodata, dtype):
                     raise click.BadParameter(

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -5,9 +5,12 @@ import sys
 
 import rasterio
 from rasterio import crs
-from rasterio._base import is_geographic_crs, is_projected_crs, is_same_crs
+from rasterio.crs import (
+    is_geographic_crs, is_projected_crs, is_same_crs, is_valid_crs)
+
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
 
 # When possible, Rasterio gives you the CRS in the form of an EPSG code.
 def test_read_epsg(tmpdir):
@@ -118,3 +121,15 @@ def test_is_same_crs():
     lcc_crs1 = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     lcc_crs2 = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=45 +lat_0=0')
     assert is_same_crs(lcc_crs1, lcc_crs2) is False
+
+
+def test_to_string():
+    assert crs.to_string({'init': 'EPSG:4326'}) == "+init=EPSG:4326"
+
+
+def test_is_valid_false():
+    assert not is_valid_crs('EPSG:432600')
+
+
+def test_is_valid():
+    assert is_valid_crs('EPSG:4326')

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -224,6 +224,54 @@ def test_tags_callback(data):
 def test_edit_crs_like(data):
     runner = CliRunner()
 
+    # Set up the file to be edited.
+    inputfile = str(data.join('RGB.byte.tif'))
+    with rasterio.open(inputfile, 'r+') as dst:
+        dst.crs = {'init': 'epsg:32617'}
+        dst.nodata = 1.0
+
+    # Double check.
+    with rasterio.open(inputfile) as src:
+        assert src.crs == {'init': 'epsg:32617'}
+        assert src.nodata == 1.0
+
+    # The test.
+    templatefile = 'tests/data/RGB.byte.tif'
+    result = runner.invoke(info.edit, [
+        inputfile, '--like', templatefile, '--crs', 'like'])
+    assert result.exit_code == 0
+    with rasterio.open(inputfile) as src:
+        assert src.crs == {'init': 'epsg:32618'}
+        assert src.nodata == 1.0
+
+
+def test_edit_nodata_like(data):
+    runner = CliRunner()
+
+    # Set up the file to be edited.
+    inputfile = str(data.join('RGB.byte.tif'))
+    with rasterio.open(inputfile, 'r+') as dst:
+        dst.crs = {'init': 'epsg:32617'}
+        dst.nodata = 1.0
+
+    # Double check.
+    with rasterio.open(inputfile) as src:
+        assert src.crs == {'init': 'epsg:32617'}
+        assert src.nodata == 1.0
+
+    # The test.
+    templatefile = 'tests/data/RGB.byte.tif'
+    result = runner.invoke(info.edit, [
+        inputfile, '--like', templatefile, '--nodata', 'like'])
+    assert result.exit_code == 0
+    with rasterio.open(inputfile) as src:
+        assert src.crs == {'init': 'epsg:32617'}
+        assert src.nodata == 0.0
+
+
+def test_edit_all_like(data):
+    runner = CliRunner()
+
     inputfile = str(data.join('RGB.byte.tif'))
     with rasterio.open(inputfile, 'r+') as dst:
         dst.crs = {'init': 'epsg:32617'}
@@ -236,30 +284,11 @@ def test_edit_crs_like(data):
 
     templatefile = 'tests/data/RGB.byte.tif'
     result = runner.invoke(info.edit, [
-        inputfile, '--like', templatefile, '--crs', 'like'])
-    assert result.exit_code == 0
-    with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32618'}
-        assert src.nodata == 1.0
-
-
-def test_edit_all_like(data):
-    runner = CliRunner()
-
-    inputfile = str(data.join('RGB.byte.tif'))
-    with rasterio.open(inputfile, 'r+') as dst:
-        dst.crs = {'init': 'epsg:32617'}
-
-    # Double check.
-    with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32617'}
-
-    templatefile = 'tests/data/RGB.byte.tif'
-    result = runner.invoke(info.edit, [
         inputfile, '--like', templatefile, '--all'])
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
         assert src.crs == {'init': 'epsg:32618'}
+        assert src.nodata == 0.0
 
 
 def test_env():

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -133,10 +133,16 @@ def test_like_dataset_callback(data):
     assert ctx.obj['like']['crs'] == {'init': 'epsg:32618'}
 
 
+def test_all_callback_pass(data):
+    ctx = MockContext()
+    ctx.obj['like'] = {'transform': 'foo'}
+    assert info.all_handler(ctx, None, None) == None
+
+
 def test_all_callback(data):
     ctx = MockContext()
     ctx.obj['like'] = {'transform': 'foo'}
-    assert info.all_handler(ctx, None, None) == {'transform': 'foo'}
+    assert info.all_handler(ctx, None, True) == {'transform': 'foo'}
 
 
 def test_all_callback_None(data):

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -131,22 +131,43 @@ def test_like_dataset_callback(data):
     assert ctx.obj['like']['crs'] == {'init': 'epsg:32618'}
 
 
+def test_transform_callback_pass(data):
+    """Always return None if the value is None"""
+    ctx = MockContext()
+    ctx.obj['like'] = {'affine': 'foo'}
+    assert info.transform_handler(ctx, MockOption('transform'), None) is None
+
+
 def test_transform_callback(data):
     ctx = MockContext()
     ctx.obj['like'] = {'affine': 'foo'}
-    assert info.transform_handler(ctx, MockOption('transform'), None) == 'foo'
+    assert info.transform_handler(ctx, MockOption('transform'), '?') == 'foo'
+
+
+def test_nodata_callback_pass(data):
+    """Always return None if the value is None"""
+    ctx = MockContext()
+    ctx.obj['like'] = {'nodata': -1}
+    assert info.nodata_handler(ctx, MockOption('nodata'), None) is None
 
 
 def test_nodata_callback(data):
     ctx = MockContext()
     ctx.obj['like'] = {'nodata': -1}
-    assert info.nodata_handler(ctx, MockOption('nodata'), None) == -1
+    assert info.nodata_handler(ctx, MockOption('nodata'), '?') == -1
+
+
+def test_crs_callback_pass(data):
+    """Always return None if the value is None"""
+    ctx = MockContext()
+    ctx.obj['like'] = {'crs': 'foo'}
+    assert info.crs_handler(ctx, MockOption('crs'), None) is None
 
 
 def test_crs_callback(data):
     ctx = MockContext()
     ctx.obj['like'] = {'crs': 'foo'}
-    assert info.crs_handler(ctx, MockOption('crs'), None) == 'foo'
+    assert info.crs_handler(ctx, MockOption('crs'), '?') == 'foo'
 
 
 def test_edit_crs_like(data):
@@ -270,7 +291,8 @@ def test_mo_info():
 
 def test_info_stats():
     runner = CliRunner()
-    result = runner.invoke(info.info, ['tests/data/RGB.byte.tif', '--tell-me-more'])
+    result = runner.invoke(
+        info.info, ['tests/data/RGB.byte.tif', '--tell-me-more'])
     assert result.exit_code == 0
     assert '"max": 255.0' in result.output
     assert '"min": 1.0' in result.output
@@ -279,7 +301,8 @@ def test_info_stats():
 
 def test_info_stats_only():
     runner = CliRunner()
-    result = runner.invoke(info.info, ['tests/data/RGB.byte.tif', '--stats', '--bidx', '2'])
+    result = runner.invoke(
+        info.info, ['tests/data/RGB.byte.tif', '--stats', '--bidx', '2'])
     assert result.exit_code == 0
     assert result.output.startswith('1.000000 255.000000 66.02')
 
@@ -345,8 +368,8 @@ def test_transform_point_multi():
         '--precision', '2'
     ], "[-78.0, 23.0]\n[-78.0, 23.0]", catch_exceptions=False)
     assert result.exit_code == 0
-    assert result.output.strip() == '[192457.13, 2546667.68]\n[192457.13, 2546667.68]'
-
+    assert result.output.strip() == (
+        '[192457.13, 2546667.68]\n[192457.13, 2546667.68]')
 
 
 def test_bounds_defaults():
@@ -427,7 +450,8 @@ def test_bounds_obj_bbox_mercator():
         '--precision', '3'
     ])
     assert result.exit_code == 0
-    assert result.output.strip() == '[-8782900.033, 2700489.278, -8527010.472, 2943560.235]'
+    assert result.output.strip() == (
+        '[-8782900.033, 2700489.278, -8527010.472, 2943560.235]')
 
 
 def test_bounds_obj_bbox_projected():
@@ -440,7 +464,8 @@ def test_bounds_obj_bbox_projected():
         '--precision', '3'
     ])
     assert result.exit_code == 0
-    assert result.output.strip() == '[101985.0, 2611485.0, 339315.0, 2826915.0]'
+    assert result.output.strip() == (
+        '[101985.0, 2611485.0, 339315.0, 2826915.0]')
 
 
 def test_bounds_crs_bbox():
@@ -453,7 +478,8 @@ def test_bounds_crs_bbox():
         '--precision', '3'
     ])
     assert result.exit_code == 0
-    assert result.output.strip() == '[101985.0, 2611485.0, 339315.0, 2826915.0]'
+    assert result.output.strip() == (
+        '[101985.0, 2611485.0, 339315.0, 2826915.0]')
 
 
 def test_bounds_seq():
@@ -476,7 +502,8 @@ def test_bounds_seq():
         '--precision', '2'
     ])
     assert result.exit_code == 0
-    assert result.output == '[-78.9, 23.56, -76.6, 25.55]\n[-78.9, 23.56, -76.6, 25.55]\n'
+    assert result.output == (
+        '[-78.9, 23.56, -76.6, 25.55]\n[-78.9, 23.56, -76.6, 25.55]\n')
     assert '\x1e' not in result.output
 
 
@@ -492,7 +519,8 @@ def test_bounds_seq_rs():
         '--precision', '2'
     ])
     assert result.exit_code == 0
-    assert result.output == '\x1e[-78.9, 23.56, -76.6, 25.55]\n\x1e[-78.9, 23.56, -76.6, 25.55]\n'
+    assert result.output == (
+        '\x1e[-78.9, 23.56, -76.6, 25.55]\n\x1e[-78.9, 23.56, -76.6, 25.55]\n')
 
 
 def test_insp():


### PR DESCRIPTION
In combination with, eg, `--crs ?`, this will extract the metadata value from another file.

So far, it seems like a value will be required for the options. I think `?` makes a decent placeholder.

This PR also moves validation of the --crs, --transform, and --nodata options to callbacks, simplifying the command's function quite a bit.

Thoughts, @brendan-ward @jacquestardie @geowurster?

See #387.