### PR TITLE
Add a --color option to rio-shapes

### DIFF
--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -349,6 +349,14 @@ def test_shapes_band1_as_mask(runner):
     assert result.output.count('"Feature"') == 9
 
 
+def test_shapes_color(runner):
+    result = runner.invoke(features.shapes, ['tests/data/RGB.byte.tif', '--mask', '--color', '#999999'])
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 7
+    assert result.output.count('#999999') == 14
+
+
 def test_rasterize_err(tmpdir, runner):
     output = str(tmpdir.join('test.tif'))
     # Test invalid stdin


### PR DESCRIPTION
This is turned into [simplestyle](https://github.com/mapbox/simplestyle-spec/tree/master/1.1.0) `fill` and `stroke` properties.

Now the following 

```bash
rio shapes tests/data/shade.tif --sampling 1 --color '#990000' > 1.geojson
rio shapes tests/data/shade.tif --sampling 20 --color '#999999' > 20.geojson
rio shapes tests/data/shade.tif --sampling 50 --color '#000099' > 50.geojson
fio cat 1.geojson 20.geojson 50.geojson | fio collect | geojsonio
```

Produces

![geojson io color](https://cloud.githubusercontent.com/assets/33697/8632703/240f9fe2-2764-11e5-8078-b83c3a091829.png)

Closes #393.