### PR TITLE
enable all the gdals, py2.7 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,26 @@ env:
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
   matrix:
-    - GDALVERSION = "1.9.2"
-    - GDALVERSION = "1.11.4"
-    - GDALVERSION = "2.0.2"
+    - GDALVERSION="1.9.2"
+    - GDALVERSION="1.10.0"  # doesn't exist but path/lib will fall back to system
+    - GDALVERSION="1.11.4"
+    - GDALVERSION="2.0.2"
+    - GDALVERSION="2.1.0"
 addons:
   apt:
     packages:
     - libgdal1h
     - gdal-bin
+    - libproj-dev
+    - libhdf5-serial-dev
+    - libpng-dev
     - libgdal-dev
     - libatlas-dev
     - libatlas-base-dev
     - gfortran
 python:
   - "2.7"
-  - "3.3"
+  # - "3.3"   # disabling python3.3 for now
   - "3.4"
 before_install:
   - pip install -U pip
@@ -34,6 +39,7 @@ before_install:
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$PATH
   - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$LD_LIBRARY_PATH
 install:
+  - "if [ $(gdal-config --version) == \"$GDALVERSION\" ]; then echo \"Using gdal $GDALVERSION\"; else echo \"NOT using gdal $GDALVERSION as expected; aborting\"; exit 1; fi"
   - "pip wheel -r requirements-dev.txt"
   - "pip install -r requirements-dev.txt"
   - "pip install --upgrade --force-reinstall --global-option=build_ext --global-option='-I$GDALINST/gdal-$GDALVERSION/include' --global-option='-L$GDALINST/gdal-$GDALVERSION/lib' --global-option='-R$GDALINST/gdal-$GDALVERSION/lib' -e ."

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -17,13 +17,13 @@ GDALOPTS="  --with-ogr \
             --without-cfitsio \
             --without-pcraster \
             --without-netcdf \
-            --without-png \
+            --with-png \
             --with-jpeg=internal \
             --without-gif \
             --without-ogdi \
             --without-fme \
             --without-hdf4 \
-            --without-hdf5 \
+            --with-hdf5 \
             --without-jasper \
             --without-ecw \
             --without-kakadu \
@@ -43,7 +43,8 @@ GDALOPTS="  --with-ogr \
             --without-perl \
             --without-php \
             --without-ruby \
-            --without-python"
+            --without-python \
+            --with-static-proj4=/usr/lib"
 
 # Create build dir if not exists
 if [ ! -d "$GDALBUILD" ]; then
@@ -67,22 +68,36 @@ if [ ! -d $GDALINST/gdal-1.9.2 ]; then
   make install
 fi
 
-if [ ! -d $GDALINST/gdal-1.11.2 ]; then
+if [ ! -d $GDALINST/gdal-1.11.4 ]; then
   cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
-  tar -xzf gdal-1.11.2.tar.gz
-  cd gdal-1.11.2
-  ./configure --prefix=$GDALINST/gdal-1.11.2 $GDALOPTS
+  wget http://download.osgeo.org/gdal/1.11.4/gdal-1.11.4.tar.gz
+  tar -xzf gdal-1.11.4.tar.gz
+  cd gdal-1.11.4
+  ./configure --prefix=$GDALINST/gdal-1.11.4 $GDALOPTS
   make -s -j 2
   make install
 fi
 
-if [ ! -d $GDALINST/gdal-2.0.1 ]; then
+if [ ! -d $GDALINST/gdal-2.0.2 ]; then
   cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/2.0.1/gdal-2.0.1.tar.gz
-  tar -xzf gdal-2.0.1.tar.gz
-  cd gdal-2.0.1
-  ./configure --prefix=$GDALINST/gdal-2.0.1 $GDALOPTS
+  wget http://download.osgeo.org/gdal/2.0.2/gdal-2.0.2.tar.gz
+  tar -xzf gdal-2.0.2.tar.gz
+  cd gdal-2.0.2
+  ./configure --prefix=$GDALINST/gdal-2.0.2 $GDALOPTS
+  make -s -j 2
+  make install
+fi
+
+
+if [ ! -d $GDALINST/gdal-2.1.0 ]; then
+  cd $GDALBUILD
+  #
+  # TODO Use official release, for now use nightly
+  #
+  wget http://www.gdal.org/daily/gdal-svn-trunk-2016.03.24.tar.gz
+  tar -xzf gdal-svn-trunk-2016.03.24.tar.gz
+  cd gdal-svn-trunk-2016.03.24
+  ./configure --prefix=$GDALINST/gdal-2.1.0 $GDALOPTS
   make -s -j 2
   make install
 fi


### PR DESCRIPTION
This PR incorporates many of the ideas in #605 but enables caching and gdal 2.1

To recap:
* Actually use the build matrix - removing the space in GDALVERSION allows env var to get set properly.
* Build the GDAL versions with proper flags to set hdf5, proj and png deps
* Add the aforementioned deps by apt dev packages
* removes redundant pip install
* Adds GDAL 2.1 to the build matrix
* Adds GDAL 1.10.0 to the build matrix (that's the system version which, ironically, was the only one we were testing previously)
* Adds a test that the correct GDAL is being run, i.e. `gdal-config --version` is equal to $GDALVERSION
* Disables Python 3.3 support to keep the build matrix reasonable. (3.5 is already out so we should be adding that soon)

Cached need to be cleared so if any branches or PRs are still failing, we might need to clear something. Let me know.

Fixes #571 
Closes #605 
