### PR TITLE
Fix memleaks in _warp._reproject()

### DIFF
--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -115,6 +115,7 @@ def _transform_geom(
                     <const OGRGeometry *>src_ogr_geom,
                     <OGRCoordinateTransformation *>transform,
                     options)
+    del factory
     g = _features.GeomBuilder().build(dst_ogr_geom)
 
     _ogr.OGR_G_DestroyGeometry(dst_ogr_geom)
@@ -354,7 +355,6 @@ def _reproject(
     
     cdef void *hTransformArg = NULL
     cdef _gdal.GDALWarpOptions *psWOptions = NULL
-    cdef GDALWarpOperation *oWarper = new GDALWarpOperation()
 
     hTransformArg = _gdal.GDALCreateGenImgProjTransformer(
                                         hdsin, NULL, hdsout, NULL,
@@ -388,6 +388,9 @@ def _reproject(
 
     # Set src_nodata and dst_nodata
     if src_nodata is None and dst_nodata is not None:
+        psWOptions.papszWarpOptions = warp_extras
+        _gdal.GDALDestroyGenImgProjTransformer(hTransformArg)
+        _gdal.GDALDestroyWarpOptions(psWOptions)
         raise ValueError("src_nodata must be provided because dst_nodata "
                          "is not None")
     log.debug("src_nodata: %s" % src_nodata)
@@ -402,6 +405,9 @@ def _reproject(
     # Validate nodata values
     if src_nodata is not None:
         if not _io.in_dtype_range(src_nodata, source.dtype):
+            psWOptions.papszWarpOptions = warp_extras
+            _gdal.GDALDestroyGenImgProjTransformer(hTransformArg)
+            _gdal.GDALDestroyWarpOptions(psWOptions)
             raise ValueError("src_nodata must be in valid range for "
                             "source dtype")
 
@@ -418,6 +424,9 @@ def _reproject(
 
     if dst_nodata is not None and not _io.in_dtype_range(
             dst_nodata, destination.dtype):
+        psWOptions.papszWarpOptions = warp_extras
+        _gdal.GDALDestroyGenImgProjTransformer(hTransformArg)
+        _gdal.GDALDestroyWarpOptions(psWOptions)
         raise ValueError("dst_nodata must be in valid range for "
                          "destination dtype")
 
@@ -455,6 +464,7 @@ def _reproject(
 
     # Now that the transformer and warp options are set up, we init
     # and run the warper.
+    cdef GDALWarpOperation *oWarper = new GDALWarpOperation()
     try:
         with cpl_errs:
             oWarper.Initialize(psWOptions)
@@ -479,11 +489,9 @@ def _reproject(
 
     # Clean up transformer, warp options, and dataset handles.
     finally:
-
-        if hTransformArg != NULL:
-            _gdal.GDALDestroyGenImgProjTransformer(hTransformArg)
-        if psWOptions != NULL:
-            _gdal.GDALDestroyWarpOptions(psWOptions)
+        _gdal.GDALDestroyGenImgProjTransformer(hTransformArg)
+        _gdal.GDALDestroyWarpOptions(psWOptions)
         if dtypes.is_ndarray(source):
             if hdsin != NULL:
                 _gdal.GDALClose(hdsin)
+        del oWarper


### PR DESCRIPTION
Objects factory = new OGRGeometryFactory() and oWarper = new GDALWarpOperation()
need to be explicitly deallocated with del
(see https://github.com/cython/cython/wiki/WrappingCPlusPlus)

Also fixes a few leaks in exception code paths.

Now 'valgrind --leak-check=full --trace-children=yes ~/.local/bin/py.test tests/test_warp.py'
no longer reports memory leaks.