### PR TITLE
Initial implementation of rio-warp

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -488,7 +488,13 @@ Or provide output bounds (in source crs) and resolution:
 
 .. code-block:: console
 
-    $ rio warp input.tif output.tif --dst-crs EPSG:4326 --bounds -78 22 -76 24 --res 0.1
+    $ rio warp input.tif output.tif --dst-crs EPSG:4326 --bounds -78 22 -76 24 --res 0.1 0.1
+
+Other options are available, see:
+
+.. code-block:: console
+
+    $ rio warp --help
 
 
 Suggestions for other commands are welcome!

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -326,7 +326,7 @@ raster.
 The resulting file will have an upper left coordinate determined by the bounds
 of the GeoJSON (in EPSG:4326, which is the default), with a
 pixel size of approximately 30 arc seconds.  Pixels whose center is within the
-polygon or that are selected by brezenhams line algorithm will be burned in
+polygon or that are selected by Bresenham's line algorithm will be burned in
 with a default value of 1.
 
 It is possible to rasterize into an existing raster and use an alternative
@@ -448,5 +448,47 @@ a raster dataset, do the following.
 
     $ echo "[-78.0, 23.0, -76.0, 25.0]" | rio transform - --dst-crs tests/data/RGB.byte.tif --precision 2
     [192457.13, 2546667.68, 399086.97, 2765319.94]
+
+
+warp
+----
+
+New in 0.25
+
+The warp command warps (reprojects) a raster based on parameters that can be
+obtained from a template raster, or input directly.  The output is always
+overwritten.
+
+
+To copy coordinate reference system, transform, and dimensions from a template
+raster, do the following:
+
+.. code-block:: console
+
+    $ rio warp input.tif output.tif --like template.tif
+
+You can specify an output coordinate system using a PROJ.4 or EPSG:nnnn string,
+or a JSON text-encoded PROJ.4 object:
+
+.. code-block:: console
+
+    $ rio warp input.tif output.tif --dst-crs EPSG:4326
+
+    $ rio warp input.tif output.tif --dst-crs '+proj=longlat +ellps=WGS84 +datum=WGS84'
+
+You can also specify dimensions, which will automatically calculate appropriate
+resolution based on the relationship between the bounds in the target crs and
+these dimensions:
+
+.. code-block:: console
+
+    $ rio warp input.tif output.tif --dst-crs EPSG:4326 --dimensions 100 200
+
+Or provide output bounds (in source crs) and resolution:
+
+.. code-block:: console
+
+    $ rio warp input.tif output.tif --dst-crs EPSG:4326 --bounds -78 22 -76 24 --res 0.1
+
 
 Suggestions for other commands are welcome!

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -488,7 +488,7 @@ Or provide output bounds (in source crs) and resolution:
 
 .. code-block:: console
 
-    $ rio warp input.tif output.tif --dst-crs EPSG:4326 --bounds -78 22 -76 24 --res 0.1 0.1
+    $ rio warp input.tif output.tif --dst-crs EPSG:4326 --bounds -78 22 -76 24 --res 0.1
 
 Other options are available, see:
 

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -10,6 +10,7 @@
 #   {'proj': 'longlat', 'ellps': 'WGS84', 'datum': 'WGS84', 'no_defs': True}
 #
 
+import json
 from rasterio._base import is_geographic_crs, is_projected_crs, is_same_crs
 from rasterio.five import string_types
 

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -44,7 +44,13 @@ def from_string(prjs):
 
     Bare parameters like "+no_defs" are given a value of ``True``. All keys
     are checked against the ``all_proj_keys`` list.
+
+    EPSG:XXXX is also allowed.
     """
+
+    if 'EPSG:' in prjs.upper():
+        return from_epsg(prjs.split(':')[1])
+
     parts = [o.lstrip('+') for o in prjs.strip().split()]
 
     def parse(v):

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -45,8 +45,17 @@ def from_string(prjs):
     Bare parameters like "+no_defs" are given a value of ``True``. All keys
     are checked against the ``all_proj_keys`` list.
 
-    EPSG:XXXX is also allowed.
+    EPSG:nnnn is allowed.
+
+    JSON text-encoded strings are allowed.
     """
+
+    if '{' in prjs:
+        # may be json, try to decode it
+        try:
+            return json.loads(prjs, strict=False)
+        except ValueError:
+            raise ValueError('crs appears to be JSON but is not valid')
 
     if 'EPSG:' in prjs.upper():
         return from_epsg(prjs.split(':')[1])

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -551,6 +551,9 @@ def rasterize(
                             'pixel dimensions are required',
                             ctx, param=res, param_hint='--res')
 
