### PR TITLE
Consolidated checks for ndarray type

### DIFF
--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -67,7 +67,7 @@ def _shapes(image, mask, connectivity, transform):
     if is_float:
         fieldtp = 2
 
-    if isinstance(image, np.ndarray):
+    if dtypes.is_ndarray(image):
         mem_ds = InMemoryRaster(image, transform)
         hband = mem_ds.band
     elif isinstance(image, tuple):
@@ -76,7 +76,7 @@ def _shapes(image, mask, connectivity, transform):
     else:
         raise ValueError("Invalid source image")
 
-    if isinstance(mask, np.ndarray):
+    if dtypes.is_ndarray(mask):
         # A boolean mask must be converted to uint8 for GDAL
         mask_ds = InMemoryRaster(mask.astype('uint8'), transform)
         hmaskband = mask_ds.band
@@ -168,7 +168,7 @@ def _sieve(image, size, output, mask, connectivity):
     cdef _io.RasterUpdater udr
     cdef _io.RasterReader mask_reader
 
-    if isinstance(image, np.ndarray):
+    if dtypes.is_ndarray(image):
         in_mem_ds = InMemoryRaster(image)
         in_band = in_mem_ds.band
     elif isinstance(image, tuple):
@@ -177,7 +177,7 @@ def _sieve(image, size, output, mask, connectivity):
     else:
         raise ValueError("Invalid source image")
 
-    if isinstance(output, np.ndarray):
+    if dtypes.is_ndarray(output):
         log.debug("Output array: %r", output)
         out_mem_ds = InMemoryRaster(output)
         out_band = out_mem_ds.band
@@ -187,7 +187,7 @@ def _sieve(image, size, output, mask, connectivity):
     else:
         raise ValueError("Invalid output image")
 
-    if isinstance(mask, np.ndarray):
+    if dtypes.is_ndarray(mask):
         # A boolean mask must be converted to uint8 for GDAL
         mask_mem_ds = InMemoryRaster(mask.astype('uint8'))
         mask_band = mask_mem_ds.band

--- a/rasterio/_fill.pyx
+++ b/rasterio/_fill.pyx
@@ -23,7 +23,7 @@ def _fillnodata(image, mask, double max_search_distance=100.0,
     cdef _io.RasterReader mrdr
     cdef char **alg_options = NULL
 
-    if isinstance(image, np.ndarray):
+    if dtypes.is_ndarray(image):
         # copy numpy ndarray into an in-memory dataset.
         image_dataset = _gdal.GDALCreate(
             memdriver,
@@ -38,7 +38,7 @@ def _fillnodata(image, mask, double max_search_distance=100.0,
     else:
         raise ValueError("Invalid source image")
 
-    if isinstance(mask, np.ndarray):
+    if dtypes.is_ndarray(mask):
         mask_cast = mask.astype('uint8')
         mask_dataset = _gdal.GDALCreate(
             memdriver,

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -246,7 +246,7 @@ def _reproject(
     # If the source is an ndarray, we copy to a MEM dataset.
     # We need a src_transform and src_dst in this case. These will
     # be copied to the MEM dataset.
-    if isinstance(source, np.ndarray):
+    if dtypes.is_ndarray(source):
         # Convert 2D single-band arrays to 3D multi-band.
         if len(source.shape) == 2:
             source = source.reshape(1, *source.shape)
@@ -300,7 +300,7 @@ def _reproject(
         raise ValueError("Invalid source")
     
     # Next, do the same for the destination raster.
-    if isinstance(destination, np.ndarray):
+    if dtypes.is_ndarray(destination):
         if len(destination.shape) == 2:
             destination = destination.reshape(1, *destination.shape)
         if destination.shape[0] != src_count:
@@ -489,11 +489,11 @@ def _reproject(
         #    _gdal.GDALDestroyApproxTransformer(psWOptions.pTransformerArg)
         if psWOptions != NULL:
             _gdal.GDALDestroyWarpOptions(psWOptions)
-        if isinstance(source, np.ndarray):
+        if dtypes.is_ndarray(source):
             if hdsin != NULL:
                 _gdal.GDALClose(hdsin)
 
-    if reprojected and isinstance(destination, np.ndarray):
+    if reprojected and dtypes.is_ndarray(destination):
         retval = _io.io_auto(destination, hdsout, 0)
         # TODO: handle errors (by retval).
 

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -96,3 +96,9 @@ def get_minimum_int_dtype(values):
         return int16
     elif min_value >= -2147483648 and max_value <= 2147483647:
         return int32
+
+
+def is_ndarray(array):
+    import numpy
+
+    return isinstance(array, numpy.ndarray) or hasattr(array, '__array__')

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -1,14 +1,23 @@
 import numpy as np
 
-import rasterio.dtypes
+from rasterio import dtypes, ubyte
+
+
+def test_is_ndarray():
+    assert dtypes.is_ndarray(np.zeros((1,)))
+    assert dtypes.is_ndarray([0]) == False
+    assert dtypes.is_ndarray((0,)) == False
+
 
 def test_np_dt_uint8():
-    assert rasterio.dtypes.check_dtype(np.uint8)
+    assert dtypes.check_dtype(np.uint8)
+
 
 def test_dt_ubyte():
-    assert rasterio.dtypes.check_dtype(rasterio.ubyte)
+    assert dtypes.check_dtype(ubyte)
+
 
 def test_gdal_name():
-    assert rasterio.dtypes._gdal_typename(rasterio.ubyte) == 'Byte'
-    assert rasterio.dtypes._gdal_typename(np.uint8) == 'Byte'
-    assert rasterio.dtypes._gdal_typename(np.uint16) == 'UInt16'
+    assert dtypes._gdal_typename(ubyte) == 'Byte'
+    assert dtypes._gdal_typename(np.uint8) == 'Byte'
+    assert dtypes._gdal_typename(np.uint16) == 'UInt16'


### PR DESCRIPTION
closes #436 

Putting it in ```rasterio.dtypes``` seemed like the most logical place to put it, since we're effectively doing a check for the array's type.  Can easily be moved elsewhere if needed.