### PR TITLE
Switch to --scale-ratio and --scale-offset

### DIFF
--- a/rasterio/rio/convert.py
+++ b/rasterio/rio/convert.py
@@ -5,6 +5,7 @@ import warnings
 
 import click
 from cligj import files_inout_arg, format_opt
+import numpy as np
 
 from .helpers import resolve_inout
 from . import options
@@ -14,7 +15,7 @@ import rasterio
 warnings.simplefilter('default')
 
 
-@click.command(short_help="Copy a raster dataset with translations.")
+@click.command(short_help="Copy and convert raster dataset.")
 @click.argument(
     'files',
     nargs=-1,
@@ -24,32 +25,30 @@ warnings.simplefilter('default')
 @options.output_opt
 @format_opt
 @options.dtype_opt
-@click.option('--scale-linear', 'scaling', flag_value='linear',
-              help="Scale intensity of raster values.", show_default=True)
-@click.option(
-    '--src-scale-points', 'src_points', nargs=2, type=float, default=None,
-    help="Source points for intensity scaling [default: full range].")
-@click.option(
-    '--dst-scale-points', 'dst_points', nargs=2, type=float, default=None,
-    help="Destination points for intensity scaling [default: full range].")
+@click.option('--scale-ratio', type=float, default=None,
+              help="Source to destination scaling ratio.")
+@click.option('--scale-offset', type=float, default=None,
+              help="Source to destination scaling offset.")
 @options.creation_options
 @click.pass_context
 def convert(
-        ctx, files, output, driver, dtype, scaling, src_points, dst_points,
+        ctx, files, output, driver, dtype, scale_ratio, scale_offset,
         creation_options):
     """Copy and convert raster datasets to other data types and formats.
 
     Data values may be linearly scaled when copying by using the
-    --scale-linear option. The default is to scale the full input range
-    to the full output range, eg, uint16's 0-65,535 to uint8's 0-255.
-    A different scaling can be performed by using the --src-scale-points
-    and --dst-scale-points options. For example, to scale uint16 data with
-    an actual range of 0-10,000 to 0-100 as uint8:
+    --scale-ratio and --scale-offset options. Destination raster values
+    are calculated as
 
-      --scale-linear --src-scale-points 0 10000 --dst-scale-points 0 100
+      dst = scale_ratio * src + scale_offset
 
-    Format specific creation options may also be passed using --co. To tile
-    a new GeoTIFF output file, do the following.
+    For example, to scale uint16 data with an actual range of 0-4095 to
+    0-255 as uint8:
+
+      $ rio convert in16.tif out8.tif --dtype uint8 --scale-ratio 0.0625
+
+    Format specific creation options may also be passed using --co. To
+    tile a new GeoTIFF output file, do the following.
 
       --co tiled=true --co blockxsize=256 --co blockysize=256
 
@@ -82,33 +81,19 @@ def convert(
             profile.update(**creation_options)
 
             with rasterio.open(outputfile, 'w', **profile) as dst:
+
                 data = src.read()
 
-                data = data.astype(dst_dtype, copy=False)
+                if scale_ratio:
+                    # Add a very small epsilon to 
+                    data = data.astype('float64', casting='unsafe')
+                    np.multiply(
+                        data, scale_ratio, out=data, casting='unsafe')
 
-                if scaling == 'linear':
-                    # Determine our rescaling ranges. As the data types
-                    # must be known, this is less difficult to do here
-                    # than in an option validating callback.
-                    import numpy as np
-                    infos = {'c': np.finfo, 'f': np.finfo, 'i': np.iinfo,
-                             'u': np.iinfo}
+                if scale_offset:
+                    np.add(
+                        data, scale_offset, out=data, casting='unsafe')
 
-                    if not src_points:
-                        rng = infos[np.dtype(src.meta['dtype']).kind](
-                            src.meta['dtype'])
-                        src_points = rng.min, rng.max
+                result = data.astype(dst_dtype, casting='unsafe', copy=False)
 
-                    if not dst_points:
-                        rng = infos[np.dtype(dst_dtype).kind](dst_dtype)
-                        dst_points = rng.min, rng.max
-
-                    scale_slope = ((dst_points[1] - dst_points[0]) /
-                                   (src_points[1] - src_points[0]))
-                    scale_intercept = (
-                        dst_points[0] - scale_slope * src_points[0])
-
-                    np.multiply(data, scale_slope, out=data, casting='unsafe')
-                    np.add(data, scale_intercept, out=data, casting='unsafe')
-
-                dst.write(data)
+                dst.write(result)

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -58,11 +58,12 @@ def test_dtype(tmpdir):
 
 
 def test_dtype_rescaling_uint8_full(tmpdir):
+    """Rescale uint8 [0, 255] to uint8 [0, 255]"""
     outputname = str(tmpdir.join('test.tif'))
     runner = CliRunner()
     result = runner.invoke(
         convert,
-        ['tests/data/RGB.byte.tif', outputname, '--scale-linear'])
+        ['tests/data/RGB.byte.tif', outputname, '--scale-ratio', '1.0'])
     assert result.exit_code == 0
 
     src_stats = [
@@ -78,26 +79,42 @@ def test_dtype_rescaling_uint8_full(tmpdir):
 
 
 def test_dtype_rescaling_uint8_half(tmpdir):
+    """Rescale uint8 [0, 255] to uint8 [0, 127]"""
     outputname = str(tmpdir.join('test.tif'))
     runner = CliRunner()
     result = runner.invoke(convert, [
-        'tests/data/RGB.byte.tif', outputname, '--scale-linear',
-        '--dst-scale-points', '0', '127'])
+        'tests/data/RGB.byte.tif', outputname, '--scale-ratio', '0.5'])
     assert result.exit_code == 0
     with rasterio.open(outputname) as src:
-        for band in src.read(masked=True):
-            assert round(band.min() - 1, 6) == 0.0
+        for band in src.read():
+            assert round(band.min() - 0, 6) == 0.0
             assert round(band.max() - 127, 6) == 0.0
 
 
 def test_dtype_rescaling_uint16(tmpdir):
+    """Rescale uint8 [0, 255] to uint16 [0, 4095]"""
+    # NB: 255 * 16 is 4080, we don't actually get to 4095.
     outputname = str(tmpdir.join('test.tif'))
     runner = CliRunner()
     result = runner.invoke(convert, [
         'tests/data/RGB.byte.tif', outputname, '--dtype', 'uint16',
-        '--scale-linear', '--dst-scale-points', '0', '10000'])
+        '--scale-ratio', '16'])
     assert result.exit_code == 0
     with rasterio.open(outputname) as src:
-        for band in src.read(masked=True):
-            assert round(band.min() - 39, 6) == 0.0
-            assert round(band.max() - 10000, 6) == 0.0
+        for band in src.read():
+            assert round(band.min() - 0, 6) == 0.0
+            assert round(band.max() - 4080, 6) == 0.0
+
+
+def test_dtype_rescaling_float64(tmpdir):
+    """Rescale uint8 [0, 255] to float64 [-1, 1]"""
+    outputname = str(tmpdir.join('test.tif'))
+    runner = CliRunner()
+    result = runner.invoke(convert, [
+        'tests/data/RGB.byte.tif', outputname, '--dtype', 'float64',
+        '--scale-ratio', str(2.0/255), '--scale-offset', '-1.0'])
+    assert result.exit_code == 0
+    with rasterio.open(outputname) as src:
+        for band in src.read():
+            assert round(band.min() + 1.0, 6) == 0.0
+            assert round(band.max() - 1.0, 6) == 0.0


### PR DESCRIPTION
@brendan-ward How about this for a solution to the scaling and range communication issue: we switch to very explicit (explicit is better than implicit) `--scale-ratio` and `--scale-offset` options, exactly as in the GDAL VRT spec? Simplies the code quite a bit, which is good.

This PR is not against master, but against the rio-translate branch, btw. A PR on a PR.

There's still future room for auto linear scaling. I think we could let non-linear scaling be handled by rio-calc.