### PR TITLE
Use transform_bounds to compute rio bounds

### DIFF
--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -642,7 +642,7 @@ def rasterize(
 @click.command(short_help="Write bounding boxes to stdout as GeoJSON.")
 # One or more files, the bounds of each are a feature in the collection
 # object or feature sequence.
-@click.argument('INPUT', nargs=-1, type=click.Path(exists=True))
+@click.argument('INPUT', nargs=-1, type=click.Path(exists=True), required=True)
 @precision_opt
 @indent_opt
 @compact_opt

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -694,13 +694,16 @@ def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
                 with rasterio.open(path) as src:
                     bounds = src.bounds
                     if dst_crs:
-                        bbox = bounds
+                        bbox = transform_bounds(src.crs,
+                                                dst_crs, *bounds)
                     elif projection == 'mercator':
                         bbox = transform_bounds(src.crs,
                                                 {'init': 'epsg:3857'}, *bounds)
                     elif projection == 'geographic':
                         bbox = transform_bounds(src.crs,
                                                 {'init': 'epsg:4326'}, *bounds)
+                    else:
+                        bbox = bounds
 
                 if precision >= 0:
                     bbox = [round(b, precision) for b in bbox]

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -482,7 +482,7 @@ def test_bounds_obj_bbox():
         '--precision', '2'
     ])
     assert result.exit_code == 0
-    assert result.output.strip() == '[-78.9, 23.56, -76.6, 25.55]'
+    assert result.output.strip() == '[-78.96, 23.56, -76.57, 25.55]'
 
 
 def test_bounds_compact():
@@ -495,7 +495,7 @@ def test_bounds_compact():
         '--compact'
     ])
     assert result.exit_code == 0
-    assert result.output.strip() == '[-78.9,23.56,-76.6,25.55]'
+    assert result.output.strip() == '[-78.96,23.56,-76.57,25.55]'
 
 
 def test_bounds_indent():
@@ -522,7 +522,7 @@ def test_bounds_obj_bbox_mercator():
     ])
     assert result.exit_code == 0
     assert result.output.strip() == (
-        '[-8782900.033, 2700489.278, -8527010.472, 2943560.235]')
+        '[-8789636.708, 2700489.278, -8524281.514, 2943560.235]')
 
 
 def test_bounds_obj_bbox_projected():
@@ -574,7 +574,7 @@ def test_bounds_seq():
     ])
     assert result.exit_code == 0
     assert result.output == (
-        '[-78.9, 23.56, -76.6, 25.55]\n[-78.9, 23.56, -76.6, 25.55]\n')
+        '[-78.96, 23.56, -76.57, 25.55]\n[-78.96, 23.56, -76.57, 25.55]\n')
     assert '\x1e' not in result.output
 
 
@@ -591,8 +591,7 @@ def test_bounds_seq_rs():
     ])
     assert result.exit_code == 0
     assert result.output == (
-        '\x1e[-78.9, 23.56, -76.6, 25.55]\n\x1e[-78.9, 23.56, -76.6, 25.55]\n')
-
+        '\x1e[-78.96, 23.56, -76.57, 25.55]\n\x1e[-78.96, 23.56, -76.57, 25.55]\n')
 
 def test_insp():
     runner = CliRunner()


### PR DESCRIPTION
Fixes #556 

This PR modifies `rio bounds` to use the `rasterio.warp.transform_bounds` function which densifies the line and considers all 4 corners to ensure that the resulting bbox is actually a bounding rectangle in the output projection.

This image show the old output in green, the new output in red

![screen shot 2016-02-02 at 3 40 59 pm](https://cloud.githubusercontent.com/assets/1151287/12762464/9b059e4a-c9c5-11e5-8561-dacd5e4ea094.png)

Also, makes input required to avoid funky exception when not provided.