### PR TITLE
WIP: fixes for GDAL on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,26 @@
 language: python
 sudo: false
-cache:
-  directories:
-    - $GDALINST
-    - ~/.cache/pip
 env:
   global:
     - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
     - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
+    - PROJINST=$HOME/projinstall
   matrix:
-    - GDALVERSION = "1.9.2"
-    - GDALVERSION = "1.11.4"
-    - GDALVERSION = "2.0.2"
+    - GDALVERSION="1.9.2"
+    - GDALVERSION="1.11.4"
+    - GDALVERSION="2.0.2"
+cache:
+  directories:
+    - pip
 addons:
   apt:
     packages:
-    - libgdal1h
-    - gdal-bin
-    - libgdal-dev
-    - libatlas-dev
-    - libatlas-base-dev
-    - gfortran
+      - libhdf5-serial-dev
+      - libatlas-dev
+      - libatlas-base-dev
+      - gfortran
 python:
   - "2.7"
   - "3.3"
@@ -32,13 +30,12 @@ before_install:
   - pip install wheel
   - . ./scripts/travis_gdal_install.sh
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$PATH
-  - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$LD_LIBRARY_PATH
+  - export LD_LIBRARY_PATH=$PROJINST/lib:$GDALINST/gdal-$GDALVERSION/lib:$LD_LIBRARY_PATH
 install:
-  - "pip wheel -r requirements-dev.txt"
-  - "pip install -r requirements-dev.txt"
-  - "pip install --upgrade --force-reinstall --global-option=build_ext --global-option='-I$GDALINST/gdal-$GDALVERSION/include' --global-option='-L$GDALINST/gdal-$GDALVERSION/lib' --global-option='-R$GDALINST/gdal-$GDALVERSION/lib' -e ."
-  - "pip install coveralls>=1.1"
-  - "pip install -e ."
+  - pip wheel -r requirements-dev.txt
+  - pip install -r requirements-dev.txt
+  - pip install --upgrade --force-reinstall --global-option=build_ext --global-option='-I$GDALINST/gdal-$GDALVERSION/include' --global-option='-L$GDALINST/gdal-$GDALVERSION/lib' --global-option='-R$GDALINST/gdal-$GDALVERSION/lib' -e .
+  - pip install coveralls>=1.1
 script:
   - py.test --cov rasterio --cov-report term-missing
 after_success:

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -17,13 +17,13 @@ GDALOPTS="  --with-ogr \
             --without-cfitsio \
             --without-pcraster \
             --without-netcdf \
-            --without-png \
+            --with-png \
             --with-jpeg=internal \
             --without-gif \
             --without-ogdi \
             --without-fme \
             --without-hdf4 \
-            --without-hdf5 \
+            --with-hdf5 \
             --without-jasper \
             --without-ecw \
             --without-kakadu \
@@ -56,35 +56,50 @@ fi
 
 ls -l $GDALINST
 
-# download and compile gdal version
-if [ ! -d $GDALINST/gdal-1.9.2 ]; then
-  cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/gdal-1.9.2.tar.gz
-  tar -xzf gdal-1.9.2.tar.gz
-  cd gdal-1.9.2
-  ./configure --prefix=$GDALINST/gdal-1.9.2 $GDALOPTS
-  make -s -j 2
-  make install
-fi
+# download and install proj.4
+wget http://download.osgeo.org/proj/proj-4.9.2.tar.gz
+tar -xf proj-4.9.2.tar.gz
+cd proj-4.9.2
+./configure --prefix=$PROJINST
+make
+make install
 
-if [ ! -d $GDALINST/gdal-1.11.2 ]; then
-  cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
-  tar -xzf gdal-1.11.2.tar.gz
-  cd gdal-1.11.2
-  ./configure --prefix=$GDALINST/gdal-1.11.2 $GDALOPTS
-  make -s -j 2
-  make install
-fi
+cd $GDALBUILD
 
-if [ ! -d $GDALINST/gdal-2.0.1 ]; then
-  cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/2.0.1/gdal-2.0.1.tar.gz
-  tar -xzf gdal-2.0.1.tar.gz
-  cd gdal-2.0.1
-  ./configure --prefix=$GDALINST/gdal-2.0.1 $GDALOPTS
-  make -s -j 2
-  make install
+# compile and install the correct gdal version
+if [ "$GDALVERSION" = "1.9.2" ]; then
+    wget http://download.osgeo.org/gdal/gdal-1.9.2.tar.gz
+    tar -xf gdal-1.9.2.tar.gz
+
+    echo "building GDAL 1.9.2"
+    cd gdal-1.9.2
+    ./configure --prefix=$GDALINST/gdal-1.9.2 $GDALOPTS
+    make -s -j 2
+    make install
+
+elif [ "$GDALVERSION" = "1.11.4" ]; then
+    wget http://download.osgeo.org/gdal/1.11.4/gdal-1.11.4.tar.gz
+    tar -xf gdal-1.11.4.tar.gz
+
+    echo "building GDAL 1.11.4"
+    cd gdal-1.11.4
+    ./configure --prefix=$GDALINST/gdal-1.11.4 $GDALOPTS
+    make -s -j 2
+    make install
+
+elif [ "$GDALVERSION" = "2.0.2" ]; then
+    wget http://download.osgeo.org/gdal/2.0.2/gdal-2.0.2.tar.gz
+    tar -xf gdal-2.0.2.tar.gz
+
+    echo "building GDAL 2.0.2"
+    cd gdal-2.0.2
+    ./configure --prefix=$GDALINST/gdal-2.0.2 $GDALOPTS
+    make -s -j 2
+    make install
+
+else
+    echo "Error: GDALVERSION ($GDALVERSION) not in expected set"
+    exit 1
 fi
 
 # change back to travis build dir


### PR DESCRIPTION
As @perrygeo found in #571, there are some problems with the install script for GDAL on Travis. This is my second try at getting it right.

Unfortunately, this disables caching of GDAL compiles for the moment.

```
installs libproj and hdf5

makes numerous fixes to the GDAL installation script:
- removes redundant install command
- removes gdal installed via apt becaue we're gonna compile it anyway

disables caching for now because that was leading to problems in my testing
```