### PR TITLE
Add creation options to CLI commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ band.  This new band is then written to a new single band TIFF.
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             b, g, r = src.read()
         
-        # Combine arrays in place. Expecting that the sum will 
+        # Combine arrays in place. Expecting that the sum will
         # temporarily exceed the 8-bit integer range, initialize it as
         # 16-bit. Adding other arrays to it in-place converts those
         # arrays "up" and preserves the type of the total array.
@@ -50,17 +50,17 @@ band.  This new band is then written to a new single band TIFF.
         total /= 3
 
         # Write the product as a raster band to a new 8-bit file. For
-        # keyword arguments, we start with the meta attributes of the
-        # source file, but then change the band count to 1, set the
+        # the new file's profile, we start with the meta attributes of
+        # the source file, but then change the band count to 1, set the
         # dtype to uint8, and specify LZW compression.
 
-        kwargs = src.meta
-        kwargs.update(
+        profile = src.meta
+        profile.update(
             dtype=rasterio.uint8,
             count=1,
             compress='lzw')
         
-        with rasterio.open('example-total.tif', 'w', **kwargs) as dst:
+        with rasterio.open('example-total.tif', 'w', **profile) as dst:
             dst.write_band(1, total.astype(rasterio.uint8))
 
     # At the end of the ``with rasterio.drivers()`` block, context

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -417,9 +417,7 @@ cdef class DatasetReader(object):
             'crs': self.crs,
             'transform': self.affine.to_gdal(),
             'affine': self.affine,
-            'blockxsize': self.block_shapes[0][1],
-            'blockysize': self.block_shapes[0][0],
-            'tiled': self.block_shapes[0][1] != self.width }
+        }
         self._read = True
         return m
 

