### PR TITLE
When importing matplotlib, convert a potential RuntimeError to a warning

### DIFF
--- a/rasterio/tool.py
+++ b/rasterio/tool.py
@@ -1,11 +1,28 @@
+"""
+Implementations of various common operations, like `show()` for displaying an
+array or with matplotlib, and `stats()` for computing min/max/avg.  Most can
+handle a numpy array or `rasterio.Band()`.  Primarily supports `$ rio insp`.
+"""
+
+
+from __future__ import absolute_import
 
 import code
 import collections
 import logging
+import warnings
 
 try:
     import matplotlib.pyplot as plt
 except ImportError:
+    plt = None
+except RuntimeError as e:
+    # Certain environment configurations can trigger a RuntimeError like:
+
+    # Trying to import matplotlibRuntimeError: Python is not installed as a
+    # framework. The Mac OS X backend will not be able to function correctly
+    # if Python is not installed as a framework. See the Python ...
+    warnings.warn(str(e), RuntimeWarning, stacklevel=2)
     plt = None
 
 import numpy


### PR DESCRIPTION
@sgillies @perrygeo @brendan-ward Ready.

In some environment configurations (primarily Python 2 in a virtualenv?) `matplotlib` can raise a `RuntimeError` on import, but we don't want this to bring down the entire `tools` modules, so converting it to a warning seems like a better move.  This warns with `RuntimeWarning` rather than `ImportWarning` because the latter is [ignored by default](https://docs.python.org/2/library/warnings.html#warning-categories).

**Before:**

```console
$ rio insp ../rasterio/tests/data/RGB.byte.tif --ipython
Traceback (most recent call last):
  File "/Users/kwurster/code/benthos-pipeline/venv/bin/rio", line 11, in <module>
    sys.exit(main_group())
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/rasterio/rio/info.py", line 337, in insp
    import rasterio.tool
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/rasterio/tool.py", line 7, in <module>
    import matplotlib.pyplot as plt
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/matplotlib/pyplot.py", line 114, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
    globals(),locals(),[backend_name],0)
  File "/Users/kwurster/code/benthos-pipeline/venv/lib/python2.7/site-packages/matplotlib/backends/backend_macosx.py", line 24, in <module>
    from matplotlib.backends import _macosx
RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. See the Python documentation for more information on installing Python as a framework on Mac OS X. Please either reinstall Python as a framework, or try one of the other backends. If you are Working with Matplotlib in a virtual enviroment see 'Working with Matplotlib in Virtual environments' in the Matplotlib FAQ
```

**After:**

```console
$ rio insp --ipython tests/data/RGB.byte.tif                                                                                                                                  
/Users/kwurster/code/rasterio/rasterio/rio/info.py:295: RuntimeWarning: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. See the Python documentation for more information on installing Python as a framework on Mac OS X. Please either reinstall Python as a framework, or try one of the other backends. If you are Working with Matplotlib in a virtual enviroment see 'Working with Matplotlib in Virtual environments' in the Matplotlib FAQ
  import rasterio.tool
Rasterio 0.31.0 Interactive Inspector (Python 2.7.10)
Type "src.meta", "src.read(1)", or "help(src)" for more information.
In [1]:
```