### PR TITLE
Fix test_write_3857() with GDAL trunk (#548)

### DIFF
--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -41,24 +41,8 @@ def test_write_3857(tmpdir):
                 assert dst.crs == {'init': 'epsg:3857'}
     info = subprocess.check_output([
         'gdalinfo', dst_path])
-    assert """PROJCS["WGS 84 / Pseudo-Mercator",
-    GEOGCS["WGS 84",
-        DATUM["WGS_1984",
-            SPHEROID["WGS 84",6378137,298.257223563,
-                AUTHORITY["EPSG","7030"]],
-            AUTHORITY["EPSG","6326"]],
-        PRIMEM["Greenwich",0],
-        UNIT["degree",0.0174532925199433],
-        AUTHORITY["EPSG","4326"]],
-    PROJECTION["Mercator_1SP"],
-    PARAMETER["central_meridian",0],
-    PARAMETER["scale_factor",1],
-    PARAMETER["false_easting",0],
-    PARAMETER["false_northing",0],
-    UNIT["metre",1,
-        AUTHORITY["EPSG","9001"]],
-    EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],
-    AUTHORITY["EPSG","3857"]]""" in info.decode('utf-8')
+    # WKT string may vary a bit w.r.t GDAL versions
+    assert 'PROJCS["WGS 84 / Pseudo-Mercator"' in info.decode('utf-8')
 
 
 def test_from_proj4_json():


### PR DESCRIPTION
The WKT string for EPSG:3857 has changed in GDAL 2.1, so make
the test a bit less specific for robustness.