### PR TITLE
fix overlap stop equal to zero bug, add tests

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -978,10 +978,10 @@ cdef class RasterReader(_base.DatasetReader):
         else:
             # Compute the overlap between the dataset and the boundless window.
             overlap = ((
-                max(min(window[0][0] or 0, self.height), 0),
-                max(min(window[0][1] or self.height, self.height), 0)), (
-                max(min(window[1][0] or 0, self.width), 0),
-                max(min(window[1][1] or self.width, self.width), 0)))
+                max(min(window[0][0], self.height), 0),
+                max(min(window[0][1], self.height), 0)), (
+                max(min(window[1][0], self.width), 0),
+                max(min(window[1][1], self.width), 0)))
 
             if overlap != ((0, 0), (0, 0)):
                 # Prepare a buffer.

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -816,10 +816,10 @@ cdef class RasterReader(_base.DatasetReader):
         else:
             # Compute the overlap between the dataset and the boundless window.
             overlap = ((
-                max(min(window[0][0] or 0, self.height), 0),
-                max(min(window[0][1] or self.height, self.height), 0)), (
-                max(min(window[1][0] or 0, self.width), 0),
-                max(min(window[1][1] or self.width, self.width), 0)))
+                max(min(window[0][0], self.height), 0),
+                max(min(window[0][1], self.height), 0)), (
+                max(min(window[1][0], self.width), 0),
+                max(min(window[1][1], self.width), 0)))
 
             if overlap != ((0, 0), (0, 0)):
                 # Prepare a buffer.

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -77,3 +77,10 @@ def test_read_boundless_zero_stop():
             window=((-200, 0), (-200, 0)), boundless=True, masked=True)
         assert data.shape == (3, 200, 200)
         assert data.mask.all()
+
+
+def test_read_boundless_masks_zero_stop():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        data = src.read_masks(window=((-200, 0), (-200, 0)), boundless=True)
+        assert data.shape == (3, 200, 200)
+        assert data.min() == data.max() == src.nodata

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -69,3 +69,11 @@ def test_read_boundless_masked_overlap():
         assert not data.mask.all()
         assert data.mask[0,399,399] == False
         assert data.mask[0,0,0] == True
+
+
+def test_read_boundless_zero_stop():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        data = src.read(
+            window=((-200, 0), (-200, 0)), boundless=True, masked=True)
+        assert data.shape == (3, 200, 200)
+        assert data.mask.all()


### PR DESCRIPTION
The overlap calculation logic had a bug when the `window[0][1]` or  `widow[1][1]` was equal to zero. The problem stems from the superfluous `or` statement which, in most cases, did absolutely nothing but in this particular edge case caused an error.

Resolves #476