### PR TITLE
Add rasterio.tool.show_hist()

### DIFF
--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -48,6 +48,55 @@ def stats(source):
     return Stats(numpy.min(arr), numpy.max(arr), numpy.mean(arr))
 
 
+def show_hist(source, bins=10):
+
+    """
+    Display a histogram with matplotlib.
+
+    Parameters
+    ----------
+    data : np.array or rasterio.Band or tuple(dataset, bidx)
+        Input data to display.  The first three arrays in multi-dimensional
+        arrays are plotted as red, green, and blue.
+    bins : int, optional
+        Compute histogram across N bins.
+    """
+
+    if plt is None:
+        raise ImportError("Could not import matplotlib")
+
+    if isinstance(source, (tuple, rasterio.Band)):
+        arr = source[0].read(source[1])
+    else:
+        arr = source
+
+    # The histogram is computed individually for each 'band' in the array
+    # so we need the overall min/max to constrain the plot
+    rng = arr.min(), arr.max()
+
+    if len(arr.shape) is 2:
+        arr = [arr]
+        colors = ['gold']
+    else:
+        colors = ('red', 'green', 'blue', 'violet')
+
+    labels = (str(i + 1) for i in range(len(arr)))
+
+    for band, color, label in zip(arr, colors, labels):
+
+        plt.hist(
+            band.flatten(),
+            bins=bins,
+            alpha=0.5,
+            color=color,
+            label=label,
+            range=rng
+        )
+
+    plt.legend(loc="upper right")
+    plt.show()
+
+
 def main(banner, dataset, alt_interpreter=None):
     """ Main entry point for use with python interpreter """
     local = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -86,7 +86,12 @@ def show_hist(source, bins=10, masked=True, title='Histogram'):
     else:
         colors = ('red', 'green', 'blue', 'violet', 'gold', 'saddlebrown')
 
-    labels = (str(i + 1) for i in range(len(arr)))
+    # If a rasterio.Band() is given make sure the proper index is displayed
+    # in the legend.
+    if isinstance(source, (tuple, rasterio.Band)):
+        labels = [str(source[1])]
+    else:
+        labels = (str(i + 1) for i in range(len(arr)))
 
     # This loop should add a single plot each band in the input array,
     # regardless of if the number of bands exceeds the number of colors.
@@ -95,10 +100,10 @@ def show_hist(source, bins=10, masked=True, title='Histogram'):
     # The goal is to provide a curated set of colors for working with
     # smaller datasets and let matplotlib define additional colors when
     # working with larger datasets.
-    for band, color, label in zip_longest(arr, colors[:len(arr)], labels):
+    for bnd, color, label in zip_longest(arr, colors[:len(arr)], labels):
 
         plt.hist(
-            band.flatten(),
+            bnd.flatten(),
             bins=bins,
             alpha=0.5,
             color=color,

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -53,7 +53,7 @@ def test_show_hist():
         # Return because plotting causes the tests to block until the plot
         # window is closed.
         return
-    with rasterio.open('testsdata/RGB.byte.tif') as src:
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show_hist((src, 1), bins=256)
         except ImportError:

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -6,7 +6,7 @@ except ImportError:
     plt = None
 
 import rasterio
-from rasterio.tool import show, stats
+from rasterio.tool import show, show_hist, stats
 
 
 def test_stats():
@@ -42,3 +42,24 @@ def test_show():
                 show(src.read(1))
             except ImportError:
                 pass
+
+
+def test_show_hist():
+    """
+    This test only verifies that code up to the point of plotting with
+    matplotlib works correctly.  Tests do not exercise matplotlib.
+    """
+    if plt:
+        # Return because plotting causes the tests to block until the plot
+        # window is closed.
+        return
+    with rasterio.open('testsdata/RGB.byte.tif') as src:
+        try:
+            show_hist((src, 1), bins=256)
+        except ImportError:
+            pass
+
+        try:
+            show_hist(src.read(), bins=256)
+        except ImportError:
+            pass


### PR DESCRIPTION
Closes #456.

@sgillies @brendan-ward ready for review, especially the color choices.  I chose `gold` as the default for 2d arrays both because it stands out against the grey border and to get away from the default blue.  It's a bit soft since the transparency is set to `50%` so I'm open to other suggestions.

With `rio-insp`:

```console
$ rio insp tests/data/RGB.byte.tif
>>> show_hist(src.read(), bins=256)
```

Directly with Python:

```python
import rasterio
import rasterio.tool

with rasterio.open('tests/data/RGB.byte.tif') as src:
    rasterio.tool.show_hist(src.read(), bins=256)
```

![figure_1](https://cloud.githubusercontent.com/assets/2676083/9287385/2cb59fba-42e0-11e5-9fd2-7137edc10307.png)


![figure_1](https://cloud.githubusercontent.com/assets/2676083/9287389/45f950fc-42e0-11e5-928c-36744a1bff28.png)
