### PR TITLE
use creation options when setting rgb

### DIFF
--- a/rasterio/rio/convert.py
+++ b/rasterio/rio/convert.py
@@ -82,10 +82,10 @@ def convert(
                 profile['dtype'] = dtype
             dst_dtype = profile['dtype']
 
-            profile.update(**creation_options)
-
             if photometric:
-                kwargs['photometric'] = photometric
+                creation_options['photometric'] = photometric
+
+            profile.update(**creation_options)
 
             with rasterio.open(outputfile, 'w', **profile) as dst:
 


### PR DESCRIPTION
@sgillies - I was receiving an error when using the new `--rgb` flag. This creation option wasn't being passed to the new file during an invocation of `rio convert`.

If you're inclined to reproduce the problem:

```shell
# Create a uint16 file without an RGB color profile
rio convert RGB.byte.tif --dtype uint16 --scale-ratio 257 RGB.uint16.tif
rio convert RGB.uint16.tif out.tif --rgb
Traceback (most recent call last):
  File "/Users/amitkapadia/anaconda/envs/pl/bin/rio", line 9, in <module>
    load_entry_point('rasterio==0.25.0', 'console_scripts', 'rio')()
  File "/Users/amitkapadia/anaconda/envs/pl/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/Users/amitkapadia/anaconda/envs/pl/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/Users/amitkapadia/anaconda/envs/pl/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/amitkapadia/anaconda/envs/pl/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/amitkapadia/anaconda/envs/pl/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/Users/amitkapadia/anaconda/envs/pl/lib/python2.7/site-packages/rasterio/rio/convert.py", line 88, in convert
    kwargs['photometric'] = photometric
NameError: global name 'kwargs' is not defined
```