### PR TITLE
Add GDAL 2.0.1 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   matrix:
     - GDALVERSION = "1.9.2"
     - GDALVERSION = "1.11.2"
-      #- GDALVERSION = "2.0.1"
+    - GDALVERSION = "2.0.1"
 addons:
   apt:
     packages:


### PR DESCRIPTION
I'm expecting at least one error, see https://github.com/mapbox/rasterio/issues/478.