### PR TITLE
masking function within rasterio

### DIFF
--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -2,8 +2,8 @@ import json
 import logging
 from math import ceil
 import os
-import shutil
 import re
+import shutil
 
 import click
 import cligj
@@ -135,9 +135,9 @@ def mask(
 
         with rasterio.open(input) as src:
             try:
-                out_image, out_transform = mask_tool(src, geometries, crop=crop,
-                                                     all_touched=all_touched,
-                                                     invert=invert)
+                out_image, out_transform = mask_tool(src, geometries,
+                                                     crop=crop, invert=invert,
+                                                     all_touched=all_touched)
             except ValueError as e:
                 if e.args[0] == 'Input shapes do not overlap raster.':
                     if crop:
@@ -145,11 +145,6 @@ def mask(
                                                  'outside the extent of the '
                                                  'input raster',                                                                 param=crop,
                                                  param_hint='--crop')
-#                    else:
-#                        click.echo('GeoJSON outside bounds of existing output '
-#                                   'raster. Are they in different coordinate '
-#                                   'reference systems?',
-#                                   err=True)
 
             meta = src.meta.copy()
             meta.update(**creation_options)

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -99,6 +99,7 @@ def mask(
     from rasterio.features import bounds as calculate_bounds
 
     verbosity = (ctx.obj and ctx.obj.get('verbosity')) or 1
+    logger = logging.getLogger('rio')
 
     output, files = resolve_inout(
         files=files, output=output, force_overwrite=force_overwrite)
@@ -138,17 +139,17 @@ def mask(
                                                      all_touched=all_touched,
                                                      invert=invert)
             except ValueError as e:
-                if e.args[0] == "Input shapes do not overlap raster.":
+                if e.args[0] == 'Input shapes do not overlap raster.':
                     if crop:
                         raise click.BadParameter('not allowed for GeoJSON '
                                                  'outside the extent of the '
                                                  'input raster',                                                                 param=crop,
                                                  param_hint='--crop')
-                    else:
-                        click.echo('GeoJSON outside bounds of existing output '
-                                   'raster. Are they in different coordinate '
-                                   'reference systems?',
-                                   err=True)
+#                    else:
+#                        click.echo('GeoJSON outside bounds of existing output '
+#                                   'raster. Are they in different coordinate '
+#                                   'reference systems?',
+#                                   err=True)
 
             meta = src.meta.copy()
             meta.update(**creation_options)

--- a/rasterio/tools/mask.py
+++ b/rasterio/tools/mask.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 
+import warnings
+
 import rasterio
 from rasterio.features import geometry_mask
+
 
 def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
          invert=False):
@@ -22,7 +25,8 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
         defaults to the nodata value for the input raster. If there is no
         set nodata value for the raster, it defaults to 0.
     crop: bool (opt)
-        Whether to crop the raster to the extent of the data. Defaults to True.
+        Whether to crop the raster to the extent of the data. Defaults to
+        False.
     all_touched: bool (opt)
         Use all pixels touched by features. If False (default), use only
         pixels whose center is within the polygon or that are selected by
@@ -61,9 +65,9 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
         if crop:
             raise ValueError("Input shapes do not overlap raster.")
         else:
-            print("GeoJSON outside bounds of existing output " +
-                  "raster. Are they in different coordinate " +
-                  "reference systems?")
+            warnings.warn("GeoJSON outside bounds of existing output " +
+                          "raster. Are they in different coordinate " +
+                          "reference systems?")
     if invert_y:
         mask_bounds = [mask_bounds[0], mask_bounds[3],
                        mask_bounds[2], mask_bounds[1]]
@@ -80,6 +84,7 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
     shape_mask = geometry_mask(shapes, transform=out_transform, invert=invert,
                                out_shape=out_shape, all_touched=all_touched)
     out_image.mask = out_image.mask | shape_mask
+    out_image.fill_value = nodata
 
     for i in range(raster.count):
         out_image[i] = out_image[i].filled(nodata)

--- a/rasterio/tools/mask.py
+++ b/rasterio/tools/mask.py
@@ -9,24 +9,24 @@ def mask(raster, shapes, nodatavals=None, crop=True):
 
     Parameters
     ----------
-    source : rasterio RasterReader object
+    source: rasterio RasterReader object
         Raster to which the mask will be applied.
-    shapes : generator of (polygon, value)
+    shapes: generator of (polygon, value)
         Polygons are GeoJSON-like dicts specifying the boundaries of features
         in the raster to be kept. All data outside of specified polygons
         will be set to nodata.
-    nodatavals : list (opt)
+    nodatavals: list (opt)
         Value representing nodata within each raster band. If not set,
         defaults to the nodatavals for the input raster. If those values
         are not set, defaults to 0.
-    crop : bool (opt)
+    crop: bool (opt)
         Whether to crop the raster to the extent of the data. Defaults to True.
 
     Returns
     -------
-    masked : numpy ndarray
+    masked: numpy ndarray
         Data contained in raster after applying the mask.
-    out_transform : affine object
+    out_transform: affine object
         Information for mapping pixel coordinates in `masked` to another
         coordinate system.
     """

--- a/rasterio/tools/mask.py
+++ b/rasterio/tools/mask.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import
+
+import rasterio
+
+def mask(raster, shapes, nodatavals=None, crop=True):
+    """
+    For all regions in the input raster outside of the regions defined by
+    `shapes`, sets any data present to nodata.
+
+    Parameters
+    ----------
+    source : rasterio RasterReader object
+        Raster to which the mask will be applied.
+    shapes : generator of (polygon, value)
+        Polygons are GeoJSON-like dicts specifying the boundaries of features
+        in the raster to be kept. All data outside of specified polygons
+        will be set to nodata.
+    nodatavals : list (opt)
+        Value representing nodata within each raster band. If not set,
+        defaults to the nodatavals for the input raster. If those values
+        are not set, defaults to 0.
+    crop : bool (opt)
+        Whether to crop the raster to the extent of the data. Defaults to True.
+
+    Returns
+    -------
+    masked : numpy ndarray
+        Data contained in raster after applying the mask.
+    out_transform : affine object
+        Information for mapping pixel coordinates in `masked` to another
+        coordinate system.
+    """
+
+    # I'm not sure how good this no data handling will be generally
+    if nodatavals is None:
+        if raster.nodata is not None:
+            nodatavals = raster.nodatavals
+        else:
+            nodatavals = [0] * raster.count
+
+    # consume shapes twice, so convert to list
+    shapes = list(shapes)
+    all_bounds = [rasterio.features.bounds(shape[0]) for shape in shapes]
+    minxs, minys, maxxs, maxys = zip(*all_bounds)
+    mask_bounds = (min(minxs), min(minys), max(maxxs), max(maxys))
+
+    if rasterio.coords.disjoint_bounds(raster.bounds, mask_bounds):
+        raise ValueError("Input shapes do not overlap raster.")
+
+    if crop:
+        out_bounds = mask_bounds
+    else:
+        out_bounds = raster.bounds
+    window = raster.window(*out_bounds)
+    out_transform = raster.window_transform(window)
+    masked = raster.read(window=window)
+    out_shape = masked.shape[1:]
+
+    shape_mask = rasterio.features.rasterize(shapes, transform=out_transform,
+                                             out_shape=out_shape)
+    shape_mask = shape_mask.astype("bool")
+    for i in range(raster.count):
+        masked[i, ~shape_mask] = nodatavals[i]
+
+    return masked, out_transform

--- a/rasterio/tools/mask.py
+++ b/rasterio/tools/mask.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import rasterio
 from rasterio.features import geometry_mask
 
-def mask(raster, shapes, nodatavals=None, crop=False, all_touched=False,
+def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
          invert=False):
     """
     For all regions in the input raster outside of the regions defined by
@@ -17,10 +17,10 @@ def mask(raster, shapes, nodatavals=None, crop=False, all_touched=False,
         Polygons are GeoJSON-like dicts specifying the boundaries of features
         in the raster to be kept. All data outside of specified polygons
         will be set to nodata.
-    nodatavals: list (opt)
+    nodata: int or float (opt)
         Value representing nodata within each raster band. If not set,
-        defaults to the nodatavals for the input raster. If those values
-        are not set, defaults to 0.
+        defaults to the nodata value for the input raster. If there is no
+        set nodata value for the raster, it defaults to 0.
     crop: bool (opt)
         Whether to crop the raster to the extent of the data. Defaults to True.
     all_touched: bool (opt)
@@ -43,11 +43,11 @@ def mask(raster, shapes, nodatavals=None, crop=False, all_touched=False,
     if crop and invert:
         raise ValueError("crop and invert cannot both be True.")
     # I'm not sure how good this no data handling will be generally
-    if nodatavals is None:
+    if nodata is None:
         if raster.nodata is not None:
-            nodatavals = raster.nodatavals
+            nodata = raster.nodata
         else:
-            nodatavals = [0] * raster.count
+            nodata = 0
 
     all_bounds = [rasterio.features.bounds(shape) for shape in shapes]
     minxs, minys, maxxs, maxys = zip(*all_bounds)
@@ -81,6 +81,6 @@ def mask(raster, shapes, nodatavals=None, crop=False, all_touched=False,
     out_image.mask = out_image.mask | shape_mask
 
     for i in range(raster.count):
-        out_image[i] = out_image[i].filled(nodatavals[i])
+        out_image[i] = out_image[i].filled(nodata)
 
     return out_image, out_transform

--- a/rasterio/tools/mask.py
+++ b/rasterio/tools/mask.py
@@ -64,11 +64,9 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
         mask_bounds = [mask_bounds[0], mask_bounds[3],
                        mask_bounds[2], mask_bounds[1]]
     if crop:
-        out_bounds = mask_bounds
-        window = raster.window(*out_bounds)
+        window = raster.window(*mask_bounds)
         out_transform = raster.window_transform(window)
     else:
-        out_bounds = source_bounds
         window = None
         out_transform = raster.affine
 

--- a/rasterio/tools/mask.py
+++ b/rasterio/tools/mask.py
@@ -42,7 +42,6 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
 
     if crop and invert:
         raise ValueError("crop and invert cannot both be True.")
-    # I'm not sure how good this no data handling will be generally
     if nodata is None:
         if raster.nodata is not None:
             nodata = raster.nodata
@@ -59,7 +58,12 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
         source_bounds = [source_bounds[0], source_bounds[3],
                          source_bounds[2], source_bounds[1]]
     if rasterio.coords.disjoint_bounds(source_bounds, mask_bounds):
-        raise ValueError("Input shapes do not overlap raster.")
+        if crop:
+            raise ValueError("Input shapes do not overlap raster.")
+        else:
+            print("GeoJSON outside bounds of existing output " +
+                  "raster. Are they in different coordinate " +
+                  "reference systems?")
     if invert_y:
         mask_bounds = [mask_bounds[0], mask_bounds[3],
                        mask_bounds[2], mask_bounds[1]]
@@ -73,7 +77,6 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
     out_image = raster.read(window=window, masked=True)
     out_shape = out_image.shape[1:]
 
-    # using rasterize instead of geometry_mask gets correct behavior
     shape_mask = geometry_mask(shapes, transform=out_transform, invert=invert,
                                out_shape=out_shape, all_touched=all_touched)
     out_image.mask = out_image.mask | shape_mask

--- a/rasterio/tools/mask.py
+++ b/rasterio/tools/mask.py
@@ -41,7 +41,7 @@ def mask(raster, shapes, nodatavals=None, crop=False, all_touched=False,
     """
 
     if crop and invert:
-        invert = False
+        raise ValueError("crop and invert cannot both be True.")
     # I'm not sure how good this no data handling will be generally
     if nodatavals is None:
         if raster.nodata is not None:
@@ -49,7 +49,6 @@ def mask(raster, shapes, nodatavals=None, crop=False, all_touched=False,
         else:
             nodatavals = [0] * raster.count
 
-    shapes = [shape for shape in shapes] 
     all_bounds = [rasterio.features.bounds(shape) for shape in shapes]
     minxs, minys, maxxs, maxys = zip(*all_bounds)
     mask_bounds = (min(minxs), min(minys), max(maxxs), max(maxys))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,42 @@ def diagonal_image():
 
 
 @pytest.fixture()
+def basic_image_file(tmpdir, basic_image):
+    """
+    A basic raster file with a 10x10 array for testing sieve functions.
+    Contains data from pixelated_image.
+
+    Returns
+    -------
+
+    string
+        Filename of test raster file
+    """
+
+    from affine import Affine
+    import rasterio
+
+    image = basic_image
+
+    outfilename = str(tmpdir.join('basic_image.tif'))
+    kwargs = {
+        "crs": {'init': 'epsg:4326'},
+        "transform": Affine.identity(),
+        "count": 1,
+        "dtype": rasterio.uint8,
+        "driver": "GTiff",
+        "width": image.shape[1],
+        "height": image.shape[0],
+        "nodata": None
+    }
+    with rasterio.drivers():
+        with rasterio.open(outfilename, 'w', **kwargs) as out:
+            out.write_band(1, image)
+
+    return outfilename
+
+
+@pytest.fixture()
 def pixelated_image_file(tmpdir, pixelated_image):
     """
     A basic raster file with a 10x10 array for testing sieve functions.

--- a/tests/test_tools_mask.py
+++ b/tests/test_tools_mask.py
@@ -1,0 +1,51 @@
+import pytest
+
+import rasterio
+from rasterio.tools.mask import mask as mask_tool
+
+
+def test_nodata(basic_image_file, basic_geometry):
+    nodata_val = 0
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, crop=False,
+                                      nodata=nodata_val, invert=True)
+    assert(masked.data.all() == nodata_val)
+
+
+def test_no_nodata(basic_image_file, basic_geometry):
+    default_nodata_val = 0
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, crop=False, invert=True)
+    assert(masked.data.all() == default_nodata_val)
+
+
+def test_crop(basic_image, basic_image_file, basic_geometry):
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, crop=True)
+
+    image = basic_image
+    image[4, :] = 0
+    image[:, 4] = 0
+    assert(masked.shape == (1, 4, 3))
+    assert((masked[0] == image[1:5, 2:5]).all())
+
+
+def test_crop_all_touched(basic_image, basic_image_file, basic_geometry):
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, crop=True,
+                                      all_touched=True)
+
+    assert(masked.shape == (1, 4, 3))
+    assert((masked[0] == basic_image[1:5, 2:5]).all())
+
+
+def test_crop_and_invert(basic_image_file, basic_geometry):
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file) as src:
+        with pytest.raises(ValueError):
+            masked, transform = mask_tool(src, geometries,
+                                          crop=True, invert=True)


### PR DESCRIPTION
Before putting together this pull request, I thought I had seen some sort of masking utility, but didn't find it. Now, as I write the summary, I discovered that it is in `rio.features`, rather than `rio.clip` as I had guessed. So maybe if you all are interested in something like this, it will look more like the `rio.features.mask` function than what I've got right now.

Anyway, I've added a function for use in python that applies the geo-JSON-like `shapes` from `rasterio.features.shapes` to a raster as a mask, setting all pixels outside of the region defined by shapes to be no data. I do so in the spirit of @sgillies suggestion to commit early and solicit comments. Aside from the possible DRY issue that I noted above, I'm not so sure about where I've put this function, nor about how I'm handling nodata.

Test case, removing all pixels where the first channel has a value less than 30: 
    `>>> import rasterio, rasterio.features, rasterio.tools.mask`
    `>>> raster = rasterio.open("RGB.byte.tif")`
    `>>> shapes = rasterio.features.shapes(raster.read(1))`
    `>>> mask_shapes = [shape for shape in shapes if shape[1] > 30]`
    `>>> masked, out_transform = rasterio.tools.mask.mask(raster, mask_shapes)`

I haven't added any tests yet. I'll get working on that if you are interested in incorporating some version of this pull request.