### PR TITLE
Check invert proj

### DIFF
--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -68,10 +68,10 @@ def x_dst_bounds_handler(ctx, param, value):
 @click.option('--resampling', type=click.Choice([r.name for r in Resampling]),
               default='nearest', help="Resampling method.",
               show_default=True)
-@click.option('--threads', type=int, default=2,
+@click.option('--threads', type=int, default=1,
               help='Number of processing threads.')
 @click.option('--check-invert-proj', type=bool, default=True,
-              help='Constrain output extent to valid coordinate region in dst-crs')
+              help='Constrain output to valid coordinate region in dst-crs')
 @options.force_overwrite_opt
 @options.creation_options
 @click.pass_context

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -70,12 +70,14 @@ def x_dst_bounds_handler(ctx, param, value):
               show_default=True)
 @click.option('--threads', type=int, default=2,
               help='Number of processing threads.')
+@click.option('--check-invert-proj', type=bool, default=True,
+              help='Constrain output extent to valid coordinate region in dst-crs')
 @options.force_overwrite_opt
 @options.creation_options
 @click.pass_context
 def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
-         x_dst_bounds, bounds, res, resampling, threads, force_overwrite,
-         creation_options):
+         x_dst_bounds, bounds, res, resampling, threads, check_invert_proj,
+         force_overwrite, creation_options):
     """
     Warp a raster dataset.
 
@@ -132,7 +134,8 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
         # Expand one value to two if needed
         res = (res[0], res[0]) if len(res) == 1 else res
 
-    with rasterio.drivers(CPL_DEBUG=verbosity > 2):
+    with rasterio.drivers(CPL_DEBUG=verbosity > 2,
+                          CHECK_WITH_INVERT_PROJ=check_invert_proj):
         with rasterio.open(files[0]) as src:
             l, b, r, t = src.bounds
             out_kwargs = src.meta.copy()

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -288,7 +288,7 @@ def calculate_default_transform(
     ----
     Must be called within a raster.drivers() context
 
-    Some behavior determined by the
+    Some behavior of this function is determined by the
     CHECK_WITH_INVERT_PROJ environment variable
         YES: constrain output raster to extents that can be inverted
              avoids visual artifacts and coordinate discontinuties.

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -283,12 +283,21 @@ def calculate_default_transform(
     Returns
     -------
     tuple of destination affine transform, width, and height
+
+    Note
+    ----
+    Must be called within a raster.drivers() context
+
+    Some behavior determined by the
+    CHECK_WITH_INVERT_PROJ environment variable
+        YES: constrain output raster to extents that can be inverted
+             avoids visual artifacts and coordinate discontinuties.
+        NO:  reproject coordinates beyond valid bound limits
     """
-    with rasterio.drivers():
-        dst_affine, dst_width, dst_height = _calculate_default_transform(
-            src_crs, dst_crs,
-            width, height,
-            left, bottom, right, top)
+    dst_affine, dst_width, dst_height = _calculate_default_transform(
+        src_crs, dst_crs,
+        width, height,
+        left, bottom, right, top)
 
     # If resolution is specified, Keep upper-left anchored
     # adjust the transform resolutions


### PR DESCRIPTION
This PR adds 

* `--check-invert-proj` option to rio-warp to set the gdalenv for clipping to valid coordinate region or not
* Temporarily set `--threads` to default to 1 for safety (other threads could get diff envs, see #599)
* removes the drivers context manager within `calculate_default_transform` - gdalenv must now be provided by the caller

Resolves #575