### PR TITLE
Fix boundless offsets

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -865,9 +865,9 @@ cdef class RasterReader(_base.DatasetReader):
                 roff = 0
                 coff = 0
                 if window[0][0] < 0:
-                    roff = (0 - window[0][0]) * scaling_h
+                    roff = -window[0][0] * scaling_h
                 if window[1][0] < 0:
-                    coff = (0 - window[1][0]) * scaling_w
+                    coff = -window[1][0] * scaling_w
 
                 for dst, src in zip(
                         out if len(out.shape) == 3 else [out],

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -865,9 +865,9 @@ cdef class RasterReader(_base.DatasetReader):
                 roff = 0
                 coff = 0
                 if window[0][0] < 0:
-                    roff = int(round(window_h*scaling_h)) - data_h
+                    roff = (0 - window[0][0]) * scaling_h
                 if window[1][0] < 0:
-                    coff = int(round(window_w*scaling_w)) - data_w
+                    coff = (0 - window[1][0]) * scaling_w
 
                 for dst, src in zip(
                         out if len(out.shape) == 3 else [out],

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -84,3 +84,20 @@ def test_read_boundless_masks_zero_stop():
         data = src.read_masks(window=((-200, 0), (-200, 0)), boundless=True)
         assert data.shape == (3, 200, 200)
         assert data.min() == data.max() == src.nodata
+
+def test_read_boundless_noshift():
+    with rasterio.open('tests/data/rgb4.tif') as src:
+        # the read offsets should be determined by start col/row alone
+        # when col stop exceeds image width
+        c1 = src.read(boundless=True,
+                      window=((100, 101), (-1, src.shape[1])))[0, 0, 0:9]
+        c2 = src.read(boundless=True,
+                      window=((100, 101), (-1, src.shape[1] + 1)))[0, 0, 0:9]
+        assert numpy.array_equal(c1, c2)
+
+        # when row stop exceeds image height
+        r1 = src.read(boundless=True,
+                      window=((-1, src.shape[0]), (100, 101)))[0, 0, 0:9]
+        r2 = src.read(boundless=True,
+                      window=((-1, src.shape[0] + 1), (100, 101)))[0, 0, 0:9]
+        assert numpy.array_equal(r1, r2)


### PR DESCRIPTION
Closes #532 

In determining where to put the valid data in the output array of a boundless read, this fixes the offsets to be dependent only on the col/row start.

Ready to merge.

/cc @sgillies @dnomadb 