### PR TITLE
Full cover window

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -377,23 +377,18 @@ cdef class DatasetReader(object):
             row += self.height
         return c+a*col, f+e*row
 
-    def index(self, x, y, row_op=math.floor, col_op=math.floor):
+    def index(self, x, y, op=math.floor):
         """Returns the (row, col) index of the pixel containing (x, y)."""
         a, b, c, d, e, f, _, _, _ = self.affine
-        return int(row_op((y-f)/e)), int(col_op((x-c)/a))
+        return int(op((y-f)/e)), int(op((x-c)/a))
 
-    def window(self, left, bottom, right, top, boundless=False, full_cover=False):
+    def window(self, left, bottom, right, top, boundless=False):
         """Returns the window corresponding to the world bounding box.
         If boundless is False, window is limited to extent of this dataset."""
         EPS = 1.0e-8
-        if full_cover:
-            # Ensure window results in bounds that fully cover specified bound args
-            window = tuple(zip(self.index(left + EPS, top - EPS),
-                               self.index(right + EPS, bottom - EPS,
-                                          row_op=math.ceil, col_op=math.ceil)))
-        else:
-            window = tuple(zip(self.index(left + EPS, top - EPS),
-                               self.index(right + EPS, bottom - EPS)))
+        # Ensure window results in bounds that fully cover specified bound args
+        window = tuple(zip(self.index(left + EPS, top - EPS),
+                           self.index(right - EPS, bottom + EPS, op=math.ceil)))
 
         if boundless:
             return window

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -698,7 +698,7 @@ cpdef eval_window(object window, int height, int width):
     return (r_start, r_stop), (c_start, c_stop)
 
 
-def get_index(x, y, affine):
+def get_index(x, y, affine, op=math.floor):
     """
     Returns the (row, col) index of the pixel containing (x, y) given a
     coordinate reference system.
@@ -711,6 +711,8 @@ def get_index(x, y, affine):
         y value in coordinate reference system
     affine : tuple
         Coefficients mapping pixel coordinates to coordinate reference system.
+    op : function
+        Function to convert fractional pixels to whole numbers (floor, ceiling, round)
 
     Returns
     -------
@@ -720,8 +722,8 @@ def get_index(x, y, affine):
         col index
     """
 
-    row = int(math.floor((y - affine[5]) / affine[4]))
-    col = int(math.floor((x - affine[2]) / affine[0]))
+    row = int(op((y - affine[5]) / affine[4]))
+    col = int(op((x - affine[2]) / affine[0]))
 
     return row, col
 
