### PR TITLE
Added warnings for affine input / output

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -14,11 +14,11 @@ from libc.stdlib cimport malloc, free
 
 from rasterio cimport _gdal, _ogr
 from rasterio._drivers import driver_count, GDALEnv
-from rasterio._err import cpl_errs
+from rasterio._err import cpl_errs, GDALError
 from rasterio import dtypes
 from rasterio.coords import BoundingBox
 from rasterio.transform import Affine
-from rasterio.enums import ColorInterp, Compression, Interleaving, GDALError
+from rasterio.enums import ColorInterp, Compression, Interleaving
 from rasterio.vfs import parse_path, vsi_path
 
 

--- a/rasterio/_err.pyx
+++ b/rasterio/_err.pyx
@@ -29,6 +29,9 @@ manager raises a more useful and informative error:
     ValueError: The PNG driver does not support update access to existing datasets.
 """
 
+from enums import IntEnum
+
+
 # CPL function declarations.
 cdef extern from "cpl_error.h":
     int CPLGetLastErrorNo()
@@ -68,3 +71,10 @@ cdef class GDALErrCtxManager:
 
 cpl_errs = GDALErrCtxManager()
 
+
+class GDALError(IntEnum):
+    none = 0,  # CE_None
+    debug = 1,  # CE_Debug
+    warning= 2,  # CE_Warning
+    failure = 3,  # CE_Failure
+    fatal = 4  # CE_Fatal

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -17,12 +17,12 @@ from rasterio cimport _base, _gdal, _ogr, _io
 from rasterio._base import (
     crop_window, eval_window, window_shape, window_index, tastes_like_gdal)
 from rasterio._drivers import driver_count, GDALEnv
-from rasterio._err import cpl_errs
+from rasterio._err import cpl_errs, GDALError
 from rasterio import dtypes
 from rasterio.coords import BoundingBox
 from rasterio.five import text_type, string_types
 from rasterio.transform import Affine
-from rasterio.enums import ColorInterp, MaskFlags, Resampling, GDALError
+from rasterio.enums import ColorInterp, MaskFlags, Resampling
 from rasterio.sample import sample_gen
 from rasterio.vfs import parse_path
 from rasterio.warnings import NodataShadowWarning

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -22,7 +22,7 @@ from rasterio import dtypes
 from rasterio.coords import BoundingBox
 from rasterio.five import text_type, string_types
 from rasterio.transform import Affine
-from rasterio.enums import ColorInterp, MaskFlags, Resampling
+from rasterio.enums import ColorInterp, MaskFlags, Resampling, GDALError
 from rasterio.sample import sample_gen
 from rasterio.vfs import parse_path
 from rasterio.warnings import NodataShadowWarning
@@ -1450,6 +1450,14 @@ cdef class RasterUpdater(RasterReader):
     def write_transform(self, transform):
         if self._hds == NULL:
             raise ValueError("Can't read closed raster file")
+
+        if [abs(v) for v in transform] == [0, 1, 0, 0, 0, 1]:
+            warnings.warn(
+                "Dataset uses default geotransform (Affine.identity). "
+                "No tranform will be written to the output by GDAL.",
+                UserWarning
+            )
+
         cdef double gt[6]
         for i in range(6):
             gt[i] = transform[i]

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -52,11 +52,3 @@ class MaskFlags(IntEnum):
     per_dataset=2
     alpha=4
     nodata=8
-
-
-class GDALError(IntEnum):
-    none = 0,  # CE_None
-    debug = 1,  # CE_Debug
-    warning= 2,  # CE_Warning
-    failure = 3,  # CE_Failure
-    fatal = 4  # CE_Fatal

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -52,3 +52,11 @@ class MaskFlags(IntEnum):
     per_dataset=2
     alpha=4
     nodata=8
+
+
+class GDALError(IntEnum):
+    none = 0,  # CE_None
+    debug = 1,  # CE_Debug
+    warning= 2,  # CE_Warning
+    failure = 3,  # CE_Failure
+    fatal = 4  # CE_Fatal

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,3 +1,5 @@
+from affine import Affine
+import pytest
 import rasterio
 from rasterio import transform
 
@@ -74,3 +76,47 @@ def test_window_bounds():
 
             for e, a in zip(expected, actual):
                 assert round(e, 7) == round(a, 7)
+
+
+def test_affine_roundtrip(tmpdir):
+    output = str(tmpdir.join('test.tif'))
+    out_affine = Affine(2, 0, 0, 0, -2, 0)
+
+    with rasterio.open(
+        output, 'w',
+        driver='GTiff',
+        count=1,
+        dtype=rasterio.uint8,
+        width=1,
+        height=1,
+        transform=out_affine
+    ) as out:
+        assert out.affine == out_affine
+
+    with rasterio.open(output) as out:
+        assert out.affine == out_affine
+
+
+def test_affine_identity(tmpdir):
+    """
+    Setting a transform with absolute values equivalent to Affine.identity()
+    should result in a warning (not captured here) and read with
+    affine that matches Affine.identity().
+    """
+
+    output = str(tmpdir.join('test.tif'))
+    out_affine = Affine(1, 0, 0, 0, -1, 0)
+
+    with rasterio.open(
+        output, 'w',
+        driver='GTiff',
+        count=1,
+        dtype=rasterio.uint8,
+        width=1,
+        height=1,
+        transform=out_affine
+    ) as out:
+        assert out.affine == out_affine
+
+    with rasterio.open(output) as out:
+        assert out.affine == Affine.identity()


### PR DESCRIPTION
This also adds an enum for GDAL errors, and specifically checks one of those on attempting to read affine.

Warnings could not be tested in this case; the tests pass when run individually, but fail when run as a suite.

I modified @perrygeo 's failing test from `affine_roundtrip` branch for use here.