### PR TITLE
Catch CRSError in rio-warp and raise BadParameter

### DIFF
--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -8,9 +8,9 @@ cimport numpy as np
 
 from rasterio cimport _base, _gdal, _ogr, _io, _features
 from rasterio import dtypes
-from rasterio._err import CPLErrors, GDALError
+from rasterio._err import CPLErrors, GDALError, CPLE_NotSupported
 from rasterio._io cimport InMemoryRaster
-from rasterio.errors import DriverRegistrationError
+from rasterio.errors import DriverRegistrationError, CRSError
 from rasterio.transform import Affine, from_bounds
 
 
@@ -577,6 +577,8 @@ def _calculate_default_transform(
                     geotransform, &npixels, &nlines, extent, 0)
                 cple.check()
             log.debug("Created transformer and warp output.")
+        except CPLE_NotSupported as err:
+            raise CRSError(err.errmsg)
         finally:
             if wkt != NULL:
                 _gdal.CPLFree(wkt)

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -3,16 +3,22 @@
 from click import FileError
 
 
-class RasterioIOError(IOError):
-    """A failure to open a dataset using the presently registered drivers."""
+class CRSError(ValueError):
+    """Raised when a CRS string or mapping is invalid or cannot serve
+    to define a coordinate transformation."""
 
 
 class DriverRegistrationError(ValueError):
-    """To be raised when, eg, _gdal.GDALGetDriverByName("MEM") returns NULL."""
+    """Raised when a format driver is requested but is not registered."""
 
 
 class FileOverwriteError(FileError):
-    """Rasterio's CLI refuses to implicitly clobber output files."""
+    """Raised when Rasterio's CLI refuses to clobber output files."""
 
     def __init__(self, message):
         super(FileOverwriteError, self).__init__('', hint=message)
+
+
+class RasterioIOError(IOError):
+    """Raised when a dataset cannot be opened using one of the
+    registered format drivers."""

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -24,6 +24,9 @@ def test_dst_crs_error(runner, tmpdir):
     assert 'for dst_crs: crs appears to be JSON but is not' in result.output
 
 
+@pytest.mark.xfail(
+    os.environ.get('GDALVERSION', 'a.b.c').startswith('1.9'),
+                   reason="GDAL 1.9 doesn't catch this error")
 def test_dst_crs_error_2(runner, tmpdir):
     """Invalid PROJ.4 is a bad parameter."""
     srcname = 'tests/data/RGB.byte.tif'

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -8,9 +8,50 @@ import pytest
 
 import rasterio
 from rasterio.rio import warp
+from rasterio.rio.main import main_group
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+def test_dst_crs_error(runner, tmpdir):
+    """Invalid JSON is a bad parameter."""
+    srcname = 'tests/data/RGB.byte.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(main_group, [
+        'warp', srcname, outputname, '--dst-crs', '{foo: bar}'])
+    assert result.exit_code == 2
+    assert 'for dst_crs: crs appears to be JSON but is not' in result.output
+
+
+def test_dst_crs_error_2(runner, tmpdir):
+    """Invalid PROJ.4 is a bad parameter."""
+    srcname = 'tests/data/RGB.byte.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(main_group, [
+        'warp', srcname, outputname, '--dst-crs', '{"proj": "foobar"}'])
+    assert result.exit_code == 2
+    assert 'for dst_crs: Failed to initialize PROJ.4' in result.output
+
+
+def test_dst_crs_error_epsg(runner, tmpdir):
+    """Malformed EPSG string is a bad parameter."""
+    srcname = 'tests/data/RGB.byte.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(main_group, [
+        'warp', srcname, outputname, '--dst-crs', 'EPSG:'])
+    assert result.exit_code == 2
+    assert 'for dst_crs: invalid literal for int()' in result.output
+
+
+def test_dst_crs_error_epsg_2(runner, tmpdir):
+    """Invalid EPSG code is a bad parameter."""
+    srcname = 'tests/data/RGB.byte.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(main_group, [
+        'warp', srcname, outputname, '--dst-crs', 'EPSG:0'])
+    assert result.exit_code == 2
+    assert 'for dst_crs: EPSG codes are positive integers' in result.output
 
 
 def test_warp_no_reproject(runner, tmpdir):
@@ -119,15 +160,6 @@ def test_warp_reproject_dst_crs(runner, tmpdir):
             assert numpy.allclose(output.bounds,
                                   [-78.95864996545055, 23.564787976164418,
                                    -76.5759177302349, 25.550873767433984])
-
-
-def test_warp_reproject_dst_crs_error(runner, tmpdir):
-    srcname = 'tests/data/RGB.byte.tif'
-    outputname = str(tmpdir.join('test.tif'))
-    result = runner.invoke(warp.warp, [srcname, outputname,
-                                       '--dst-crs', '{foo: bar}'])
-    assert result.exit_code == 2
-    assert 'invalid crs format' in result.output
 
 
 def test_warp_reproject_dst_crs_proj4(runner, tmpdir):

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import rasterio

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -79,6 +79,9 @@ def test_gdal_transform_fail_src_crs():
             top=70)
 
 
+@pytest.mark.xfail(
+    os.environ.get('GDALVERSION', 'a.b.c').startswith('1.9'),
+                   reason="GDAL 1.9 doesn't catch this error")
 def test_gdal_transform_fail_src_crs():
     with rasterio.drivers():
         with pytest.raises(CRSError):

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -1,6 +1,10 @@
+import pytest
+
 import rasterio
 from rasterio._warp import _calculate_default_transform
+from rasterio.errors import CRSError
 from rasterio.transform import Affine, from_bounds
+from rasterio.warp import transform_bounds
 
 
 def test_identity():
@@ -22,6 +26,18 @@ def test_identity():
     assert res_height == height
     for res, exp in zip(res_transform, transform):
         assert round(res, 7) == round(exp, 7)
+
+
+def test_transform_bounds():
+    """CRSError is raised."""
+    with rasterio.drivers():
+        left, bottom, right, top = (
+            -11740727.544603072, 4852834.0517692715, -11584184.510675032,
+            5009377.085697309)
+        src_crs = 'EPSG:3857'
+        dst_crs = {'proj': 'foobar'}
+        with pytest.raises(CRSError):
+            transform_bounds(src_crs, dst_crs, left, bottom, right, top)
 
 
 def test_gdal_transform_notnull():
@@ -61,3 +77,17 @@ def test_gdal_transform_fail_src_crs():
             bottom=30,
             right=-80,
             top=70)
+
+
+def test_gdal_transform_fail_src_crs():
+    with rasterio.drivers():
+        with pytest.raises(CRSError):
+            dt, dw, dh = _calculate_default_transform(
+                {'init': 'EPSG:4326'},
+                {'proj': 'foobar'},
+                width=80,
+                height=80,
+                left=-120,
+                bottom=30,
+                right=-80,
+                top=70)


### PR DESCRIPTION
CRSError is new and derives from ValueError.

Tests added for bad --dst-crs parameters in rio-warp

Closes #595