### PR TITLE
Remove references to read/_band() but not the actual methods

### DIFF
--- a/docs/color.rst
+++ b/docs/color.rst
@@ -57,7 +57,7 @@ to bands using the ``write_colormap()`` method.
             meta = src.meta
 
         with rasterio.open('/tmp/colormap.tif', 'w', **meta) as dst:
-            dst.write_band(1, shade)
+            dst.write(shade, indexes=1)
             dst.write_colormap(
                 1, {
                     0: (255, 0, 0, 255), 

--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -104,11 +104,7 @@ Here is the program in examples/concurrent-cpu-bound.py.
 
                             result, window = future_to_window[future]
 
-                            # Since there's no multiband write() method yet in
-                            # Rasterio, we use write_band for each part of the
-                            # 3D data array.
-                            for i, arr in enumerate(result, 1):
-                                dst.write_band(i, arr, window=window)
+                            dst.write(arr, window=window)
 
 
     if __name__ == '__main__':

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -91,7 +91,7 @@ written to disk like this,
             count=1, 
             width=src.width, 
             height=src.height) as dst:
-        dst.write_band(1, image)
+        dst.write(image, indexes=1)
 
 has a black background and white foreground features.
 

--- a/docs/reproject.rst
+++ b/docs/reproject.rst
@@ -157,7 +157,7 @@ the output dataset's transform matrix and, thereby, its spatial extent.
                     dst_crs=src.crs,
                     resampling=RESAMPLING.nearest)
 
-                dst.write_band(i, dest)
+                dst.write(dest, indexes=i)
 
 .. image:: https://farm8.staticflickr.com/7399/16390100651_54f01b8601_b_d.jpg)
 

--- a/docs/windowed-rw.rst
+++ b/docs/windowed-rw.rst
@@ -87,7 +87,7 @@ and 50 pixels to the right of the upper left corner of the GeoTIFF.
             '/tmp/example.tif', 'w',
             driver='GTiff', width=500, height=300, count=1,
             dtype=image.dtype) as dst:
-        dst.write_band(1, image, window=((30, 180), (50, 300)))
+        dst.write(image, window=((30, 180), (50, 300)), indexes=1)
     
 The result:
 
@@ -113,7 +113,7 @@ Below, the window is scaled to one third of the source image.
             driver='GTiff', width=500, height=300, count=3,
             dtype=r.dtype) as dst:
         for k, arr in [(1, b), (2, g), (3, r)]:
-            dst.write_band(k, arr, window=write_window)
+            dst.write(arr, indexes=k, window=write_window)
 
 And the result:
 
@@ -153,7 +153,7 @@ destination dataset.
             driver='GTiff', width=500, height=300, count=3,
             dtype=r.dtype) as dst:
         for k, arr in [(1, b), (2, g), (3, r)]:
-            dst.write_band(k, arr, window=write_window)
+            dst.write(arr, window=write_window, indexes=k)
 
 This example also demonstrates decimation.
 
@@ -242,7 +242,7 @@ The block windows themselves can be had from the block_windows function.
     ...
 
 This function returns an iterator that yields a pair of values. The second is
-a window tuple that can be used in calls to `read` or `write_band`. The first
+a window tuple that can be used in calls to `read` or `write`. The first
 is the pair of row and column indexes of this block within all blocks of the
 dataset.
 

--- a/examples/async-rasterio.py
+++ b/examples/async-rasterio.py
@@ -64,9 +64,7 @@ def main(infile, outfile, with_threads=False):
                     else:
                         compute(data, result)
                     
