### PR TITLE
Fix 'tranform' typo, replace with 'transform'.

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1448,7 +1448,7 @@ cdef class RasterUpdater(RasterReader):
         if [abs(v) for v in transform] == [0, 1, 0, 0, 0, 1]:
             warnings.warn(
                 "Dataset uses default geotransform (Affine.identity). "
-                "No tranform will be written to the output by GDAL.",
+                "No transform will be written to the output by GDAL.",
                 UserWarning
             )
 


### PR DESCRIPTION
The lintian QA tool reported this spelling error for the recent rebuild of the rasterio 0.31.0 Debian package with GDAL 1.11.4 and 2.0.2.