### PR TITLE
An empty JSON object used as a CRS is invalid

### DIFF
--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -59,7 +59,7 @@ def from_string(prjs):
         try:
             val = json.loads(prjs, strict=False)
         except ValueError:
-            raise ValueError('crs appears to be JSON but is not valid')
+            raise CRSError('crs appears to be JSON but is not valid')
 
         if not val:
             raise CRSError("crs is empty JSON")

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -1,14 +1,14 @@
-# Coordinate reference systems and functions.
-#
-# PROJ.4 is the law of this land: http://proj.osgeo.org/. But whereas PROJ.4
-# coordinate reference systems are described by strings of parameters such as
-#
-#   +proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs
-#
-# here we use mappings:
-#
-#   {'proj': 'longlat', 'ellps': 'WGS84', 'datum': 'WGS84', 'no_defs': True}
-#
+"""Coordinate reference systems and functions.
+
+PROJ.4 is the law of this land: http://proj.osgeo.org/. But whereas PROJ.4
+coordinate reference systems are described by strings of parameters such as
+
+  +proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs
+
+here we use mappings:
+
+  {'proj': 'longlat', 'ellps': 'WGS84', 'datum': 'WGS84', 'no_defs': True}
+"""
 
 
 import json

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -10,8 +10,11 @@
 #   {'proj': 'longlat', 'ellps': 'WGS84', 'datum': 'WGS84', 'no_defs': True}
 #
 
+
 import json
+
 from rasterio._base import is_geographic_crs, is_projected_crs, is_same_crs
+from rasterio.errors import CRSError
 from rasterio.five import string_types
 
 
@@ -57,8 +60,9 @@ def from_string(prjs):
             val = json.loads(prjs, strict=False)
         except ValueError:
             raise ValueError('crs appears to be JSON but is not valid')
+
         if not val:
-            raise ValueError("crs is empty JSON")
+            raise CRSError("crs is empty JSON")
         else:
             return val
 
@@ -86,7 +90,12 @@ def from_string(prjs):
         lambda kv: len(kv) == 2 and (kv[0], parse(kv[1])) or (kv[0], True),
         (p.split('=') for p in parts))
 
-    return dict((k, v) for k, v in items if k in all_proj_keys)
+    out = dict((k, v) for k, v in items if k in all_proj_keys)
+
+    if not out:
+        raise CRSError("crs is empty or invalid: {}".format(prjs))
+
+    return out
 
 
 def from_epsg(code):

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -54,9 +54,13 @@ def from_string(prjs):
     if '{' in prjs:
         # may be json, try to decode it
         try:
-            return json.loads(prjs, strict=False)
+            val = json.loads(prjs, strict=False)
         except ValueError:
             raise ValueError('crs appears to be JSON but is not valid')
+        if not val:
+            raise ValueError("crs is empty JSON")
+        else:
+            return val
 
     if prjs.strip().upper().startswith('EPSG:'):
         return from_epsg(prjs.split(':')[1])

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -157,7 +157,7 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
                     dst_height = template_ds.height
                     dst_width = template_ds.width
 
-            elif dst_crs:
+            elif dst_crs is not None:
                 try:
                     dst_crs = crs.from_string(dst_crs)
                 except ValueError as err:
@@ -241,6 +241,8 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
                 dst_height = max(int(ceil((t - b) / res[1])), 1)
 
             else:
+                print(dst_crs)
+                print("HEYYYYY")
                 dst_crs = src.crs
                 dst_transform = src.affine
                 dst_width = src.width

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -241,8 +241,6 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
                 dst_height = max(int(ceil((t - b) / res[1])), 1)
 
             else:
-                print(dst_crs)
-                print("HEYYYYY")
                 dst_crs = src.crs
                 dst_transform = src.affine
                 dst_width = src.width

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -146,3 +146,8 @@ def test_is_valid_false():
 
 def test_is_valid():
     assert is_valid_crs('EPSG:4326')
+
+
+def test_empty_json():
+    with pytest.raises(ValueError):
+        crs.from_string('{}')

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -8,6 +8,7 @@ import rasterio
 from rasterio import crs
 from rasterio.crs import (
     is_geographic_crs, is_projected_crs, is_same_crs, is_valid_crs)
+from rasterio.errors import CRSError
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -149,5 +150,9 @@ def test_is_valid():
 
 
 def test_empty_json():
-    with pytest.raises(ValueError):
+    with pytest.raises(CRSError):
         crs.from_string('{}')
+    with pytest.raises(CRSError):
+        crs.from_string('[]')
+    with pytest.raises(CRSError):
+        crs.from_string('')


### PR DESCRIPTION
Closes #628

@sgillies @brendan-ward @perrygeo Currently `$ rio warp --dst-crs {}` is valid but produces an output dataset without a CRS.  I modified `rasterio.crs.from_string()` to raise a `ValueError()` if an empty JSON object is decoded for consistency between the library and CLI.

What about `"[]"`?  Currently `from_string()` produces an empty dict, but it seems like this should also raise an exception.  We don't use lists for CRS at all, right?

```python
>>> from rasterio.crs import from_string
>>> print(from_string('[]'))
{}
```

```console
$ rio warp --dst-crs {} tests/data/RGB.byte.tif -o OUT.tif
Usage: rio warp [OPTIONS] INPUTS... OUTPUT

Error: Invalid value for dst_crs: crs is empty JSON
```