### PR TITLE
s/read_band/read/ throughout docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ using Python.
 
     $ rio insp tests/data/RGB.byte.tif
     Rasterio 0.10 Interactive Inspector (Python 3.4.1)
-    Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.meta", "src.read(1)", or "help(src)" for more information.
     >>> src.name
     'tests/data/RGB.byte.tif'
     >>> src.closed

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -373,7 +373,7 @@ The ``insp`` command opens a dataset and an interpreter.
 
     $ rio insp tests/data/RGB.byte.tif
     Rasterio 0.18 Interactive Inspector (Python 2.7.9)
-    Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.meta", "src.read(1)", or "help(src)" for more information.
     >>> print src.name
     tests/data/RGB.byte.tif
     >>> print src.bounds

--- a/docs/colormaps.rst
+++ b/docs/colormaps.rst
@@ -14,7 +14,7 @@ to bands using the ``write_colormap()`` method.
     with rasterio.drivers():
 
         with rasterio.open('tests/data/shade.tif') as src:
-            shade = src.read_band(1)
+            shade = src.read(1)
             meta = src.meta
 
         with rasterio.open('/tmp/colormap.tif', 'w', **meta) as dst:

--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -76,8 +76,6 @@ Here is the program in examples/concurrent-cpu-bound.py.
                 with rasterio.open(outfile, 'w', **meta) as dst:
 
                     # Define a generator for data, window pairs.
-                    # We use the new read() method here to a 3D array with all
-                    # bands, but could also use read_band().
                     def jobs():
                         for ij, window in dst.block_windows():
                             data = src.read(window=window)

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -89,7 +89,7 @@ a file can be read like this:
 
 .. code-block:: pycon
 
