### PR TITLE
Added kwargs to index method in _base.pyx.

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -389,10 +389,9 @@ cdef class DatasetReader(object):
             row += self.height
         return c+a*col, f+e*row
 
-    def index(self, x, y, **kwargs):
-        """Returns the (row, col) index of the pixel containing (x, y).
-        See `rasterio._base.get_index` for information on available kwargs."""
-        return get_index(x, y, self.affine, **kwargs)
+    def index(self, x, y, op=math.floor, precision=6):
+        """Returns the (row, col) index of the pixel containing (x, y)."""
+        return get_index(x, y, self.affine, op=op, precision=precision)
 
     def window(self, left, bottom, right, top, boundless=False):
         """Returns the window corresponding to the world bounding box.

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -389,9 +389,10 @@ cdef class DatasetReader(object):
             row += self.height
         return c+a*col, f+e*row
 
-    def index(self, x, y, op=math.floor):
-        """Returns the (row, col) index of the pixel containing (x, y)."""
-        return get_index(x, y, self.affine)
+    def index(self, x, y, **kwargs):
+        """Returns the (row, col) index of the pixel containing (x, y).
+        See `rasterio._base.get_index` for information on available kwargs."""
+        return get_index(x, y, self.affine, **kwargs)
 
     def window(self, left, bottom, right, top, boundless=False):
         """Returns the window corresponding to the world bounding box.


### PR DESCRIPTION
The `op` keyword was not being passed to `get_index`, and precision was not available to the `index` method.

I debated whether this was preferable to explicitly setting keyword arguments `op` and `precision` in `index`. Both sides have drawbacks. And, of course, I started this by adding the `get_index` function in the first place. In any case, I'm not sure this is the right way to go, but wanted to make sure the full functionality was available to `index`.