### PR TITLE
fixes #669

### DIFF
--- a/rasterio/rio/stack.py
+++ b/rasterio/rio/stack.py
@@ -1,4 +1,5 @@
 """Commands for operating on bands of datasets."""
+import collections
 import logging
 
 import click
@@ -105,7 +106,7 @@ def stack(ctx, files, output, driver, bidx, photometric, force_overwrite,
                             data = src.read(index)
                             dst.write(data, dst_idx)
                             dst_idx += 1
-                        elif isinstance(index, list):
+                        elif isinstance(index, collections.Iterable):
                             data = src.read(index)
                             dst.write(data, range(dst_idx, dst_idx+len(index)))
                             dst_idx += len(index)

--- a/tests/test_rio_stack.py
+++ b/tests/test_rio_stack.py
@@ -14,6 +14,7 @@ def test_stack(tmpdir):
     assert result.exit_code == 0
     with rasterio.open(outputname) as out:
         assert out.count == 3
+        assert out.read(1).max() > 0
 
 
 def test_stack_list(tmpdir):


### PR DESCRIPTION
`rio stack` explicitly type-checked for lists. The caused a bug when we started returning indexes as tuples in #655 

This PR makes checks for the Iterable base class and adds a test that the output data's max > 0. 