+                    elif len(res) == 1:
+                        res = (res[0], res[0])
+
                     width = max(int(ceil((bounds[2] - bounds[0]) /
                                 float(res[0]))), 1)
                     height = max(int(ceil((bounds[3] - bounds[1]) /

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -363,8 +363,7 @@ def shapes(
 @format_opt
 @options.like_file_opt
 @options.bounds_opt
-@click.option('--dimensions', nargs=2, type=int, default=None,
-              help='Output dataset width, height in number of pixels.')
+@options.dimensions_opt
 @options.resolution_opt
 @click.option('--src-crs', '--src_crs', 'src_crs', default=None,
               help='Source coordinate reference system.  Limited to EPSG '

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -550,8 +550,6 @@ def rasterize(
                         raise click.BadParameter(
                             'pixel dimensions are required',
                             ctx, param=res, param_hint='--res')
-                    elif len(res) == 1:
-                        res = (res[0], res[0])
 
                     width = max(int(ceil((bounds[2] - bounds[0]) /
                                 float(res[0]))), 1)

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -38,11 +38,18 @@ def merge(ctx, files, output, driver, bounds, res, nodata, creation_options):
     Geospatial bounds and resolution of a new output file in the
     units of the input file coordinate reference system may be provided
     and are otherwise taken from the first input file.
+
+    Note: --res changed from 2 parameters in 0.25.
+      --res 0.1 0.1  => --res 0.1 (square)
+      --res 0.1 0.2  => --res 0.1 --res 0.2  (rectangular)
     """
     import numpy as np
 
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
     logger = logging.getLogger('rio')
+
+    if len(res) == 1:
+        res = (res[0], res[0])
 
     try:
         with rasterio.drivers(CPL_DEBUG=verbosity>2):

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -20,8 +20,7 @@ from rasterio.transform import Affine
 @options.output_opt
 @format_opt
 @options.bounds_opt
-@click.option('-r', '--res', nargs=2, type=float, default=None,
-              help="Output dataset resolution: pixel width, pixel height")
+@options.resolution_opt
 @click.option('--nodata', type=float, default=None,
               help="Override nodata values defined in input datasets")
 @options.creation_options

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -138,18 +138,18 @@ output_opt = click.option(
     help="Path to output file (optional alternative to a positional arg "
          "for some commands).")
 
-
 resolution_opt = click.option(
     '-r', '--res',
-    multiple=True, type=float, default=None,
-    help='Output dataset resolution in units of coordinate '
-         'reference system. Pixels assumed to be square if this option '
-         'is used once, otherwise use: '
-         '--res pixel_width --res pixel_height')
-
+    nargs=2,
+    type=float,
+    default=None,
+    help="Output dataset resolution: pixel width, pixel height")
 
 creation_options = click.option(
-    '--co', 'creation_options', metavar='NAME=VALUE', multiple=True, callback=_cb_key_val,
-    help="Driver specific creation options.  See the documentation for the selected output "
-         "driver for more information."
-)
+    '--co', 'creation_options',
+    metavar='NAME=VALUE',
+    multiple=True,
+    callback=_cb_key_val,
+    help="Driver specific creation options."
+         "See the documentation for the selected output driver for "
+         "more information.")

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -105,6 +105,11 @@ bounds_opt = click.option(
     nargs=4, type=float, default=None,
     help='Output bounds: left, bottom, right, top.')
 
+dimensions_opt = click.option(
+    '--dimensions',
+    nargs=2, type=int, default=None,
+    help='Output dataset width, height in number of pixels.')
+
 dtype_opt = click.option(
     '-t', '--dtype',
     type=click.Choice([

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -140,10 +140,11 @@ output_opt = click.option(
 
 resolution_opt = click.option(
     '-r', '--res',
-    nargs=2,
-    type=float,
-    default=None,
-    help="Output dataset resolution: pixel width, pixel height")
+    multiple=True, type=float, default=None,
+    help='Output dataset resolution in units of coordinate '
+         'reference system. Pixels assumed to be square if this option '
+         'is used once, otherwise use: '
+         '--res pixel_width --res pixel_height')
 
 creation_options = click.option(
     '--co', 'creation_options',

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -103,7 +103,7 @@ bidx_mult_opt = click.option(
 bounds_opt = click.option(
     '--bounds',
     nargs=4, type=float, default=None,
-    help='Output bounds: left, bottom, right, top.')
+    help='Output bounds: left bottom right top.')
 
 dimensions_opt = click.option(
     '--dimensions',

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -76,7 +76,7 @@ def warp(
     coordinate reference system.
 
       rio warp input.tif output.tif --bounds -78 22 -76 24 --dst-crs EPSG:4326
-        --res 0.1
+        --res 0.1 0.1
     """
 
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
@@ -85,9 +85,6 @@ def warp(
     if not len(res):
         # Click sets this as an empty tuple if not provided
         res = None
-    else:
-        # Expand one value to two if needed
-        res = (res[0], res[0]) if len(res) == 1 else res
 
     with rasterio.drivers(CPL_DEBUG=verbosity > 2):
         with rasterio.open(input) as src:

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -1,0 +1,176 @@
+import logging
+from math import ceil
+import click
+from cligj import format_opt
+
+from . import options
+import rasterio
+from rasterio import crs
+from rasterio.transform import Affine
+from rasterio.warp import (reproject, RESAMPLING, calculate_default_transform,
+   transform_bounds)
+
+
+logger = logging.getLogger('rio')
+
+
+@click.command(short_help='Warp a raster dataset.')
+@options.file_in_arg
+@options.file_out_arg
+@format_opt
+@options.like_file_opt
+@click.option('--dst-crs', default=None,
+              help='Target coordinate reference system.  Default: EPSG:4326')
+@options.dimensions_opt
+@options.bounds_opt
+#TODO: flag for bounds in target
+@options.resolution_opt
+@click.option('--resampling', type=click.Choice(['nearest', 'bilinear', 'cubic',
+                'cubic_spline','lanczos', 'average', 'mode']),
+              default='nearest', help='Resampling method')
+@click.option('--threads', type=int, default=1,
+              help='Number of processing threads.')
+@click.pass_context
+def warp(
+        ctx,
+        input,
+        output,
+        driver,
+        like,
+        dst_crs,
+        dimensions,
+        bounds,
+        res,
+        resampling,
+        threads):
+    """
+    Warp a raster dataset.
+
+    The output is always overwritten.
+
+    If a template raster is provided using the --like option, the coordinate
+    reference system, affine transform, and dimensions of that raster will
+    be used for the output.  In this case --dst-crs, --bounds, --res, and
+    --dimensions options are ignored.
+
+    If --dimensions are provided, --res and --bounds are ignored.  Resolution
+    is calculated based on the relationship between the source raster bounds
+    and dimensions, and may produce rectangular rather than square pixels.
+
+    If --bounds are provided, --res is required if --dst-crs is provided
+    (defaults to source raster resolution otherwise).  Bounds are in the source
+    coordinate reference system.
+    """
+
+    verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
+    resampling = getattr(RESAMPLING, resampling)  # get integer code for method
+
+    if not len(res):
+        # Click sets this as an empty tuple if not provided
+        res = None
+    else:
+        # Expand one value to two if needed
+        res = (res[0], res[0]) if len(res) == 1 else res
+
+    with rasterio.drivers(CPL_DEBUG=verbosity > 2):
+        with rasterio.open(input) as src:
+            l, b, r, t = src.bounds
+            out_kwargs = src.meta.copy()
+            out_kwargs['driver'] = driver
+
+            if like:
+                with rasterio.open(like) as template_ds:
+                    dst_crs = template_ds.crs
+                    dst_transform = template_ds.affine
+                    dst_height = template_ds.height
+                    dst_width = template_ds.width
+
+            elif dst_crs:
+                if dimensions:
+                    # Calculate resolution appropriate for dimensions in target
+                    dst_width, dst_height = dimensions
+                    xmin, ymin, xmax, ymax = transform_bounds(src.crs, dst_crs,
+                                                              *src.bounds)
+                    dst_transform = Affine(
+                        (xmax - xmin) / float(dst_width),
+                        0, xmin, 0,
+                        (ymin - ymax) / float(dst_height),
+                        ymax
+                    )
+
+                elif bounds:
+                    if not res:
+                        raise click.BadParameter('Required when using --bounds',
+                            param='res', param_hint='res')
+
+                    xmin, ymin, xmax, ymax = transform_bounds(src.crs, dst_crs,
+                                                              *bounds)
+                    dst_transform = Affine(res[0], 0, xmin, 0, -res[1], ymax)
+                    dst_width = max(int(ceil((xmax - xmin) / res[0])), 1)
+                    dst_height = max(int(ceil((ymax - ymin) / res[1])), 1)
+
+                else:
+                    dst_crs = crs.from_string(dst_crs)
+                    dst_transform, dst_width, dst_height = calculate_default_transform(
+                        src.crs, dst_crs, src.width, src.height, *src.bounds,
+                        resolution=res)
+
+            elif dimensions:
+                # Same projection, different dimensions, calculate resolution
+                dst_crs = src.crs
+                dst_width, dst_height = dimensions
+                dst_transform = Affine(
+                    (r - l) / float(dst_width),
+                    0, l, 0,
+                    (b - t) / float(dst_height),
+                    t
+                )
+
+            elif bounds:
+                # Same projection, different dimensions and possibly different
+                # resolution
+                if not res:
+                    res = (src.affine.a, -src.affine.e)
+
+                dst_crs = src.crs
+                xmin, ymin, xmax, ymax = bounds
+                dst_transform = Affine(res[0], 0, xmin, 0, -res[1], ymax)
+                dst_width = max(int(ceil((xmax - xmin) / res[0])), 1)
+                dst_height = max(int(ceil((ymax - ymin) / res[1])), 1)
+
+            elif res:
+                # Same projection, different resolution
+                dst_crs = src.crs
+                dst_transform = Affine(res[0], 0, l, 0, -res[1], t)
+                dst_width = max(int(ceil((r - l) / res[0])), 1)
+                dst_height = max(int(ceil((t - b) / res[1])), 1)
+
+            else:
+                dst_crs = src.crs
+                dst_transform = src.affine
+                dst_width = src.width
+                dst_height = src.height
+
+            out_kwargs.update({
+                'crs': dst_crs,
+                'transform': dst_transform,
+                'affine': dst_transform,
+                'width': dst_width,
+                'height': dst_height
+            })
+
+            with rasterio.open(output, 'w', **out_kwargs) as dst:
+                for i in range(1, src.count + 1):
+                    click.echo('Warping band {0}...'.format(i))
+
+                    reproject(
+                        source=rasterio.band(src, i),
+                        destination=rasterio.band(dst, i),
+                        src_transform=src.affine,
+                        src_crs=src.crs,
+                        # src_nodata=#TODO
+                        dst_transform=out_kwargs['transform'],
+                        dst_crs=out_kwargs['crs'],
+                        # dst_nodata=#TODO
+                        resampling=resampling,
+                        num_threads=threads)

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -23,7 +23,6 @@ logger = logging.getLogger('rio')
               help='Target coordinate reference system.  Default: EPSG:4326')
 @options.dimensions_opt
 @options.bounds_opt
-#TODO: flag for bounds in target
 @options.resolution_opt
 @click.option('--resampling', type=click.Choice(['nearest', 'bilinear', 'cubic',
                 'cubic_spline','lanczos', 'average', 'mode']),
@@ -76,7 +75,7 @@ def warp(
     coordinate reference system.
 
       rio warp input.tif output.tif --bounds -78 22 -76 24 --dst-crs EPSG:4326
-        --res 0.1 0.1
+        --res 0.1
     """
 
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
@@ -85,6 +84,9 @@ def warp(
     if not len(res):
         # Click sets this as an empty tuple if not provided
         res = None
+    else:
+        # Expand one value to two if needed
+        res = (res[0], res[0]) if len(res) == 1 else res
 
     with rasterio.drivers(CPL_DEBUG=verbosity > 2):
         with rasterio.open(input) as src:

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -262,6 +262,10 @@ def calculate_default_transform(
         Example: {'init': 'EPSG:4326'}
     dst_crs: dict
         Target coordinate reference system.
+    width: int
+        Source raster width.
+    height: int
+        Source raster height.
     left, bottom, right, top: float
         Bounding coordinates in src_crs, from the bounds property of a raster.
     resolution: tuple (x resolution, y resolution) or float, optional

--- a/setup.py
+++ b/setup.py
@@ -244,6 +244,7 @@ setup_args = dict(
         sample=rasterio.rio.sample:sample
         shapes=rasterio.rio.features:shapes
         stack=rasterio.rio.bands:stack
+        warp=rasterio.rio.warp:warp
         transform=rasterio.rio.info:transform
     ''',
     include_package_data=True,

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 import subprocess
 import sys
+import json
 
 import rasterio
 from rasterio import crs
@@ -60,6 +61,16 @@ def test_write_3857(tmpdir):
     AUTHORITY["EPSG","3857"]]""" in info.decode('utf-8')
 
 
+def test_from_proj4_json():
+    json_str = '{"proj": "longlat", "ellps": "WGS84", "datum": "WGS84"}'
+    crs_dict = crs.from_string(json_str)
+    assert crs_dict == json.loads(json_str)
+
+    # Test with invalid JSON code
+    with pytest.raises(ValueError):
+        assert crs.from_string('{foo: bar}')
+
+
 def test_from_epsg():
     crs_dict = crs.from_epsg(4326)
     assert crs_dict['init'].lower() == 'epsg:4326'
@@ -67,6 +78,15 @@ def test_from_epsg():
     # Test with invalid EPSG code
     with pytest.raises(ValueError):
         assert crs.from_epsg(0)
+
+
+def test_from_epsg_string():
+    crs_dict = crs.from_string('epsg:4326')
+    assert crs_dict['init'].lower() == 'epsg:4326'
+
+    # Test with invalid EPSG code
+    with pytest.raises(ValueError):
+        assert crs.from_string('epsg:xyz')
 
 
 def test_bare_parameters():

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -365,13 +365,13 @@ def test_rasterize_err(tmpdir, runner):
     assert result.exit_code == 2
 
     # Test invalid CRS for bounds
-    result = runner.invoke(features.rasterize, [output, '--res', 1],
+    result = runner.invoke(features.rasterize, [output, '--res', 1, 1],
                            input=TEST_MERC_FEATURECOLLECTION)
     assert result.exit_code == 2
 
     # Test invalid CRS value
     result = runner.invoke(features.rasterize, [output,
-                                                '--res', 1,
+                                                '--res', 1, 1,
                                                 '--src-crs', 'BOGUS'],
                            input=TEST_MERC_FEATURECOLLECTION)
     assert result.exit_code == 2
@@ -413,7 +413,7 @@ def test_rasterize(tmpdir, runner):
     # Test resolution
     output = str(tmpdir.join('test3.tif'))
     result = runner.invoke(features.rasterize,
-                           [output, '--res', 0.5], input=TEST_FEATURES)
+                           [output, '--res', 0.5, 0.5], input=TEST_FEATURES)
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
@@ -440,7 +440,7 @@ def test_rasterize(tmpdir, runner):
 def test_rasterize_existing_output(tmpdir, runner):
     output = str(tmpdir.join('test.tif'))
     result = runner.invoke(features.rasterize,
-                           [output, '--res', 0.5], input=TEST_FEATURES)
+                           [output, '--res', 0.5, 0.5], input=TEST_FEATURES)
     assert result.exit_code == 0
     assert os.path.exists(output)
 
@@ -473,7 +473,7 @@ def test_rasterize_existing_output(tmpdir, runner):
     # Confirm that a different src-crs is rejected, even if a geographic crs
     result = runner.invoke(features.rasterize,
                            [output,
-                            '--res', 0.5,
+                            '--res', 0.5, 0.5,
                             '--src-crs', 'EPSG:4269'
                             ], input=TEST_FEATURES)
     assert result.exit_code == 2
@@ -513,7 +513,7 @@ def test_rasterize_property_value(tmpdir, runner):
     output = str(tmpdir.join('test.tif'))
     result = runner.invoke(features.rasterize,
                            [output,
-                            '--res', 1000,
+                            '--res', 1000, 1000,
                             '--property', 'val',
                             '--src-crs', 'EPSG:3857'
                            ],
@@ -530,7 +530,7 @@ def test_rasterize_property_value(tmpdir, runner):
     # Test feature property values
     output = str(tmpdir.join('test2.tif'))
     result = runner.invoke(features.rasterize,
-                           [output, '--res', 0.5, '--property', 'val'],
+                           [output, '--res', 0.5, 0.5, '--property', 'val'],
                            input=TEST_FEATURES)
     assert result.exit_code == 0
     assert os.path.exists(output)

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -365,13 +365,13 @@ def test_rasterize_err(tmpdir, runner):
     assert result.exit_code == 2
 
     # Test invalid CRS for bounds
-    result = runner.invoke(features.rasterize, [output, '--res', 1, 1],
+    result = runner.invoke(features.rasterize, [output, '--res', 1],
                            input=TEST_MERC_FEATURECOLLECTION)
     assert result.exit_code == 2
 
     # Test invalid CRS value
     result = runner.invoke(features.rasterize, [output,
-                                                '--res', 1, 1,
+                                                '--res', 1,
                                                 '--src-crs', 'BOGUS'],
                            input=TEST_MERC_FEATURECOLLECTION)
     assert result.exit_code == 2
@@ -413,7 +413,7 @@ def test_rasterize(tmpdir, runner):
     # Test resolution
     output = str(tmpdir.join('test3.tif'))
     result = runner.invoke(features.rasterize,
-                           [output, '--res', 0.5, 0.5], input=TEST_FEATURES)
+                           [output, '--res', 0.5], input=TEST_FEATURES)
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
@@ -440,7 +440,7 @@ def test_rasterize(tmpdir, runner):
 def test_rasterize_existing_output(tmpdir, runner):
     output = str(tmpdir.join('test.tif'))
     result = runner.invoke(features.rasterize,
-                           [output, '--res', 0.5, 0.5], input=TEST_FEATURES)
+                           [output, '--res', 0.5], input=TEST_FEATURES)
     assert result.exit_code == 0
     assert os.path.exists(output)
 
@@ -473,7 +473,7 @@ def test_rasterize_existing_output(tmpdir, runner):
     # Confirm that a different src-crs is rejected, even if a geographic crs
     result = runner.invoke(features.rasterize,
                            [output,
-                            '--res', 0.5, 0.5,
+                            '--res', 0.5,
                             '--src-crs', 'EPSG:4269'
                             ], input=TEST_FEATURES)
     assert result.exit_code == 2
@@ -513,7 +513,7 @@ def test_rasterize_property_value(tmpdir, runner):
     output = str(tmpdir.join('test.tif'))
     result = runner.invoke(features.rasterize,
                            [output,
-                            '--res', 1000, 1000,
+                            '--res', 1000,
                             '--property', 'val',
                             '--src-crs', 'EPSG:3857'
                            ],
@@ -530,7 +530,7 @@ def test_rasterize_property_value(tmpdir, runner):
     # Test feature property values
     output = str(tmpdir.join('test2.tif'))
     result = runner.invoke(features.rasterize,
-                           [output, '--res', 0.5, 0.5, '--property', 'val'],
+                           [output, '--res', 0.5, '--property', 'val'],
                            input=TEST_FEATURES)
     assert result.exit_code == 0
     assert os.path.exists(output)

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -329,3 +329,23 @@ def test_merge_tiny_output_opt(tiffs):
         assert (data[0][0:2,3] == 90).all()
         assert data[0][2][1] == 60
         assert data[0][3][0] == 40
+
+
+def test_merge_tiny_res(tiffs):
+    outputname = str(tiffs.join('merged.tif'))
+    inputs = [str(x) for x in tiffs.listdir()]
+    inputs.sort()
+    runner = CliRunner()
+    result = runner.invoke(merge, inputs + [outputname, '--res', 2])
+    assert result.exit_code == 0
+
+    # Output should be
+    # [[[120  90]
+    #   [  0   0]]]
+
+    with rasterio.open(outputname) as src:
+        data = src.read()
+        print(data)
+        assert data[0, 0, 0] == 120
+        assert data[0, 0, 1] == 90
+        assert (data[0, 1, 0:1] == 0).all()

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -1,0 +1,229 @@
+import logging
+import os
+import re
+import sys
+import numpy
+
+import rasterio
+from rasterio.rio import warp
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+def test_warp_no_reproject(runner, tmpdir):
+    """ When called without parameters, output should be same as source """
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.count == src.count
+            assert output.crs == src.crs
+            assert output.nodata == src.nodata
+            assert numpy.allclose(output.bounds, src.bounds)
+            assert output.affine.almost_equals(src.affine)
+            assert numpy.allclose(output.read(1), src.read(1))
+
+
+def test_warp_no_reproject_dimensions(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dimensions', '100', '100'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.crs == src.crs
+            assert output.width == 100
+            assert output.height == 100
+            assert numpy.allclose([97.839396, 97.839396],
+                                  [output.affine.a, -output.affine.e])
+
+
+def test_warp_no_reproject_res(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--res', '30'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.crs == src.crs
+            assert numpy.allclose([30, 30], [output.affine.a, -output.affine.e])
+            assert output.width == 327
+            assert output.height == 327
+
+
+def test_warp_no_reproject_bounds(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    out_bounds = [-11850000, 4810000, -11849000, 4812000]
+    result = runner.invoke(warp.warp,[srcname, outputname,
+                                      '--bounds'] + out_bounds)
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.crs == src.crs
+            assert numpy.allclose(output.bounds, out_bounds)
+            assert numpy.allclose([src.affine.a, src.affine.e],
+                                  [output.affine.a, output.affine.e])
+            assert output.width == 105
+            assert output.height == 210
+
+
+def test_warp_no_reproject_bounds_res(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    out_bounds = [-11850000, 4810000, -11849000, 4812000]
+    result = runner.invoke(warp.warp,[srcname, outputname,
+                                      '--res', 30, '--bounds', ] + out_bounds)
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.crs == src.crs
+            assert numpy.allclose(output.bounds, out_bounds)
+            assert numpy.allclose([30, 30], [output.affine.a, -output.affine.e])
+            assert output.width == 34
+            assert output.height == 67
+
+
+def test_warp_reproject_dst_crs(runner, tmpdir):
+    srcname = 'tests/data/RGB.byte.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dst-crs', 'EPSG:4326'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.count == src.count
+            assert output.crs == {'init': 'epsg:4326'}
+            assert output.width == 824
+            assert output.height == 686
+            assert numpy.allclose(output.bounds,
+                                  [-78.95864996545055, 23.564424693996177,
+                                   -76.57259451863895, 25.550873767433984])
+
+
+def test_warp_reproject_dst_crs_proj4(runner, tmpdir):
+    proj4 = '+proj=longlat +ellps=WGS84 +datum=WGS84'
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dst-crs', proj4])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(outputname) as output:
+        assert output.crs == {'init': 'epsg:4326'}  # rasterio converts to EPSG
+
+
+def test_warp_reproject_res(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dst-crs', 'EPSG:4326',
+                                       '--res', '0.01'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(outputname) as output:
+        assert output.crs == {'init': 'epsg:4326'}
+        assert numpy.allclose([0.01, 0.01], [output.affine.a, -output.affine.e])
+        assert output.width == 9
+        assert output.height == 7
+
+
+def test_warp_reproject_dimensions(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dst-crs', 'EPSG:4326',
+                                       '--dimensions', '100', '100'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.crs == {'init': 'epsg:4326'}
+            assert output.width == 100
+            assert output.height == 100
+            assert numpy.allclose([0.0008789062498762235, 0.0006771676143921468],
+                                  [output.affine.a, -output.affine.e])
+
+
+def test_warp_reproject_bounds_no_res(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    out_bounds = [-11850000, 4810000, -11849000, 4812000]
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dst-crs', 'EPSG:4326',
+                                       '--bounds', ] + out_bounds)
+    assert result.exit_code == 2
+
+
+def test_warp_reproject_bounds_res(runner, tmpdir):
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    out_bounds = [-11850000, 4810000, -11849000, 4812000]
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dst-crs', 'EPSG:4326',
+                                       '--res', 0.001, '--bounds', ]
+                                       + out_bounds)
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.crs == {'init': 'epsg:4326'}
+            assert numpy.allclose(output.bounds[:],
+                                  [-106.45036, 39.6138, -106.44136, 39.6278])
+            assert numpy.allclose([0.001, 0.001],
+                                  [output.affine.a, -output.affine.e])
+            assert output.width == 9
+            assert output.height == 14
+
+
+def test_warp_reproject_like(runner, tmpdir):
+    likename = str(tmpdir.join('like.tif'))
+    kwargs = {
+        "crs": {'init': 'epsg:4326'},
+        "transform": (-106.523, 0.001, 0, 39.6395, 0, -0.001),
+        "count": 1,
+        "dtype": rasterio.uint8,
+        "driver": "GTiff",
+        "width": 10,
+        "height": 10,
+        "nodata": 0
+    }
+
+    with rasterio.drivers():
+        with rasterio.open(likename, 'w', **kwargs) as dst:
+            data = numpy.zeros((10, 10), dtype=rasterio.uint8)
+            dst.write_band(1, data)
+
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--like', likename])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(outputname) as output:
+        assert output.crs == {'init': 'epsg:4326'}
+        assert numpy.allclose([0.001, 0.001], [output.affine.a, -output.affine.e])
+        assert output.width == 10
+        assert output.height == 10

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -50,7 +50,7 @@ def test_warp_no_reproject_res(runner, tmpdir):
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     result = runner.invoke(warp.warp, [srcname, outputname,
-                                       '--res', '30'])
+                                       '--res', 30, 30])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 
@@ -86,7 +86,8 @@ def test_warp_no_reproject_bounds_res(runner, tmpdir):
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
     result = runner.invoke(warp.warp,[srcname, outputname,
-                                      '--res', 30, '--bounds', ] + out_bounds)
+                                      '--res', 30, 30,
+                                      '--bounds', ] + out_bounds)
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 
@@ -136,7 +137,7 @@ def test_warp_reproject_res(runner, tmpdir):
     outputname = str(tmpdir.join('test.tif'))
     result = runner.invoke(warp.warp, [srcname, outputname,
                                        '--dst-crs', 'EPSG:4326',
-                                       '--res', '0.01'])
+                                       '--res', 0.01, 0.01])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 
@@ -181,7 +182,7 @@ def test_warp_reproject_bounds_res(runner, tmpdir):
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
     result = runner.invoke(warp.warp, [srcname, outputname,
                                        '--dst-crs', 'EPSG:4326',
-                                       '--res', 0.001, '--bounds', ]
+                                       '--res', 0.001, 0.001, '--bounds', ]
                                        + out_bounds)
     assert result.exit_code == 0
     assert os.path.exists(outputname)

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -50,7 +50,7 @@ def test_warp_no_reproject_res(runner, tmpdir):
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     result = runner.invoke(warp.warp, [srcname, outputname,
-                                       '--res', 30, 30])
+                                       '--res', 30])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 
@@ -86,7 +86,7 @@ def test_warp_no_reproject_bounds_res(runner, tmpdir):
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
     result = runner.invoke(warp.warp,[srcname, outputname,
-                                      '--res', 30, 30,
+                                      '--res', 30,
                                       '--bounds', ] + out_bounds)
     assert result.exit_code == 0
     assert os.path.exists(outputname)
@@ -118,6 +118,14 @@ def test_warp_reproject_dst_crs(runner, tmpdir):
                                   [-78.95864996545055, 23.564424693996177,
                                    -76.57259451863895, 25.550873767433984])
 
+def test_warp_reproject_dst_crs_error(runner, tmpdir):
+    srcname = 'tests/data/RGB.byte.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--dst-crs', '{foo: bar}'])
+    assert result.exit_code == 2
+    assert 'invalid crs format' in result.output
+
 
 def test_warp_reproject_dst_crs_proj4(runner, tmpdir):
     proj4 = '+proj=longlat +ellps=WGS84 +datum=WGS84'
