### PR TITLE
Keep rasterio's cpl error handler in place

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -3,6 +3,12 @@ from __future__ import absolute_import
 
 from collections import namedtuple
 import logging
+try:
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
 
 from rasterio._base import (
     eval_window, window_shape, window_index, gdal_version)
@@ -26,11 +32,12 @@ __all__ = [
 __version__ = "0.34.0"
 __gdal_version__ = gdal_version()
 
-log = logging.getLogger('rasterio')
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-log.addHandler(NullHandler())
+# Rasterio attaches NullHandler to the 'rasterio' and 'GDAL' loggers.
+# See https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library
+# Applications will need to attach their own handlers in order to
+# see messages. See rasterio/rio/main.py for an example.
+log = logging.getLogger('rasterio').addHandler(NullHandler())
+log = logging.getLogger('GDAL').addHandler(NullHandler())
 
 
 def open(

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -16,8 +16,18 @@ import rasterio
 
 
 def configure_logging(verbosity):
-    log_level = max(10, 30 - 10*verbosity)
+    log_level = max(10, 30 - 10 * verbosity)
     logging.basicConfig(stream=sys.stderr, level=log_level)
+
+    # Rasterio has attached the 'rasterio' and 'GDAL' loggers to
+    # NullHandler. The CLI attaches a new StreamHandler to each
+    # so log messages go to sys.stderr.
+    log = logging.getLogger('rasterio')
+    log.setLevel(log_level)
+    log.addHandler(logging.StreamHandler())
+    log = logging.getLogger('GDAL')
+    log.setLevel(log_level)
+    log.addHandler(logging.StreamHandler())
 
 
 class FakeSession(object):


### PR DESCRIPTION
Never restore it to the GDAL default. This avoids the situation where GDAL is writing directly to stderr.

Also get in line with best practices for library and application logging: NullHandlers attached in `rasterio/__init__.py` and then overridden in rasterio/rio/main.py.

- http://docs.python-guide.org/en/latest/writing/logging/#logging-in-a-library
- http://docs.python-guide.org/en/latest/writing/logging/#logging-in-an-application

Closes #649