### PR TITLE
rm ipython as default from rio insp docstring

### DIFF
--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -334,8 +334,6 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
 @click.pass_context
 def insp(ctx, input, mode, interpreter):
     """ Open the input file in a Python interpreter.
-
-    IPython will be used as the default interpreter, if available.
     """
     import rasterio.tool
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1


### PR DESCRIPTION
The `rio insp` docstring says 

> IPython will be used as the default interpreter, if available.

~~Let's do that!~~ Let's change the docstring since that's not the case