-                    # Write the result.
-                    for i, arr in enumerate(result, 1):
-                        dst.write_band(i, arr, window=window)
+                    dst.write(result, window=window)
 
                 # Queue up the loop's tasks.
                 tasks = [asyncio.Task(process_window(window)) 

--- a/examples/concurrent-cpu-bound.py
+++ b/examples/concurrent-cpu-bound.py
@@ -15,6 +15,7 @@ import numpy
 import rasterio
 from rasterio._example import compute
 
+
 def main(infile, outfile, num_workers=4):
 
     with rasterio.drivers():
@@ -60,11 +61,7 @@ def main(infile, outfile, num_workers=4):
 
                         result, window = future_to_window[future]
 
-                        # Since there's no multiband write() method yet in
-                        # Rasterio, we use write_band for each part of the
-                        # 3D data array.
-                        for i, arr in enumerate(result, 1):
-                            dst.write_band(i, arr, window=window)
+                        dst.write(result, window=window)
 
 
 if __name__ == '__main__':

--- a/examples/decimate.py
+++ b/examples/decimate.py
@@ -21,11 +21,10 @@ with rasterio.drivers():
             **meta
             ) as dst:
         for k, a in [(1, b), (2, g), (3, r)]:
-            dst.write_band(k, a)
+            dst.write(a, indexes=k)
 
     outfilename = os.path.join(tempfile.mkdtemp(), 'decimate.jpg')
 
     rasterio.copy(tmpfilename, outfilename, driver='JPEG', quality='30')
 
 info = subprocess.call(['open', outfilename])
-

--- a/examples/rasterize_geometry.py
+++ b/examples/rasterize_geometry.py
@@ -5,12 +5,18 @@ import rasterio
 from rasterio.features import rasterize
 from rasterio.transform import IDENTITY
 
+
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger('rasterize_geometry')
 
 
 rows = cols = 10
-geometry = {'type':'Polygon','coordinates':[[(2,2),(2,4.25),(4.25,4.25),(4.25,2),(2,2)]]}
+
+geometry = {
+    'type': 'Polygon',
+    'coordinates': [[(2, 2), (2, 4.25), (4.25, 4.25), (4.25, 2), (2, 2)]]}
+
+
 with rasterio.drivers():
     result = rasterize([geometry], out_shape=(rows, cols))
     with rasterio.open(
@@ -24,4 +30,4 @@ with rasterio.drivers():
             nodata=0,
             transform=IDENTITY,
             crs={'init': "EPSG:4326"}) as out:
-        out.write_band(1, result.astype(numpy.uint8))
+        out.write(result.astype(numpy.uint8), indexes=1)

--- a/examples/reproject.py
+++ b/examples/reproject.py
@@ -54,6 +54,6 @@ with rasterio.drivers():
             nodata=0,
             transform=dst_transform,
             crs=dst_crs) as dst:
-        dst.write_band(1, destination)
+        dst.write(destination, indexes=1)
 
 info = subprocess.call(['open', tiffname])

--- a/examples/sieve.py
+++ b/examples/sieve.py
@@ -29,7 +29,7 @@ with rasterio.drivers():
     kwargs = src.meta
     kwargs['transform'] = kwargs.pop('affine')
     with rasterio.open('example-sieved.tif', 'w', **kwargs) as dst:
