### PR TITLE
Use raster bounds to set extent in rasterio.tool.show.

### DIFF
--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -22,21 +22,37 @@ Stats = collections.namedtuple('Stats', ['min', 'max', 'mean'])
 funcs = locals()
 
 
-def show(source, cmap='gray'):
-    """Show a raster using matplotlib.
-
-    The raster may be either an ndarray or a (dataset, bidx)
-    tuple.
+def show(source, cmap='gray', with_bounds=True):
     """
+    Display a raster or raster band using matplotlib.
+
+    Parameters
+    ----------
+    source : array-like or (raster dataset, bidx)
+        If array-like, should be of format compatible with
+        matplotlib.pyplot.imshow. If the tuple (raster dataset, bidx),
+        selects band `bidx` from raster.
+    cmap : str (opt)
+        Specifies the colormap to use in plotting. See
+        matplotlib.Colors.Colormap. Default is 'gray'.
+    with_bounds : bool (opt)
+        Whether to change the image extent to the spatial bounds of the image,
+        rather than pixel coordinates. Only works when source is
+        (raster dataset, bidx).
+    """
+
     if isinstance(source, tuple):
         arr = source[0].read(source[1])
         xs = source[0].res[0] / 2.
         ys = source[0].res[1] / 2.
-        extent = (source[0].bounds.left - xs, source[0].bounds.right - xs,
-                  source[0].bounds.bottom - ys, source[0].bounds.top - ys)
+        if with_bounds:
+            extent = (source[0].bounds.left - xs, source[0].bounds.right - xs,
+                      source[0].bounds.bottom - ys, source[0].bounds.top - ys)
+        else:
+            extent = None
     else:
         arr = source
-        extent = (-0.5, arr.shape[1] - 0.5, arr.shape[0] - 0.5, -0.5)
+        extent = None
     if plt is not None:
         plt.imshow(arr, cmap=cmap, extent=extent)
         plt.show()

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -30,10 +30,15 @@ def show(source, cmap='gray'):
     """
     if isinstance(source, tuple):
         arr = source[0].read(source[1])
+        xs = source[0].res[0] / 2.
+        ys = source[0].res[1] / 2.
+        extent = (source[0].bounds.left - xs, source[0].bounds.right - xs,
+                  source[0].bounds.bottom - ys, source[0].bounds.top - ys)
     else:
         arr = source
+        extent = (-0.5, arr.shape[1] - 0.5, arr.shape[0] - 0.5, -0.5)
     if plt is not None:
-        plt.imshow(arr, cmap=cmap)
+        plt.imshow(arr, cmap=cmap, extent=extent)
         plt.show()
     else:
         raise ImportError("matplotlib could not be imported")

--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -54,8 +54,9 @@ def show(source, cmap='gray', with_bounds=True):
         arr = source
         extent = None
     if plt is not None:
-        plt.imshow(arr, cmap=cmap, extent=extent)
-        plt.show()
+        imax = plt.imshow(arr, cmap=cmap, extent=extent)
+        fig = plt.gcf()
+        fig.show()
     else:
         raise ImportError("matplotlib could not be imported")
 
@@ -137,7 +138,8 @@ def show_hist(source, bins=10, masked=True, title='Histogram'):
     plt.grid(True)
     plt.xlabel('DN')
     plt.ylabel('Frequency')
-    plt.show()
+    fig = plt.gcf()
+    fig.show()
 
 
 def main(banner, dataset, alt_interpreter=None):

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -8,7 +8,6 @@ except ImportError:
 import rasterio
 from rasterio.tool import show, show_hist, stats
 
-
 def test_stats():
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
@@ -21,25 +20,50 @@ def test_stats():
             assert np.allclose(np.array(results), np.array(results2))
 
 
-def test_show():
+def test_show_raster():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    if plt:
-        # Return because plotting causes the tests to block until the plot
-        # window is closed.
-        return
 
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             try:
                 show((src, 1))
+                fig = plt.gcf()
+                plt.close(fig)
             except ImportError:
                 pass
 
+
+def test_show_raster_no_bounds():
+    """
+    This test only verifies that code up to the point of plotting with
+    matplotlib works correctly.  Tests do not exercise matplotlib.
+    """
+
+    with rasterio.drivers():
+        with rasterio.open('tests/data/RGB.byte.tif') as src:
+            try:
+                show((src, 1), with_bounds=False)
+                fig = plt.gcf()
+                plt.close(fig)
+            except ImportError:
+                pass
+
+
+def test_show_array():
+    """
+    This test only verifies that code up to the point of plotting with
+    matplotlib works correctly.  Tests do not exercise matplotlib.
+    """
+
+    with rasterio.drivers():
+        with rasterio.open('tests/data/RGB.byte.tif') as src:
             try:
                 show(src.read(1))
+                fig = plt.gcf()
+                plt.close(fig)
             except ImportError:
                 pass
 
@@ -49,17 +73,18 @@ def test_show_hist():
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    if plt:
-        # Return because plotting causes the tests to block until the plot
-        # window is closed.
-        return
+
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show_hist((src, 1), bins=256)
+            fig = plt.gcf()
+            plt.close(fig)
         except ImportError:
             pass
 
         try:
             show_hist(src.read(), bins=256)
+            fig = plt.gcf()
+            plt.close(fig)
         except ImportError:
             pass


### PR DESCRIPTION
When (dataset, bidx) is passed into `rasterio.tool.show`, uses the bounds of the dataset to set the extent accordingly, so that the matplotlib figure shows world coordinates, rather than pixel coordinates. In case of a numpy array, simply uses pixel coordinates.