### PR TITLE
Build and release wheels for rasterio and requirements (on: tag)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,21 @@ before_install:
   - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
 install:
   - pip install --install-option="--no-cython-compile" cython
-  - "pip install -r requirements-dev.txt"
-  - "pip install pytest pytest-cov"
-  - "pip install coveralls"
-  - "pip install -e ."
+  - pip install -r requirements-dev.txt
+  - pip install -e .
 script: 
   - py.test --cov rasterio --cov-report term-missing
 after_success:
   - coveralls
+before_deploy:
+  - pip wheel --wheel-dir=/tmp/wheelhouse -r requirements-dev.txt
+  - pip wheel --wheel-dir=/tmp/wheelhouse -r requirements.txt
+  - pip wheel --wheel-dir=/tmp/wheelhouse .
+  - tar -C /tmp -czvf rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz wheelhouse
+deploy:
+  provider: releases
+  api_key:
+    secure: uP/hy8LRdDnN6XHSLChmKYdW9CdIy8pqvUyXFPgTDY/mlItMUdDNdP95bitzn/rNNXnOkCGsARqzRCLeGI3jB0nEGuAzY6fGWYt2igjfMOhpdDG6o3LcaoP4mITuFfe5/kCQeUb8WB3QK6c2cL7nEEPzoSniqZQ6MsxHIvUW7ts=
+  file: rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libgdal1h gdal-bin libgdal-dev
 install:
-  - pip install --install-option="--no-cython-compile" cython
+  - pip install --install-option="--no-cython-compile" cython==0.22
   - pip install -r requirements-dev.txt
   - pip install -e .
 script: 

--- a/README.rst
+++ b/README.rst
@@ -283,10 +283,41 @@ From the repo directory, run py.test
 
     $ py.test
 
-
 Note: some tests do not succeed on Windows (see
 `#66
 <https://github.com/mapbox/rasterio/issues/66>`__.).
+
+
+Downstream testing
+------------------
+
+If your project depends on Rasterio and uses Travis-CI, you can speed up your
+builds by fetching Rasterio and its dependencies as a set of wheels from 
+GitHub as done in `rio-plugin-example 
+<https://github.com/sgillies/rio-plugin-example/blob/master/.travis.yml>`__.
+
+.. code-block:: yaml
+
+    language: python
+    env:
+      - RASTERIO_VERSION=0.26
+    python:
+      - "2.7"
+      - "3.4"
+    cache:
+      directories:
+        - $HOME/.pip-cache/
+        - $HOME/wheelhouse
+    before_install:
+      - sudo add-apt-repository -y ppa:ubuntugis/ppa
+      - sudo apt-get update -qq
+      - sudo apt-get install -y libgdal1h gdal-bin
+      - curl -L https://github.com/mapbox/rasterio/releases/download/$RASTERIO_VERSION/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
+      - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
+    install:
+      - pip install --use-wheel --find-links=$HOME/wheelhouse -e .[test] --cache-dir $HOME/.pip-cache
+    script: 
+      - py.test
 
 
 Documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 affine
 cligj
 coveralls>=0.4
-cython>=0.21.2
+cython==0.22
 delocate
 enum34
 numpy>=1.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,6 @@ enum34
 numpy>=1.8.0
 snuggs>=1.2
 pytest
+pytest-cov
 setuptools>=0.9.8
 wheel


### PR DESCRIPTION
Using these gets the individual rio-mbtiles builds down to 30 seconds and can similarly speed up other plugin builds.

After some false starts and pulled hair, I decided not to do anything about speeding up Rasterio's own builds. Since we need to cythonize and compile source files anyway, the gain from using binary wheels for requirements is relatively small.

NB: between building numpy and rasterio from source, these releases take a while. Around 20 mins each.

This work is ~30% done, not quite ready for review.