### PR TITLE
Embracing hierarchy of loggers

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -1,4 +1,5 @@
-# rasterio
+"""Rasterio"""
+
 from __future__ import absolute_import
 
 from collections import namedtuple
@@ -32,12 +33,12 @@ __all__ = [
 __version__ = "0.34.0"
 __gdal_version__ = gdal_version()
 
-# Rasterio attaches NullHandler to the 'rasterio' and 'GDAL' loggers.
-# See https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library
-# Applications will need to attach their own handlers in order to
-# see messages. See rasterio/rio/main.py for an example.
-log = logging.getLogger('rasterio').addHandler(NullHandler())
-log = logging.getLogger('GDAL').addHandler(NullHandler())
+# Rasterio attaches NullHandler to the 'rasterio' logger and its
+# descendents. See
+# https://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library
+# Applications must attach their own handlers in order to see messages.
+# See rasterio/rio/main.py for an example.
+logging.getLogger(__name__).addHandler(NullHandler())
 
 
 def open(

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -1,6 +1,5 @@
-# The Numpy-free base classes.
-
 # cython: boundscheck=False
+"""Numpy-free base classes."""
 
 from __future__ import absolute_import
 
@@ -25,16 +24,7 @@ from rasterio.enums import (
 from rasterio.vfs import parse_path, vsi_path
 
 
-log = logging.getLogger('rasterio')
-if 'all' in sys.warnoptions:
-    # show messages in console with: python -W all
-    logging.basicConfig()
-else:
-    # no handler messages shown
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-    log.addHandler(NullHandler())
+log = logging.getLogger(__name__)
 
 
 def check_gdal_version(major, minor):
@@ -343,8 +333,8 @@ cdef class DatasetReader(object):
                         val < dtypes.dtype_ranges[dtype][0] or
                         val > dtypes.dtype_ranges[dtype][1]):
                     val = None
-                log.debug("Nodata success: %d", success)
-                log.debug("Nodata value: %f", nodataval)
+                log.debug(
+                    "Nodata success: %d, Nodata value: %f", success, nodataval)
                 self._nodatavals.append(val)
 
         return tuple(self._nodatavals)

--- a/rasterio/_copy.pyx
+++ b/rasterio/_copy.pyx
@@ -1,3 +1,5 @@
+"""Raster copying."""
+
 import logging
 import os
 import os.path
@@ -5,11 +7,7 @@ import os.path
 from rasterio cimport _gdal
 
 
-log = logging.getLogger('rasterio')
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-log.addHandler(NullHandler())
+log = logging.getLogger(__name__)
 
 
 cdef class RasterCopier:
@@ -52,4 +50,3 @@ cdef class RasterCopier:
 
         if options:
             _gdal.CSLDestroy(options)
-

--- a/rasterio/_drivers.pyx
+++ b/rasterio/_drivers.pyx
@@ -1,5 +1,4 @@
-# The GDAL and OGR driver registry.
-# GDAL driver management.
+"""GDAL and OGR driver management."""
 
 import logging
 import os
@@ -64,12 +63,14 @@ code_map = {
     15: 'CPLE_AWSInvalidCredentials',
     16: 'CPLE_AWSSignatureDoesNotMatch'}
 
-log = logging.getLogger('rasterio')
+log = logging.getLogger(__name__)
 
 
 cdef void * errorHandler(int eErrClass, int err_no, char *msg):
     if err_no in code_map:
-        logger = logging.getLogger('GDAL')
+        # 'rasterio._gdal' is the name in our logging hierarchy for
+        # messages coming direct from CPLError().
+        logger = logging.getLogger('rasterio._gdal')
         logger.log(level_map[eErrClass], "%s in %s", code_map[err_no], msg)
 
 
@@ -86,7 +87,7 @@ cdef class ConfigEnv(object):
         self.options = options.copy()
         self.prev_options = {}
 
-    def enter_config_options(self):
+    cdef enter_config_options(self):
         """Set GDAL config options."""
         cdef const char *key_c
         cdef const char *val_c
@@ -114,7 +115,7 @@ cdef class ConfigEnv(object):
                 val = '******'
             log.debug("Option %s=%s", key, val)
 
-    def exit_config_options(self):
+    cdef exit_config_options(self):
         """Clear GDAL config options."""
         cdef const char *key_c
         cdef const char *val_c

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -1,19 +1,16 @@
+"""Feature extraction"""
 
 import logging
+
 import numpy as np
 cimport numpy as np
+
 from rasterio._io cimport InMemoryRaster
 from rasterio cimport _gdal, _ogr, _io
 from rasterio import dtypes
 
 
-log = logging.getLogger('rasterio')
-
-
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-log.addHandler(NullHandler())
+log = logging.getLogger(__name__)
 
 
 def _shapes(image, mask, connectivity, transform):

--- a/rasterio/_fill.pyx
+++ b/rasterio/_fill.pyx
@@ -1,6 +1,6 @@
 # distutils: language = c++
 # cython: profile=True
-#
+"""Raster fill."""
 
 import numpy as np
 cimport numpy as np
@@ -13,7 +13,7 @@ from rasterio._io cimport InMemoryRaster
 
 
 def _fillnodata(image, mask, double max_search_distance=100.0,
-        int smoothing_iterations=0):
+                int smoothing_iterations=0):
     cdef void *memdriver = _gdal.GDALGetDriverByName("MEM")
     cdef void *image_dataset = NULL
     cdef void *image_band = NULL

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1,4 +1,5 @@
 # cython: boundscheck=False
+"""Rasterio input/output."""
 
 from __future__ import absolute_import
 
@@ -29,7 +30,7 @@ from rasterio.vfs import parse_path
 from rasterio.warnings import NodataShadowWarning
 
 
-log = logging.getLogger('rasterio')
+log = logging.getLogger(__name__)
 
 
 cdef bint in_dtype_range(value, dtype):

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -1,4 +1,5 @@
 # distutils: language = c++
+"""Raster and vector warping and reprojection."""
 
 from enum import IntEnum
 import logging
@@ -59,11 +60,7 @@ cdef extern from "ogr_spatialref.h":
         pass
 
 
-log = logging.getLogger('rasterio')
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-log.addHandler(NullHandler())
+log = logging.getLogger(__name__)
 
 
 def tastes_like_gdal(t):

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -1,3 +1,4 @@
+"""Enumerations."""
 
 from enum import Enum, IntEnum
 

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -1,4 +1,4 @@
-"""A module of errors."""
+"""Errors."""
 
 from click import FileError
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -13,17 +13,7 @@ from rasterio.transform import IDENTITY, guard_transform
 from rasterio.dtypes import validate_dtype, can_cast_dtype, get_minimum_dtype
 
 
-log = logging.getLogger('rasterio')
-
-
-class NullHandler(logging.Handler):
-    """Handle logging be emitting nothing."""
-
-    def emit(self, record):
-        """Do nothing."""
-        pass
-
-log.addHandler(NullHandler())
+log = logging.getLogger(__name__)
 
 
 def geometry_mask(

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -1,4 +1,5 @@
 """Copy valid pixels from input files to an output file."""
+
 from __future__ import absolute_import
 
 import logging
@@ -11,7 +12,7 @@ from rasterio._base import get_window
 from rasterio.transform import Affine
 
 
-logger = logging.getLogger('rasterio')
+logger = logging.getLogger(__name__)
 
 
 def merge(sources, bounds=None, res=None, nodata=None, precision=7):

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -4,6 +4,7 @@ Including `show()` for displaying an array or with matplotlib.
 Most can handle a numpy array or `rasterio.Band()`.
 Primarily supports `$ rio insp`.
 """
+
 from __future__ import absolute_import
 
 import logging
@@ -27,7 +28,7 @@ except RuntimeError as e:  # pragma: no cover
 
 from rasterio.five import zip_longest
 
-logger = logging.getLogger('rasterio')
+logger = logging.getLogger(__name__)
 
 
 def show(source, cmap='gray', with_bounds=True):
@@ -60,7 +61,7 @@ def show(source, cmap='gray', with_bounds=True):
         arr = source
         extent = None
     if plt is not None:
-        imax = plt.imshow(arr, cmap=cmap, extent=extent)
+        plt.imshow(arr, cmap=cmap, extent=extent)
         fig = plt.gcf()
         fig.show()
     else:  # pragma: no cover

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -1,7 +1,6 @@
 """Fetch and edit raster dataset metadata from the command line."""
 
 import json
-import logging
 
 import click
 
@@ -63,8 +62,6 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
     """
     verbosity = ctx.obj.get('verbosity')
     aws_session = ctx.obj.get('aws_session')
-
-    logger = logging.getLogger('rio')
     mode = 'r' if (verbose or meta_member == 'stats') else 'r-'
     try:
         with rasterio.drivers(
@@ -109,5 +106,4 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
                     click.echo(
                         json.dumps(src.tags(ns=namespace), indent=indent))
     except Exception:
-        logger.exception("Exception caught during processing")
         raise click.Abort()

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -19,16 +19,6 @@ def configure_logging(verbosity):
     log_level = max(10, 30 - 10 * verbosity)
     logging.basicConfig(stream=sys.stderr, level=log_level)
 
-    # Rasterio has attached the 'rasterio' and 'GDAL' loggers to
-    # NullHandler. The CLI attaches a new StreamHandler to each
-    # so log messages go to sys.stderr.
-    log = logging.getLogger('rasterio')
-    log.setLevel(log_level)
-    log.addHandler(logging.StreamHandler())
-    log = logging.getLogger('GDAL')
-    log.setLevel(log_level)
-    log.addHandler(logging.StreamHandler())
-
 
 class FakeSession(object):
     """Fake AWS Session."""

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -1,3 +1,5 @@
+"""Geospatial transforms"""
+
 from __future__ import absolute_import
 from __future__ import division
 
@@ -47,7 +49,7 @@ def from_bounds(west, south, east, north, width, height):
     `height` in number of pixels.
     """
     return Affine.translation(west, north) * Affine.scale(
-            (east - west)/width, (south - north)/height)
+        (east - west) / width, (south - north) / height)
 
 
 def array_bounds(height, width, transform):

--- a/tests/test_driver_management.py
+++ b/tests/test_driver_management.py
@@ -16,7 +16,7 @@ def test_drivers():
 
 def test_cpl_debug_true(tmpdir):
     """Setting CPL_DEBUG=True results in GDAL debug messages."""
-    log = logging.getLogger('GDAL')
+    log = logging.getLogger('rasterio._gdal')
     log.setLevel(logging.DEBUG)
     logfile = str(tmpdir.join('test.log'))
     fh = logging.FileHandler(logfile)
@@ -32,7 +32,7 @@ def test_cpl_debug_true(tmpdir):
 
 def test_cpl_debug_false(tmpdir):
     """Setting CPL_DEBUG=False results in no GDAL debug messages."""
-    log = logging.getLogger('GDAL')
+    log = logging.getLogger('rasterio._gdal')
     log.setLevel(logging.DEBUG)
     logfile = str(tmpdir.join('test.log'))
     fh = logging.FileHandler(logfile)


### PR DESCRIPTION
Basically use `logging.getLogger(__name__)` everywhere and configure at the top of the hierarchy.

Fixes a few pep8 nits along the way.