### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,7 +19,7 @@ Changes
   window_intersection(), windows_intersect() (#496, #506).
 - Warn when an alpha band that might provide a dataset mask is shadowed by a
   nodata attribute (#508, #523).
-- IPython is not the default interpeter for rio-insp and the documentation 
+- IPython is not the default interpreter for rio-insp and the documentation 
   saying it is has been corrected (#518).
 - Guard against creating datasets with block sizes larger than the dataset
   width and height. Such datasets are semi-broken and are likely to be 

--- a/docs/georeferencing.rst
+++ b/docs/georeferencing.rst
@@ -42,7 +42,7 @@ argument.
 Coordinate Transformation
 -------------------------
 
-A dataset's pixel coordinate system has its orgin at the "upper left" (imagine
+A dataset's pixel coordinate system has its origin at the "upper left" (imagine
 it displayed on your screen). Column index increases to the right, and row 
 index increases downward. The mapping of these coordinates to "world"
 coordinates in the dataset's reference system is done with an affine

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -97,7 +97,7 @@ def from_epsg(code):
 
 # Below is the big list of PROJ4 parameters from
 # http://trac.osgeo.org/proj/wiki/GenParms.
-# It is parsed into a list of paramter keys ``all_proj_keys``.
+# It is parsed into a list of parameter keys ``all_proj_keys``.
 
 _param_data = """
 +a         Semimajor radius of the ellipsoid axis

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -158,7 +158,7 @@ def sieve(image, size, out=None, output=None, mask=None, connectivity=4):
     # Start moving users over to 'out'.
     if output is not None:
         warnings.warn(
-            "The 'output' keyword arg has been superceded by 'out' "
+            "The 'output' keyword arg has been superseded by 'out' "
             "and will be removed before Rasterio 1.0.",
             FutureWarning,
             stacklevel=2)  # pragma: no cover
@@ -296,7 +296,7 @@ def rasterize(
 
     if output is not None:
         warnings.warn(
-            "The 'output' keyword arg has been superceded by 'out' "
+            "The 'output' keyword arg has been superseded by 'out' "
             "and will be removed before Rasterio 1.0.",
             FutureWarning,
             stacklevel=2) # pragma: no cover

--- a/rasterio/rio/features.py
+++ b/rasterio/rio/features.py
@@ -283,7 +283,7 @@ def shapes(
                     if bidx is None:
                         msk = numpy.logical_or.reduce(msk).astype('uint8')
 
-                    # Possibly overidden below.
+                    # Possibly overridden below.
                     img = msk
 
                 # Read the band data unless the --mask option is given.


### PR DESCRIPTION
Found with https://github.com/OSGeo/gdal/blob/trunk/gdal/scripts/fix_typos.sh