### PR TITLE
Document rasterize's "fill".

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -72,7 +72,9 @@ image to be created.
                 transform=src.transform)
 
 The values for the input shapes are replaced with ``255`` in a generator
-expression. The resulting image, written to disk like this,
+expression. Areas not covered by input geometries are replaced with an
+optional ``fill`` value, which defaults to ``0``. The resulting image,
+written to disk like this,
 
 .. code-block:: python
 


### PR DESCRIPTION
A silly little thing... for some reason I always go to the online docs when I need to rasterize, and time after time I always forget that I don't want the 0 default for NODATA.  I hope this change jogs my memory next time.  Hopefully others will find this note helpful.