### PR TITLE
Adjust tests to no longer fail on i386

### DIFF
--- a/tests/test_read_resample.py
+++ b/tests/test_read_resample.py
@@ -10,16 +10,17 @@ import rasterio
 
 def test_read_out_shape_resample_down():
     with rasterio.open('tests/data/RGB.byte.tif') as s:
-        out = numpy.zeros((7, 8), dtype=rasterio.ubyte)
+        out = numpy.zeros((8, 8), dtype=rasterio.ubyte)
         data = s.read(1, out=out)
         expected = numpy.array([
-            [  0,   8,   5,   7,   0,   0,   0,   0],
-            [  0,   6,  61,  15,  27,  15,  24, 128],
-            [  0,  20, 152,  23,  15,  19,  28,   0],
-            [  0,  17, 255,  25, 255,  22,  32,   0],
-            [  9,   7,  14,  16,  19,  18,  36,   0],
-            [  6,  27,  43, 207,  38,  31,  73,   0],
-            [  0,   0,   0,   0,  74,  23,   0,   0]], dtype=numpy.uint8)
+            [  0,   0,  20,  15,   0,   0,   0,   0],
+            [  0,   6, 193,   9, 255, 127,  23,  39],
+            [  0,   7,  27, 255, 193,  14,  28,  34],
+            [  0,  31,  29,  44,  14,  22,  43,   0],
+            [  0,   9,  69,  49,  17,  22, 255,   0],
+            [ 11,   7,  13,  25,  13,  29,  33,   0],
+            [  8,  10,  88,  27,  20,  33,  25,   0],
+            [  0,   0,   0,   0,  98,  23,   0,   0]], dtype=numpy.uint8)
         assert (data == expected).all() # all True.
 
 

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -310,10 +310,10 @@ def test_shapes_compact(runner):
 
 def test_shapes_sampling(runner):
     result = runner.invoke(
-        features.shapes, ['tests/data/shade.tif', '--sampling', '10'])
+        features.shapes, ['tests/data/shade.tif', '--sampling', '11'])
     assert result.exit_code == 0
     assert result.output.count('"FeatureCollection"') == 1
-    assert result.output.count('"Feature"') == 124
+    assert result.output.count('"Feature"') == 117
 
 
 def test_shapes_precision(runner):


### PR DESCRIPTION
See discussion on gdal-dev mailinglist:
https://lists.osgeo.org/pipermail/gdal-dev/2015-August/042380.html

"Changing very slightly the test case should hopefully hide that annoyance."

This closes Bug #229 

I tested on i386 and amd64.