-    >>> dataset.read_band(1)
+    >>> dataset.read(1)
     array([[0, 0, 0, ..., 0, 0, 0],
            [0, 0, 0, ..., 0, 0, 0],
            [0, 0, 0, ..., 0, 0, 0],
@@ -106,7 +106,7 @@ elsewhere.
 .. code-block::
 
     >>> from matplotlib import pyplot
-    >>> pyplot.imshow(dataset.read_band(1), cmap='pink')
+    >>> pyplot.imshow(dataset.read(1), cmap='pink')
     <matplotlib.image.AxesImage object at 0x111195c10>
     >>> pyplot.show()
 
@@ -136,7 +136,7 @@ After it's closed, data can no longer be read.
 
 .. code-block:: pycon
 
-    >>> dataset.read_band(1)
+    >>> dataset.read(1)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     ValueError: can't read closed raster file

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -23,7 +23,7 @@ The shapes of the foreground features can be extracted like this:
     from rasterio import features
 
     with rasterio.open('13547682814_f2e459f7a5_o_d.png') as src:
-        blue = src.read_band(3)
+        blue = src.read(3)
 
     mask = blue != 255
     shapes = features.shapes(blue, mask=mask)

--- a/docs/georeferencing.rst
+++ b/docs/georeferencing.rst
@@ -16,7 +16,7 @@ Rasterio distribution root to see.
 .. code-block:: pycon
 
     Rasterio 0.9 Interactive Inspector (Python 3.4.1)
-    Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.meta", "src.read(1)", or "help(src)" for more information.
     >>> src
     <open RasterReader name='tests/data/RGB.byte.tif' mode='r'>
     >>> src.crs

--- a/docs/masks.rst
+++ b/docs/masks.rst
@@ -29,7 +29,7 @@ inverse relationship in the context of RGB.byte.tif.
 
     $ rio insp tests/data/RGB.byte.tif
     Rasterio 0.19.0 Interactive Inspector (Python 2.7.9)
-    Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.meta", "src.read(1)", or "help(src)" for more information.
     >>> src.shape
     (718, 791)
     >>> src.count
@@ -99,7 +99,7 @@ copy of the test data opened using rio-insp in "r+" (update) mode.
 
     $ rio insp copy.tif --mode r+
     Rasterio 0.19.0 Interactive Inspector (Python 2.7.9)
-    Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.meta", "src.read(1)", or "help(src)" for more information.
     >>>
 
 To mark that all pixels of all bands are valid (i.e., to override nodata
@@ -132,7 +132,7 @@ as an RGB image (with the help of `numpy.dstack()`):
 
     $rio insp copy.tif --mode r+
     Rasterio 0.19.0 Interactive Inspector (Python 2.7.9)
-    Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.meta", "src.read(1)", or "help(src)" for more information.
     >>> msk = src.read_masks()
     >>> show(np.dstack(msk))
 
@@ -179,7 +179,7 @@ If you want, you can read dataset bands as numpy masked arrays.
 
     $ rio insp tests/data/RGB.byte.tif
     Rasterio 0.19.0 Interactive Inspector (Python 2.7.9)
-    Type "src.meta", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.meta", "src.read(1)", or "help(src)" for more information.
     >>> blue = src.read(1, masked=True)
     >>> blue.mask
     array([[ True,  True,  True, ...,  True,  True,  True],

--- a/docs/tags.rst
+++ b/docs/tags.rst
@@ -15,7 +15,7 @@ I'm going to use the rasterio interactive inspector in these examples below.
 
     $ rasterio.insp tests/data/RGB.byte.tif
     Rasterio 0.6 Interactive Inspector (Python 2.7.5)
-    Type "src.name", "src.read_band(1)", or "help(src)" for more information.
+    Type "src.name", "src.read(1)", or "help(src)" for more information.
     >>> 
 
 Tags belong to namespaces. To get a copy of a dataset's tags from the default

--- a/docs/windowed-rw.rst
+++ b/docs/windowed-rw.rst
@@ -67,7 +67,7 @@ test file.
 
     >>> import rasterio
     >>> with rasterio.open('tests/data/RGB.byte.tif') as src:
-    ...     w = src.read_band(1, window=((0, 100), (0, 100)))
+    ...     w = src.read(1, window=((0, 100), (0, 100)))
     ...
     >>> print(w.shape)
     (100, 100)
@@ -104,7 +104,7 @@ Below, the window is scaled to one third of the source image.
 .. code-block:: python
 
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        b, g, r = (src.read_band(k) for k in (1, 2, 3))
+        b, g, r = (src.read(k) for k in (1, 2, 3))
     
     write_window = (30, 269), (50, 313)
     
@@ -144,7 +144,7 @@ destination dataset.
     read_window = (350, 410), (350, 450)
     
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        b, g, r = (src.read_band(k, window=read_window) for k in (1, 2, 3))
+        b, g, r = (src.read(k, window=read_window) for k in (1, 2, 3))
     
     write_window = (-240, None), (-400, None)
     
@@ -242,7 +242,7 @@ The block windows themselves can be had from the block_windows function.
     ...
 
 This function returns an iterator that yields a pair of values. The second is
-a window tuple that can be used in calls to read_band or write_band. The first
+a window tuple that can be used in calls to `read` or `write_band`. The first
 is the pair of row and column indexes of this block within all blocks of the
 dataset.
 
@@ -252,7 +252,7 @@ You may read windows of data from a file block-by-block like this.
 
     >>> with rasterio.open('tests/data/RGB.byte.tif') as src:
     ...     for ji, window in src.block_windows(1):
-    ...         r = src.read_band(1, window=window)
+    ...         r = src.read(1, window=window)
     ...         print(r.shape)
     ...         break
     ...
@@ -266,7 +266,7 @@ it's a good idea to test this assumption in your code.
     >>> with rasterio.open('tests/data/RGB.byte.tif') as src:
     ...     assert len(set(src.block_shapes)) == 1
     ...     for ji, window in src.block_windows(1):
-    ...         b, g, r = (src.read_band(k, window=window) for k in (1, 2, 3))
+    ...         b, g, r = (src.read(k, window=window) for k in (1, 2, 3))
     ...         print(ji, r.shape, g.shape, b.shape)
     ...         break
     ...

--- a/examples/concurrent-cpu-bound.py
+++ b/examples/concurrent-cpu-bound.py
@@ -32,8 +32,6 @@ def main(infile, outfile, num_workers=4):
             with rasterio.open(outfile, 'w', **meta) as dst:
 
                 # Define a generator for data, window pairs.
-                # We use the new read() method here to a 3D array with all
-                # bands, but could also use read_band().
                 def jobs():
                     for ij, window in dst.block_windows():
                         data = src.read(window=window)

--- a/examples/decimate.py
+++ b/examples/decimate.py
@@ -7,7 +7,7 @@ import rasterio
 with rasterio.drivers():
 
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        b, g, r = (src.read_band(k) for k in (1, 2, 3))
+        b, g, r = (src.read(k) for k in (1, 2, 3))
         meta = src.meta
 
     tmpfilename = os.path.join(tempfile.mkdtemp(), 'decimate.tif')

--- a/examples/rasterio_polygonize.py
+++ b/examples/rasterio_polygonize.py
@@ -20,7 +20,7 @@ def main(raster_file, vector_file, driver, mask_value):
     with rasterio.drivers():
         
         with rasterio.open(raster_file) as src:
-            image = src.read_band(1)
+            image = src.read(1)
         
         if mask_value is not None:
             mask = image == mask_value

--- a/examples/sieve.py
+++ b/examples/sieve.py
@@ -14,7 +14,7 @@ with rasterio.drivers():
     
     # Read a raster to be sieved.
     with rasterio.open('tests/data/shade.tif') as src:
-        shade = src.read_band(1)
+        shade = src.read(1)
     
     # Print the number of shapes in the source raster.
     print("Slope shapes: %d" % len(list(shapes(shade))))

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -358,7 +358,7 @@ cdef class DatasetReader(object):
         indexes.
 
         The primary use of this function is to obtain windows to pass to
-        read_band() for highly efficient access to raster block data.
+        read() for highly efficient access to raster block data.
         """
         cdef int i, j
         block_shapes = self.block_shapes

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -524,7 +524,7 @@ def rasterize(
                     fill = fill)
 
                 for bidx in range(1, meta['count'] + 1):
-                    data = out.read_band(bidx, masked=True)
+                    data = out.read(bidx, masked=True)
                     # Burn in any non-fill pixels, and update mask accordingly
                     ne = result != fill
                     data[ne] = result[ne]


### PR DESCRIPTION
... because read_band is deprecated.  This PR does not remove the read_band function itself or its tests.

Small progress toward #516