### PR TITLE
Added vfs to imports in __init__.py

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -17,7 +17,7 @@ from rasterio.transform import Affine, guard_transform
 
 # These modules are imported from the Cython extensions, but are also import
 # here to help tools like cx_Freeze find them automatically
-from rasterio import _err, coords, enums
+from rasterio import _err, coords, enums, vfs
 
 # Classes in rasterio._io are imported below just before we need them.
 


### PR DESCRIPTION
The new `vfs.py` needs to be imported in __init__ for cx_Freeze/PyInstaller/etc to automatically detect it.