### PR TITLE
Fix 2 use after free in reproject()

### DIFF
--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -287,9 +287,9 @@ def _reproject(
         osr = _base._osr_from_crs(src_crs)
         _gdal.OSRExportToWkt(osr, &srcwkt)
         _gdal.GDALSetProjection(hdsin, srcwkt)
+        log.debug("Set CRS on temp source dataset: %s", srcwkt)
         _gdal.CPLFree(srcwkt)
         _gdal.OSRDestroySpatialReference(osr)
-        log.debug("Set CRS on temp source dataset: %s", srcwkt)
         
         # Copy arrays to the dataset.
         retval = _io.io_auto(source, hdsin, 1)
@@ -337,9 +337,9 @@ def _reproject(
         _gdal.OSRExportToWkt(osr, &dstwkt)
         retval = _gdal.GDALSetProjection(hdsout, dstwkt)
         log.debug("Setting Projection: %d", retval)
+        log.debug("Set CRS on temp destination dataset: %s", dstwkt)
         _gdal.CPLFree(dstwkt)
         _gdal.OSRDestroySpatialReference(osr)
-        log.debug("Set CRS on temp destination dataset: %s", dstwkt)
         if dst_nodata is None and hasattr(destination, "fill_value"):
             # destination is a masked array
             dst_nodata = destination.fill_value


### PR DESCRIPTION
In the case where the input / output dataset is a ndarray, the logging
of the CRS is done after CPLFree()ing the string.

Reported by Valgrind with errors like:

==9948== Invalid read of size 2
==9948==    at 0x4C2F7E0: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9948==    by 0x529DAA: PyString_FromString (in /usr/bin/python2.7)
==9948==    by 0x1BFBE155: __pyx_pf_8rasterio_5_warp_4_reproject (_warp.cpp:6248)
==9948==    by 0x1BFBE155: __pyx_pw_8rasterio_5_warp_5_reproject(_object*, _object*, _object*) (_warp.cpp:4776)
==9948==    by 0x49C4D8: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==9948==    by 0x4A090B: PyEval_EvalCodeEx (in /usr/bin/python2.7)
==9948==    by 0x499A51: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==9948==    by 0x4A1C99: ??? (in /usr/bin/python2.7)
==9948==    by 0x505F95: PyObject_Call (in /usr/bin/python2.7)
==9948==    by 0x49B079: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==9948==    by 0x4A1C99: ??? (in /usr/bin/python2.7)
==9948==    by 0x505F95: PyObject_Call (in /usr/bin/python2.7)
==9948==    by 0x49B079: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==9948==  Address 0x6bfc350 is 0 bytes inside a block of size 493 free'd
==9948==    at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9948==    by 0xDAFE573: VSIFree (cpl_vsisimple.cpp:727)
==9948==    by 0x1BFBE0DF: __pyx_pf_8rasterio_5_warp_4_reproject (_warp.cpp:6225)
==9948==    by 0x1BFBE0DF: __pyx_pw_8rasterio_5_warp_5_reproject(_object*, _object*, _object*) (_warp.cpp:4776)
==9948==    by 0x49C4D8: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==9948==    by 0x4A090B: PyEval_EvalCodeEx (in /usr/bin/python2.7)
==9948==    by 0x499A51: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==9948==    by 0x4A1C99: ??? (in /usr/bin/python2.7)
==9948==    by 0x505F95: PyObject_Call (in /usr/bin/python2.7)
==9948==    by 0x49B079: PyEval_EvalFrameEx (in /usr/bin/python2.7)
==9948==    by 0x4A1C99: ??? (in /usr/bin/python2.7)
==9948==    by 0x505F95: PyObject_Call (in /usr/bin/python2.7)
==9948==    by 0x49B079: PyEval_EvalFrameEx (in /usr/bin/python2.7)