@@ -137,7 +145,7 @@ def test_warp_reproject_res(runner, tmpdir):
     outputname = str(tmpdir.join('test.tif'))
     result = runner.invoke(warp.warp, [srcname, outputname,
                                        '--dst-crs', 'EPSG:4326',
-                                       '--res', 0.01, 0.01])
+                                       '--res', 0.01])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 
@@ -182,7 +190,7 @@ def test_warp_reproject_bounds_res(runner, tmpdir):
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
     result = runner.invoke(warp.warp, [srcname, outputname,
                                        '--dst-crs', 'EPSG:4326',
-                                       '--res', 0.001, 0.001, '--bounds', ]
+                                       '--res', 0.001, '--bounds', ]
                                        + out_bounds)
     assert result.exit_code == 0
     assert os.path.exists(outputname)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -136,10 +136,9 @@ def test_calculate_default_transform():
     )
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
-            l, b, r, t = src.bounds
             wgs84_crs = {'init': 'EPSG:4326'}
             dst_transform, width, height = calculate_default_transform(
-                src.crs, wgs84_crs, src.width, src.height, l, b, r, t)
+                src.crs, wgs84_crs, src.width, src.height, *src.bounds)
 
             assert dst_transform.almost_equals(target_transform)
             assert width == 824
@@ -157,7 +156,7 @@ def test_calculate_default_transform_single_resolution():
             )
             dst_transform, width, height = calculate_default_transform(
                 src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
-                l, b, r, t, resolution=target_resolution
+                *src.bounds, resolution=target_resolution
             )
 
             assert dst_transform.almost_equals(target_transform)
