### PR TITLE
removed errant comma in enums.py

### DIFF
--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -24,7 +24,7 @@ class Resampling(Enum):
     nearest='NEAREST'
     gauss='GAUSS'
     cubic='CUBIC'
-    average='AVERAGE',
+    average='AVERAGE'
     mode='MODE'
     average_magphase='AVERAGE_MAGPHASE'
     none='NONE'

--- a/tests/test_overviews.py
+++ b/tests/test_overviews.py
@@ -38,3 +38,13 @@ def test_build_overviews_two(data):
         assert src.overviews(1) == [2, 4]
         assert src.overviews(2) == [2, 4]
         assert src.overviews(3) == [2, 4]
+
+
+def test_build_overviews_three(data):
+    inputfile = str(data.join('RGB.byte.tif'))
+    with rasterio.open(inputfile, 'r+') as src:
+        overview_factors = [2, 4]
+        src.build_overviews(overview_factors, resampling=Resampling.average)
+        assert src.overviews(1) == [2, 4]
+        assert src.overviews(2) == [2, 4]
+        assert src.overviews(3) == [2, 4]


### PR DESCRIPTION
The Resampling.average enum value had a comma after it, which caused
that particular enum to map to a tuple instead of a string.  This broke
the use of the average kernel when making overviews.

This fixes issue #440, I added a test as well.