--- a/rasterio/rio/bands.py
+++ b/rasterio/rio/bands.py
@@ -29,8 +29,9 @@ PHOTOMETRIC_CHOICES = [val.lower() for val in [
 @click.option('--photometric', default=None,
               type=click.Choice(PHOTOMETRIC_CHOICES),
               help="Photometric interpretation")
+@options.creation_options
 @click.pass_context
-def stack(ctx, files, output, driver, bidx, photometric):
+def stack(ctx, files, output, driver, bidx, photometric, creation_options):
     """Stack a number of bands from one or more input files into a
     multiband dataset.
 
@@ -95,6 +96,7 @@ def stack(ctx, files, output, driver, bidx, photometric):
 
             with rasterio.open(files[0]) as first:
                 kwargs = first.meta
+                kwargs.update(**creation_options)
                 kwargs['transform'] = kwargs.pop('affine')
 
             kwargs.update(

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -40,8 +40,9 @@ def read_array(ix, subix=None, dtype=None):
                    '"a=tests/data/RGB.byte.tif".')
 @options.dtype_opt
 @options.masked_opt
+@options.creation_options
 @click.pass_context
-def calc(ctx, command, files, output, name, dtype, masked):
+def calc(ctx, command, files, output, name, dtype, masked, creation_options):
     """A raster data calculator
 
     Evaluates an expression using input datasets and writes the result
@@ -95,6 +96,7 @@ def calc(ctx, command, files, output, name, dtype, masked):
 
             with rasterio.open(inputs[0][1]) as first:
                 kwargs = first.meta
+                kwargs.update(**creation_options)
                 kwargs['transform'] = kwargs.pop('affine')
                 dtype = dtype or first.meta['dtype']
                 kwargs['dtype'] = dtype

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -24,8 +24,9 @@ from rasterio.transform import Affine
               help="Output dataset resolution: pixel width, pixel height")
 @click.option('--nodata', type=float, default=None,
               help="Override nodata values defined in input datasets")
+@options.creation_options
 @click.pass_context
-def merge(ctx, files, output, driver, bounds, res, nodata):
+def merge(ctx, files, output, driver, bounds, res, nodata, creation_options):
     """Copy valid pixels from input files to an output file.
 
     All files must have the same number of bands, data type, and
@@ -51,6 +52,7 @@ def merge(ctx, files, output, driver, bounds, res, nodata):
             with rasterio.open(files[0]) as first:
                 first_res = first.res
                 kwargs = first.meta
+                kwargs.update(**creation_options)
                 kwargs.pop('affine')
                 nodataval = first.nodatavals[0]
                 dtype = first.dtypes[0]
@@ -87,7 +89,7 @@ def merge(ctx, files, output, driver, bounds, res, nodata):
                 output_width = int(math.ceil((bounds[2]-bounds[0])/res[0]))
                 output_height = int(math.ceil((bounds[3]-bounds[1])/res[1]))
 
-                kwargs['driver'] == driver
+                kwargs['driver'] = driver
                 kwargs['transform'] = output_transform
                 kwargs['width'] = output_width
                 kwargs['height'] = output_height

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -49,6 +49,35 @@ Registry of common rio CLI options.  See cligj for more options.
 import click
 
 
+def _cb_key_val(ctx, param, value):
+
+    """
+    click callback to validate `--opt KEY1=VAL1 --opt KEY2=VAL2` and collect
+    in a dictionary like the one below, which is what the CLI function receives.
+    If no value or `None` is received then an empty dictionary is returned.
+
+        {
+            'KEY1': 'VAL1',
+            'KEY2': 'VAL2'
+        }
+
+    Note: `==VAL` breaks this as `str.split('=', 1)` is used.
+    """
+
+    if not value:
+        return {}
+    else:
+        out = {}
+        for pair in value:
+            if '=' not in pair:
+                raise click.BadParameter("Invalid syntax for KEY=VAL arg: {}".format(pair))
+            else:
+                k, v = pair.split('=', 1)
+                out[k] = v
+
+        return out
+
+
 # Singular input file
 file_in_arg = click.argument(
     'INPUT',
@@ -112,3 +141,10 @@ resolution_opt = click.option(
          'reference system. Pixels assumed to be square if this option '
          'is used once, otherwise use: '
          '--res pixel_width --res pixel_height')
+
+
+creation_options = click.option(
+    '--co', 'creation_options', metavar='NAME=VALUE', multiple=True, callback=_cb_key_val,
+    help="Driver specific creation options.  See the documentation for the selected output "
+         "driver for more information."
+)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,26 +3,23 @@
 import rasterio
 
 
-def test_blocksize_rgb(tmpdir):
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        kwds = src.meta
-        assert kwds['blockxsize'] == 791
-        assert kwds['blockysize'] == 3
-        assert kwds['tiled'] is False
-
-def test_blocksize_shade(tmpdir):
-    with rasterio.open('tests/data/shade.tif') as src:
-        kwds = src.meta
-        assert kwds['blockxsize'] == 1024
-        assert kwds['blockysize'] == 8
-        assert kwds['tiled'] is False
-
 def test_copy_meta(tmpdir):
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         kwds = src.meta
     with rasterio.open(
             str(tmpdir.join('test_copy_meta.tif')), 'w', **kwds) as dst:
         assert dst.meta['count'] == 3
-        assert dst.meta['blockxsize'] == 791
-        assert dst.meta['blockysize'] == 3
-        assert dst.meta['tiled'] is False
+
+
+def test_blacklisted_keys(tmpdir):
+    # Some keys were removed from .meta when they were found to clash with
+    # creation options.
+    # https://github.com/mapbox/rasterio/issues/402
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        kwds = src.meta
+    with rasterio.open(
+            str(tmpdir.join('test_copy_meta.tif')), 'w', **kwds) as dst:
+        keys = map(lambda x: x.lower(), dst.meta.keys())
+        assert 'blockxsize' not in keys
+        assert 'blockysize' not in keys
+        assert 'tiled' not in keys

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,20 @@
+import click
+import pytest
+from rasterio.rio import options
+
+
+def test_cb_key_val():
+
+    pairs = ['KEY=val', '1==']
+    expected = {
+        'KEY': 'val',
+        '1': '=',
+    }
+    assert options._cb_key_val(None, None, pairs) == expected
+
+    # Make sure None or an empty list returns an empty dict
+    assert options._cb_key_val(None, None, None) == {}
+    assert options._cb_key_val(None, None, ()) == {}
+
+    with pytest.raises(click.BadParameter):
+        options._cb_key_val(None, None, 'bad_val')


### PR DESCRIPTION
Closes #379.

@sgillies have a look at #402 before merging.  The bug fix in #401 is also included in this PR so once that is merged I'll pull it back into here to make sure it doesn't cause a conflict.

The `--photometric` flag in `rio stack` could be deprecated in favor of `--co PHOTOMETRIC=...` but I'm guessing its pretty deeply integrated into some pipelines.