@@ -168,7 +167,6 @@ def test_calculate_default_transform_single_resolution():
 def test_calculate_default_transform_multiple_resolutions():
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
-            l, b, r, t = src.bounds
             target_resolution = (0.2, 0.1)
             target_transform = Affine(
                 target_resolution[0], 0.0, -78.95864996545055,
@@ -177,7 +175,7 @@ def test_calculate_default_transform_multiple_resolutions():
 
             dst_transform, width, height = calculate_default_transform(
                 src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
-                l, b, r, t, resolution=target_resolution
+                *src.bounds, resolution=target_resolution
             )
 
             assert dst_transform.almost_equals(target_transform)


### PR DESCRIPTION
Partially resolves #264 

```
Usage: rio warp [OPTIONS] INPUT OUTPUT

  Warp a raster dataset.

  The output is always overwritten.

  If a template raster is provided using the --like option, the coordinate
  reference system, affine transform, and dimensions of that raster will be
  used for the output.  In this case --dst-crs, --bounds, --res, and
  --dimensions options are ignored.

  If --dimensions are provided, --res and --bounds are ignored.  Resolution
  is calculated based on the relationship between the source raster bounds
  and dimensions, and may produce rectangular rather than square pixels.

  If --bounds are provided, --res is required if --dst-crs is provided
  (defaults to source raster resolution otherwise).  Bounds are in the source
  coordinate reference system.

Options:
  -f, --format, --driver TEXT     Output format driver
  --like PATH                     Raster dataset to use as a template for
                                  obtaining affine transform (bounds and
                                  resolution), crs, data type, and driver used
                                  to create the output.
  --dst-crs TEXT                  Target coordinate reference system.
                                  Default: EPSG:4326
  --dimensions INTEGER...         Output dataset width, height in number of
                                  pixels.
  --bounds FLOAT...               Output bounds: left, bottom, right, top.
  -r, --res FLOAT                 Output dataset resolution in units of
                                  coordinate reference system. Pixels assumed
                                  to be square if this option is used once,
                                  otherwise use: --res pixel_width --res
                                  pixel_height
  --resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode]
                                  Resampling method
  --threads INTEGER               Number of processing threads.
```

```rio warp tests/data/RGB.byte.tif /tmp/test2.tif --resampling lanczos --dst-crs EPSG:3411```

(UTM Zone 18N -> Polar Stereographic)


Turns this:
![test](https://cloud.githubusercontent.com/assets/3375604/8493609/886ee014-2111-11e5-9c2e-c0b52751d6a1.png)

Into this:
![test2](https://cloud.githubusercontent.com/assets/3375604/8493613/919ed14e-2111-11e5-9977-cb165a2f23b2.png)



If this initial pass is good, I'll add documentation to this PR before it gets merged in.

Note: results are not identical to gdalwarp, but close for the things I've tested by hand.  Our method of calculating default resolution when reprojecting could probably use a little tuning to more closely mimic gdalwarp.