### PR TITLE
Add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,76 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IDE's etc.
+.idea/
+venv/
+venv2/
+
+# rasterio
+test.tif
+gdal-config.txt
+VERSION.txt
+rasterio/_fill.cpp
+rasterio/_warp.cpp
+rasterio/_base.c
+rasterio/_copy.c
+rasterio/_drivers.c
+rasterio/_err.c
+rasterio/_example.c
+rasterio/_features.c
+rasterio/_io.c


### PR DESCRIPTION
Closes #427 

@sgillies @brendan-ward I offer my `.gitignore` as a starting point for #427.  It's GitHub's standard Python file plus:

```
test.tif
gdal-config.txt
VERSION.txt
rasterio/_fill.cpp
rasterio/_warp.cpp
rasterio/_base.c
rasterio/_copy.c
rasterio/_drivers.c
rasterio/_err.c
rasterio/_example.c
rasterio/_features.c
rasterio/_io.c
```

Plus a few things that I use:

```
.idea/
venv/
venv2/
```