### PR TITLE
Added Cython coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+plugins = Cython.Coverage
+source = rasterio
+omit = *.pxd
+
+[report]
+show_missing = True
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
+    - CYTHON_COVERAGE=1
   matrix:
     - GDALVERSION = "1.9.2"
     - GDALVERSION = "1.11.2"
@@ -37,7 +38,7 @@ install:
   - "pip wheel -r requirements-dev.txt"
   - "pip install -r requirements-dev.txt"
   - "pip install --upgrade --force-reinstall --global-option=build_ext --global-option='-I$GDALINST/gdal-$GDALVERSION/include' --global-option='-L$GDALINST/gdal-$GDALVERSION/lib' --global-option='-R$GDALINST/gdal-$GDALVERSION/lib' -e ."
-  - "pip install coveralls"
+  - "pip install coveralls>=1.1"
   - "pip install -e ."
 script:
   - py.test --cov rasterio --cov-report term-missing

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,11 @@
 affine
 cligj
-coveralls>=0.4
-cython>=0.23.1
+cython>=0.23.4
 delocate
 enum34
 numpy>=1.8
 snuggs>=1.2
 pytest
-pytest-cov
+pytest-cov>=2.2.0
 setuptools>=0.9.8
 wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,2 @@
-[nosetests]
-tests=rasterio/tests
-nocapture=True
-verbosity=3
-logging-filter=rasterio
-logging-level=DEBUG
-with-coverage=1
-cover-package=rasterio
+[pytest]
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,10 @@ import sys
 from setuptools import setup
 from setuptools.extension import Extension
 
+
 logging.basicConfig()
 log = logging.getLogger()
 
-# python -W all setup.py ...
-if 'all' in sys.warnoptions:
-    log.level = logging.DEBUG
 
 def check_output(cmd):
     # since subprocess.check_output doesn't exist in 2.6
@@ -39,12 +37,18 @@ def check_output(cmd):
         out, err = p.communicate()
         return out
 
+
 def copy_data_tree(datadir, destdir):
     try:
         shutil.rmtree(destdir)
     except OSError:
         pass
     shutil.copytree(datadir, destdir)
+
+
+# python -W all setup.py ...
+if 'all' in sys.warnoptions:
+    log.level = logging.DEBUG
 
 # Parse the version from the rasterio module.
 with open('rasterio/__init__.py') as f:
@@ -135,6 +139,13 @@ if not os.name == "nt":
     ext_options['extra_compile_args'] = ['-Wno-unused-parameter',
                                          '-Wno-unused-function']
 
+cythonize_options = {}
+if os.environ.get('CYTHON_COVERAGE'):
+    cythonize_options['compiler_directives'] = {'linetrace': True}
+    cythonize_options['annotate'] = True
+    ext_options['define_macros'] = [('CYTHON_TRACE', '1'),
+                                    ('CYTHON_TRACE_NOGIL', '1')]
+
 log.debug('ext_options:\n%s', pprint.pformat(ext_options))
 
 # When building from a repo, Cython is required.
@@ -164,7 +175,7 @@ if os.path.exists("MANIFEST.in") and "clean" not in sys.argv:
             'rasterio._err', ['rasterio/_err.pyx'], **ext_options),
         Extension(
             'rasterio._example', ['rasterio/_example.pyx'], **ext_options),
-        ], quiet=True)
+        ], quiet=True, **cythonize_options)
 
 # If there's no manifest template, as in an sdist, we just specify .c files.
 else:


### PR DESCRIPTION
Closes #504 

Added extra cythonize arguments, enabled by an environment variable `CYTHON_COVERAGE` set for travis (or local development, if you set that manually).  This requires updated versions of Cython and pytest-cov, so I updated those in `requirements-dev.txt`, and a `.coveragerc` file.

I also dropped `coveralls` from `requirements-dev.txt` since it is used from travis and already being installed there.

While I was at it I moved the functions toward the top of setup.py, and cleaned up `setup.cfg` which wasn't being used previously (had `nose` testing config).  

Expect coverage to drop quite a bit once this goes out, so now we have some new targets to shoot for.