-        dst.write_band(1, sieved)
+        dst.write(sieved, indexes=1)
 
 # Dump out gdalinfo's report card and open (or "eog") the TIFF.
 print(subprocess.check_output(

--- a/examples/total.py
+++ b/examples/total.py
@@ -28,7 +28,7 @@ with rasterio.drivers(CPL_DEBUG=True):
         compress='lzw')
 
     with rasterio.open('example-total.tif', 'w', **kwargs) as dst:
-        dst.write_band(1, total.astype(rasterio.uint8))
+        dst.write(total.astype(rasterio.uint8), indexes=1)
 
 # Dump out gdalinfo's report card and open the image.
 info = subprocess.check_output(

--- a/rasterio/rio/rasterize.py
+++ b/rasterio/rio/rasterize.py
@@ -177,7 +177,7 @@ def rasterize(
                     ne = result != fill
                     data[ne] = result[ne]
                     data.mask[ne] = False
-                    out.write_band(bidx, data)
+                    out.write(data, indexes=bidx)
 
         else:
             if like is not None:
@@ -268,4 +268,4 @@ def rasterize(
             kwargs['nodata'] = fill
 
             with rasterio.open(output, 'w', **kwargs) as out:
-                out.write_band(1, result)
+                out.write(result, indexes=1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,7 +199,7 @@ def basic_image_file(tmpdir, basic_image):
     }
     with rasterio.drivers():
         with rasterio.open(outfilename, 'w', **kwargs) as out:
-            out.write_band(1, image)
+            out.write(image, indexes=1)
 
     return outfilename
 
@@ -235,6 +235,6 @@ def pixelated_image_file(tmpdir, pixelated_image):
     }
     with rasterio.drivers():
         with rasterio.open(outfilename, 'w', **kwargs) as out:
-            out.write_band(1, image)
+            out.write(image, indexes=1)
 
     return outfilename

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -114,7 +114,7 @@ class WindowWriteTest(unittest.TestCase):
                 name, 'w', 
                 driver='GTiff', width=100, height=100, count=1, 
                 dtype=a.dtype) as s:
-            s.write_band(1, a, window=((30, 80), (10, 60)))
+            s.write(a, indexes=1, window=((30, 80), (10, 60)))
         # subprocess.call(["open", name])
         info = subprocess.check_output(["gdalinfo", "-stats", name])
         self.assert_(

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -96,7 +96,7 @@ class WindowReadTest(unittest.TestCase):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             windows = s.block_windows(1)
             ji, first_window = next(windows)
-            first_block = s.read_band(1, window=first_window)
+            first_block = s.read(1, window=first_window)
             self.assertEqual(first_block.dtype, rasterio.ubyte)
             self.assertEqual(
                 first_block.shape, 

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -29,7 +29,7 @@ def test_write_colormap(tmpdir):
     with rasterio.drivers():
 
         with rasterio.open('tests/data/shade.tif') as src:
-            shade = src.read_band(1)
+            shade = src.read(1)
             meta = src.meta
 
         tiffname = str(tmpdir.join('foo.png'))

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -36,7 +36,7 @@ def test_write_colormap(tmpdir):
         meta['driver'] = 'PNG'
 
         with rasterio.open(tiffname, 'w', **meta) as dst:
-            dst.write_band(1, shade)
+            dst.write(shade, indexes=1)
             dst.write_colormap(1, {0: (255, 0, 0, 255), 255: (0, 0, 0, 0)})
             cmap = dst.colormap(1)
             assert cmap[0] == (255, 0, 0, 255)

--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -15,6 +15,6 @@ def test_write_ubyte(tmpdir):
             name, 'w', 
             driver='PNG', width=100, height=100, count=1, 
             dtype=a.dtype) as s:
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -67,24 +67,24 @@ class ReaderContextTest(unittest.TestCase):
 
     def test_read_ubyte(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
-            a = s.read_band(1)
+            a = s.read(1)
             self.assertEqual(a.dtype, rasterio.ubyte)
 
     def test_read_ubyte_bad_index(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
-            self.assertRaises(IndexError, s.read_band, 0)
+            self.assertRaises(IndexError, s.read, 0)
 
     def test_read_ubyte_out(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             a = numpy.zeros((718, 791), dtype=rasterio.ubyte)
-            a = s.read_band(1, a)
+            a = s.read(1, a)
             self.assertEqual(a.dtype, rasterio.ubyte)
 
     def test_read_out_dtype_fail(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             a = numpy.zeros((718, 791), dtype=rasterio.float32)
             try:
-                s.read_band(1, a)
+                s.read(1, a)
             except ValueError as e:
                 assert "the array's dtype 'float32' does not match the file's dtype" in str(e)
             except:

--- a/tests/test_revolvingdoor.py
+++ b/tests/test_revolvingdoor.py
@@ -30,7 +30,7 @@ class RevolvingDoorTest(unittest.TestCase):
         tiffname = os.path.join(self.tempdir, 'foo.tif')
         
         with rasterio.open(tiffname, 'w', **meta) as dst:
-            dst.write_band(1, shade)
+            dst.write(shade, indexes=1)
 
         with rasterio.open(tiffname) as src:
             pass

--- a/tests/test_revolvingdoor.py
+++ b/tests/test_revolvingdoor.py
@@ -24,7 +24,7 @@ class RevolvingDoorTest(unittest.TestCase):
     def test_write_colormap_revolving_door(self):
 
         with rasterio.open('tests/data/shade.tif') as src:
-            shade = src.read_band(1)
+            shade = src.read(1)
             meta = src.meta
 
         tiffname = os.path.join(self.tempdir, 'foo.tif')

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -711,7 +711,7 @@ def test_rasterize_like_raster_outside_bounds(tmpdir, runner, basic_feature,
     assert 'outside bounds' in result.output
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert not numpy.any(out.read_band(1, masked=False))
+        assert not numpy.any(out.read(1, masked=False))
 
 
 def test_rasterize_invalid_stdin(tmpdir, runner):

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -182,7 +182,7 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
         "nodata": 255}
     with rasterio.drivers():
         with rasterio.open(outfilename, 'w', **kwargs) as out:
-            out.write_band(1, image)
+            out.write(image, indexes=1)
 
     output = str(tmpdir.join('test.tif'))
 
@@ -317,7 +317,7 @@ def test_shapes_with_nodata(runner, pixelated_image, pixelated_image_file):
     pixelated_image[0:2, 8:10] = 255
 
     with rasterio.open(pixelated_image_file, 'r+') as out:
-        out.write_band(1, pixelated_image)
+        out.write(pixelated_image, indexes=1)
 
     result = runner.invoke(
         main_group, ['shapes', pixelated_image_file, '--with-nodata'])
@@ -382,7 +382,7 @@ def test_shapes_mask(runner, pixelated_image, pixelated_image_file):
     pixelated_image[8:10, 8:10] = 255
 
     with rasterio.open(pixelated_image_file, 'r+') as out:
-        out.write_band(1, pixelated_image)
+        out.write(pixelated_image, indexes=1)
 
     result = runner.invoke(
         main_group, ['shapes', pixelated_image_file, '--mask'])
@@ -409,7 +409,7 @@ def test_shapes_mask_sampling(runner, pixelated_image, pixelated_image_file):
     pixelated_image[8:10, 8:10] = 255
 
     with rasterio.open(pixelated_image_file, 'r+') as out:
-        out.write_band(1, pixelated_image)
+        out.write(pixelated_image, indexes=1)
 
     result = runner.invoke(
         main_group,
@@ -433,7 +433,7 @@ def test_shapes_band1_as_mask(runner, pixelated_image, pixelated_image_file):
     pixelated_image[2:3, 2:3] = 4
 
     with rasterio.open(pixelated_image_file, 'r+') as out:
-        out.write_band(1, pixelated_image)
+        out.write(pixelated_image, indexes=1)
 
     result = runner.invoke(
         main_group,

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -81,7 +81,7 @@ def test_merge_with_nodata(test_data_dir_1):
     assert os.path.exists(outputname)
     with rasterio.open(outputname) as out:
         assert out.count == 1
-        data = out.read_band(1, masked=False)
+        data = out.read(1, masked=False)
         expected = numpy.ones((10, 10), dtype=rasterio.uint8)
         expected[0:6, 0:6] = 255
         expected[4:8, 4:8] = 254
@@ -109,7 +109,7 @@ def test_merge_without_nodata(test_data_dir_2):
     assert os.path.exists(outputname)
     with rasterio.open(outputname) as out:
         assert out.count == 1
-        data = out.read_band(1, masked=False)
+        data = out.read(1, masked=False)
         expected = numpy.zeros((10, 10), dtype=rasterio.uint8)
         expected[0:6, 0:6] = 255
         expected[4:8, 4:8] = 254
@@ -209,7 +209,7 @@ def test_merge_overlapping(test_data_dir_overlapping):
         assert out.count == 1
         assert out.shape == (15, 15)
         assert out.bounds == (-114, 43, -111, 46)
-        data = out.read_band(1, masked=False)
+        data = out.read(1, masked=False)
         expected = numpy.zeros((15, 15), dtype=rasterio.uint8)
         expected[0:10, 0:10] = 1
         expected[5:, 5:] = 2
@@ -253,7 +253,7 @@ def test_merge_float(test_data_dir_float):
     assert os.path.exists(outputname)
     with rasterio.open(outputname) as out:
         assert out.count == 1
-        data = out.read_band(1, masked=False)
+        data = out.read(1, masked=False)
         expected = numpy.ones((10, 10), dtype=rasterio.float64) * -1.5
         expected[0:6, 0:6] = 255
         expected[4:8, 4:8] = 254

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -33,12 +33,12 @@ def test_data_dir_1(tmpdir):
         with rasterio.open(str(tmpdir.join('b.tif')), 'w', **kwargs) as dst:
             data = numpy.ones((10, 10), dtype=rasterio.uint8)
             data[0:6, 0:6] = 255
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
         with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
             data = numpy.ones((10, 10), dtype=rasterio.uint8)
             data[4:8, 4:8] = 254
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
     return tmpdir
 
@@ -61,12 +61,12 @@ def test_data_dir_2(tmpdir):
         with rasterio.open(str(tmpdir.join('b.tif')), 'w', **kwargs) as dst:
             data = numpy.zeros((10, 10), dtype=rasterio.uint8)
             data[0:6, 0:6] = 255
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
         with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
             data = numpy.zeros((10, 10), dtype=rasterio.uint8)
             data[4:8, 4:8] = 254
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
     return tmpdir
 
@@ -187,12 +187,12 @@ def test_data_dir_overlapping(tmpdir):
     with rasterio.drivers():
         with rasterio.open(str(tmpdir.join('se.tif')), 'w', **kwargs) as dst:
             data = numpy.ones((10, 10), dtype=rasterio.uint8)
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
         kwargs['transform'] = (-113, 0.2, 0, 45, 0, -0.2)
         with rasterio.open(str(tmpdir.join('nw.tif')), 'w', **kwargs) as dst:
             data = numpy.ones((10, 10), dtype=rasterio.uint8) * 2
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
     return tmpdir
 
@@ -234,12 +234,12 @@ def test_data_dir_float(tmpdir):
         with rasterio.open(str(tmpdir.join('two.tif')), 'w', **kwargs) as dst:
             data = numpy.zeros((10, 10), dtype=rasterio.float64)
             data[0:6, 0:6] = 255
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
         with rasterio.open(str(tmpdir.join('one.tif')), 'w', **kwargs) as dst:
             data = numpy.zeros((10, 10), dtype=rasterio.float64)
             data[4:8, 4:8] = 254
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
     return tmpdir
 
 
@@ -268,11 +268,12 @@ def tiffs(tmpdir):
 
     data = numpy.ones((1, 1, 1), 'uint8')
 
-    kwargs = {'count': '1',
-              'driver': 'GTiff',
-              'dtype': 'uint8',
-              'height': 1,
-              'width': 1}
+    kwargs = {
+        'count': '1',
+        'driver': 'GTiff',
+        'dtype': 'uint8',
+        'height': 1,
+        'width': 1}
 
     kwargs['transform'] = Affine( 1, 0, 1,
                                   0,-1, 1)

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -323,7 +323,7 @@ def test_warp_reproject_like(runner, tmpdir):
     with rasterio.drivers():
         with rasterio.open(likename, 'w', **kwargs) as dst:
             data = numpy.zeros((10, 10), dtype=rasterio.uint8)
-            dst.write_band(1, data)
+            dst.write(data, indexes=1)
 
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -26,7 +26,7 @@ def test_update_tags(data):
 def test_update_band(data):
     tiffname = str(data.join('RGB.byte.tif'))
     with rasterio.open(tiffname, 'r+') as f:
-        f.write_band(1, numpy.zeros(f.shape, dtype=f.dtypes[0]))
+        f.write(numpy.zeros(f.shape, dtype=f.dtypes[0]), indexes=1)
     with rasterio.open(tiffname) as f:
         assert not f.read_band(1).any()
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -28,7 +28,7 @@ def test_update_band(data):
     with rasterio.open(tiffname, 'r+') as f:
         f.write(numpy.zeros(f.shape, dtype=f.dtypes[0]), indexes=1)
     with rasterio.open(tiffname) as f:
-        assert not f.read_band(1).any()
+        assert not f.read(1).any()
 
 
 def test_update_spatial(data):

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -186,7 +186,7 @@ def test_calculate_default_transform_multiple_resolutions():
 def test_reproject_ndarray():
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read_band(1)
+            source = src.read(1)
 
         dst_crs = dict(
             proj='merc',
@@ -216,7 +216,7 @@ def test_reproject_ndarray():
 def test_reproject_epsg():
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read_band(1)
+            source = src.read(1)
 
         dst_crs = {'init': 'EPSG:3857'}
         out = numpy.empty(src.shape, dtype=numpy.uint8)
@@ -235,7 +235,7 @@ def test_reproject_out_of_bounds():
     # using EPSG code not appropriate for the transform should return blank image
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read_band(1)
+            source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
         out = numpy.empty(src.shape, dtype=numpy.uint8)
@@ -563,7 +563,7 @@ def test_reproject_unsupported_resampling():
     """Values not in enums.Resampling are not supported."""
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read_band(1)
+            source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
         out = numpy.empty(src.shape, dtype=numpy.uint8)
@@ -582,7 +582,7 @@ def test_reproject_unsupported_resampling_guass():
     """Resampling.gauss is unsupported."""
     with rasterio.drivers():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read_band(1)
+            source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
         out = numpy.empty(src.shape, dtype=numpy.uint8)

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -46,7 +46,7 @@ def test_no_crs(tmpdir):
     with rasterio.open(
             name, 'w', driver='GTiff', width=100, height=100, count=1,
             dtype=rasterio.uint8) as dst:
-        dst.write_band(1, numpy.ones((100, 100), dtype=rasterio.uint8))
+        dst.write(numpy.ones((100, 100), dtype=rasterio.uint8), indexes=1)
 
 def test_context(tmpdir):
     name = str(tmpdir.join("test_context.tif"))
@@ -81,7 +81,7 @@ def test_write_ubyte(tmpdir):
             name, 'w', 
             driver='GTiff', width=100, height=100, count=1, 
             dtype=a.dtype) as s:
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
 def test_write_ubyte_multi(tmpdir):
@@ -123,24 +123,24 @@ def test_write_float(tmpdir):
             driver='GTiff', width=100, height=100, count=2,
             dtype=rasterio.float32) as s:
         assert s.dtypes == (rasterio.float32, rasterio.float32)
-        s.write_band(1, a)
-        s.write_band(2, a)
+        s.write(a, indexes=1)
+        s.write(a, indexes=2)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=42.000, Maximum=42.000, Mean=42.000, StdDev=0.000" in info
-    
+
 def test_write_crs_transform(tmpdir):
     name = str(tmpdir.join("test_write_crs_transform.tif"))
     a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
     transform = [101985.0, 300.0379266750948, 0.0,
                        2826915.0, 0.0, -300.041782729805]
     with rasterio.open(
-            name, 'w', 
+            name, 'w',
             driver='GTiff', width=100, height=100, count=1,
-            crs={'units': 'm', 'no_defs': True, 'ellps': 'WGS84', 
+            crs={'units': 'm', 'no_defs': True, 'ellps': 'WGS84',
                  'proj': 'utm', 'zone': 18},
             transform=transform,
             dtype=rasterio.ubyte) as s:
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     assert s.crs == {'init': 'epsg:32618'}
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert 'PROJCS["UTM Zone 18, Northern Hemisphere",' in info
@@ -154,13 +154,13 @@ def test_write_crs_transform_affine(tmpdir):
     transform = [101985.0, 300.0379266750948, 0.0,
                        2826915.0, 0.0, -300.041782729805]
     with rasterio.open(
-            name, 'w', 
+            name, 'w',
             driver='GTiff', width=100, height=100, count=1,
-            crs={'units': 'm', 'no_defs': True, 'ellps': 'WGS84', 
+            crs={'units': 'm', 'no_defs': True, 'ellps': 'WGS84',
                  'proj': 'utm', 'zone': 18},
             affine=transform,
             dtype=rasterio.ubyte) as s:
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     assert s.crs == {'init': 'epsg:32618'}
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert 'PROJCS["UTM Zone 18, Northern Hemisphere",' in info
@@ -175,12 +175,12 @@ def test_write_crs_transform_2(tmpdir):
     transform = [101985.0, 300.0379266750948, 0.0,
                        2826915.0, 0.0, -300.041782729805]
     with rasterio.open(
-            name, 'w', 
+            name, 'w',
             driver='GTiff', width=100, height=100, count=1,
             crs='EPSG:32618',
             transform=transform,
             dtype=rasterio.ubyte) as s:
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     assert s.crs == {'init': 'epsg:32618'}
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert 'PROJCS["WGS 84 / UTM zone 18N",' in info
@@ -196,12 +196,12 @@ def test_write_crs_transform_3(tmpdir):
                        2826915.0, 0.0, -300.041782729805]
     crs_wkt = 'PROJCS["UTM Zone 18, Northern Hemisphere",GEOGCS["WGS 84",DATUM["unknown",SPHEROID["WGS84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-75],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]'
     with rasterio.open(
-            name, 'w', 
+            name, 'w',
             driver='GTiff', width=100, height=100, count=1,
             crs=crs_wkt,
             transform=transform,
             dtype=rasterio.ubyte) as s:
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     assert s.crs == {'init': 'epsg:32618'}
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert 'PROJCS["UTM Zone 18, Northern Hemisphere",' in info
@@ -214,19 +214,19 @@ def test_write_meta(tmpdir):
     a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
     meta = dict(driver='GTiff', width=100, height=100, count=1)
     with rasterio.open(name, 'w', dtype=a.dtype, **meta) as s:
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
-    
+
 def test_write_nodata(tmpdir):
     name = str(tmpdir.join("test_write_nodata.tif"))
     a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
     with rasterio.open(
-            name, 'w', 
-            driver='GTiff', width=100, height=100, count=2, 
+            name, 'w',
+            driver='GTiff', width=100, height=100, count=2,
             dtype=a.dtype, nodata=0) as s:
-        s.write_band(1, a)
-        s.write_band(2, a)
+        s.write(a, indexes=1)
+        s.write(a, indexes=2)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "NoData Value=0" in info
 
@@ -252,7 +252,7 @@ def test_write_lzw(tmpdir):
             dtype=a.dtype,
             compress='LZW') as s:
         assert ('compress', 'LZW') in s.kwds.items()
-        s.write_band(1, a)
+        s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert "LZW" in info
 
@@ -276,5 +276,5 @@ def test_write_noncontiguous(tmpdir):
     }
     with rasterio.open(name, 'w', **kwargs) as dst:
         for i in range(BANDS):
-            dst.write_band(i+1, arr[:,:,i])
+            dst.write(arr[:,:,i], indexes=i+1)
 


### PR DESCRIPTION
Deleting the methods should be the only remaining change for `1.0` to completely remove `read_band()` and `write_band()`.