@@ -746,8 +748,8 @@ def get_window(left, bottom, right, top, affine):
     """
 
     EPS = 1.0e-8
-    window_start = get_index(left + EPS, top - EPS, affine)
-    window_stop = get_index(right + EPS, bottom - EPS, affine)
+    window_start = get_index(left + EPS, top - EPS, affine, op=math.floor)
+    window_stop = get_index(right - EPS, bottom + EPS, affine, op=math.ceil)
     window = tuple(zip(window_start, window_stop))
 
     return window

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -377,16 +377,24 @@ cdef class DatasetReader(object):
             row += self.height
         return c+a*col, f+e*row
 
-    def index(self, x, y):
+    def index(self, x, y, row_op=math.floor, col_op=math.floor):
         """Returns the (row, col) index of the pixel containing (x, y)."""
         a, b, c, d, e, f, _, _, _ = self.affine
-        return int(math.floor((y-f)/e)), int(math.floor((x-c)/a))
+        return int(row_op((y-f)/e)), int(col_op((x-c)/a))
 
-    def window(self, left, bottom, right, top, boundless=False):
+    def window(self, left, bottom, right, top, boundless=False, full_cover=False):
         """Returns the window corresponding to the world bounding box.
         If boundless is False, window is limited to extent of this dataset."""
         EPS = 1.0e-8
-        window = tuple(zip(self.index(left + EPS, top - EPS), self.index(right + EPS, bottom - EPS)))
+        if full_cover:
+            # Ensure window results in bounds that fully cover specified bound args
+            window = tuple(zip(self.index(left + EPS, top - EPS),
+                               self.index(right + EPS, bottom - EPS,
+                                          row_op=math.ceil, col_op=math.ceil)))
+        else:
+            window = tuple(zip(self.index(left + EPS, top - EPS),
+                               self.index(right + EPS, bottom - EPS)))
+
         if boundless:
             return window
         else:

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -49,3 +49,28 @@ def test_window_bounds_roundtrip():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert ((100, 200), (100, 200)) == src.window(
             *src.window_bounds(((100, 200), (100, 200))))
+
+
+def test_window_full_cover():
+
+    def bound_covers(bounds1, bounds2):
+        """Does bounds1 cover bounds2?
+        """
+        if bounds1[0] <= bounds2[0] and bounds1[1] <= bounds2[1] and \
+           bounds1[2] >= bounds2[2] and bounds1[3] >= bounds2[3]:
+            return True
+        else:
+            return False
+
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        bounds = list(src.window_bounds(((100, 200), (100, 200))))
+        bounds[1] = bounds[1] - 10.0  # extend south
+        bounds[2] = bounds[2] + 10.0  # extend east
+
+        win = src.window(*bounds)
+        bounds_calc = list(src.window_bounds(win))
+        assert not bound_covers(bounds_calc, bounds)
+
+        win2 = src.window(*bounds, full_cover=True)
+        bounds_calc2 = list(src.window_bounds(win2))
+        assert bound_covers(bounds_calc2, bounds)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -24,7 +24,7 @@ def test_window_no_exception():
                 (0, src.height), (-4, src.width))
 
 
-def test_index():
+def test_index_values():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src.index(101985.0, 2826915.0) == (0, 0)
         assert src.index(101985.0+400.0, 2826915.0) == (0, 1)
@@ -41,8 +41,8 @@ def test_window():
                                                           (0, src.width))
         assert src.index(left+400, top-400) == (1, 1)
         assert src.index(left+dx+eps, top-dy-eps) == (1, 1)
-        assert src.window(left, top-400, left+400, top) == ((0, 1), (0, 1))
-        assert src.window(left, top-2*dy-eps, left+2*dx+eps, top) == ((0, 2), (0, 2))
+        assert src.window(left, top-400, left+400, top) == ((0, 2), (0, 2))
+        assert src.window(left, top-2*dy-eps, left+2*dx-eps, top) == ((0, 2), (0, 2))
 
 
 def test_window_bounds_roundtrip():
@@ -66,8 +66,4 @@ def test_window_full_cover():
 
         win = src.window(*bounds)
         bounds_calc = list(src.window_bounds(win))
-        assert not bound_covers(bounds_calc, bounds)
-
-        win2 = src.window(*bounds, full_cover=True)
-        bounds_calc2 = list(src.window_bounds(win2))
-        assert bound_covers(bounds_calc2, bounds)
+        assert bound_covers(bounds_calc, bounds)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -56,11 +56,8 @@ def test_window_full_cover():
     def bound_covers(bounds1, bounds2):
         """Does bounds1 cover bounds2?
         """
-        if bounds1[0] <= bounds2[0] and bounds1[1] <= bounds2[1] and \
-           bounds1[2] >= bounds2[2] and bounds1[3] >= bounds2[3]:
-            return True
-        else:
-            return False
+        return (bounds1[0] <= bounds2[0] and bounds1[1] <= bounds2[1] and
+                bounds1[2] >= bounds2[2] and bounds1[3] >= bounds2[3])
 
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         bounds = list(src.window_bounds(((100, 200), (100, 200))))

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -24,7 +24,7 @@ def test_clip_bounds(runner, tmpdir):
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert out.shape == (419, 173)
+        assert out.shape == (420, 173)
 
 
 def test_clip_like(runner, tmpdir):

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -213,7 +213,7 @@ def test_mask_crop(runner, tmpdir):
         with rasterio.open(output) as out:
             assert out.shape[1] == src.shape[1]
             assert out.shape[0] < src.shape[0]
-            assert out.shape[0] == 823
+            assert out.shape[0] == 824
 
     # Adding invert option after crop should be ignored
     result = runner.invoke(


### PR DESCRIPTION
This PR modifies the `DatasetReader.window` method with an optional kwarg, `full_cover`. 

* The default of `full_cover=False` will maintain current behavior of `floor`ing the col and row values. 
* When `full_cover=True`, the east and south values use the `ceiling` to ensure the returned window results in a bounds that fully covers the input bounds.

Consider it a 30% implementation, there might be better ways of doing this. It's really only applicable when the bounds are not aligned with the raster grid (e.g. coming from an arbitrary bbox as in `rio clip`)

To resolve #464 