### PR TITLE
Fixes #322 by ensuring src.shape == src.read().shape

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -255,7 +255,7 @@ def band(ds, bidx):
         ds,
         bidx,
         set(ds.dtypes).pop(),
-        ds.shape)
+        ds.shape[1:])
 
 
 def pad(array, transform, pad_width, mode=None, **kwargs):

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -90,7 +90,7 @@ cdef class DatasetReader(object):
         self._count = _gdal.GDALGetRasterCount(self._hds)
         self.width = _gdal.GDALGetRasterXSize(self._hds)
         self.height = _gdal.GDALGetRasterYSize(self._hds)
-        self.shape = (self.height, self.width)
+        self.shape = (self._count, self.height, self.width)
 
         self._transform = self.read_transform()
         self._crs = self.read_crs()

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -751,7 +751,7 @@ cdef class RasterReader(_base.DatasetReader):
                 (r_start, r_stop), (c_start, c_stop) = window
                 win_shape += (r_stop - r_start, c_stop - c_start)
         else:
-            win_shape += self.shape
+            win_shape += self.shape[1:]
 
         if out is not None:
             if out.dtype != dtype:
@@ -955,7 +955,7 @@ cdef class RasterReader(_base.DatasetReader):
                 win_shape += (maxr - minr, maxc - minc)
                 window = ((minr, maxr), (minc, maxc))
         else:
-            win_shape += self.shape
+            win_shape += self.shape[1:]
         
         dtype = 'uint8'
 
@@ -1154,7 +1154,7 @@ cdef class RasterReader(_base.DatasetReader):
             out_shape = (
                 window 
                 and window_shape(window, self.height, self.width) 
-                or self.shape)
+                or self.shape[1:])
             out = np.empty(out_shape, np.uint8)
         if window:
             window = eval_window(window, self.height, self.width)
@@ -1374,7 +1374,7 @@ cdef class RasterUpdater(RasterReader):
         self._count = _gdal.GDALGetRasterCount(self._hds)
         self.width = _gdal.GDALGetRasterXSize(self._hds)
         self.height = _gdal.GDALGetRasterYSize(self._hds)
-        self.shape = (self.height, self.width)
+        self.shape = (self._count, self.height, self.width)
 
         self._transform = self.read_transform()
         self._crs = self.read_crs()
@@ -1997,7 +1997,7 @@ cdef class IndirectRasterUpdater(RasterUpdater):
         self._count = _gdal.GDALGetRasterCount(self._hds)
         self.width = _gdal.GDALGetRasterXSize(self._hds)
         self.height = _gdal.GDALGetRasterYSize(self._hds)
-        self.shape = (self.height, self.width)
+        self.shape = (self._count, self.height, self.width)
 
         self._transform = self.read_transform()
         self._crs = self.read_crs()

--- a/tests/test_band.py
+++ b/tests/test_band.py
@@ -6,5 +6,5 @@ def test_band():
         assert b.ds == src
         assert b.bidx == 1
         assert b.dtype in src.dtypes
-        assert b.shape == src.shape
+        assert b.shape == src.shape[1:]
 

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -39,7 +39,7 @@ def tiffs(tmpdir):
                 str(tmpdir.join('sidecar-masked.tif')), 'w',
                 **profile) as dst:
             dst.write(src.read(masked=False))
-            mask = np.zeros(src.shape, dtype='uint8')
+            mask = np.zeros(src.shape[1:], dtype='uint8')
             dst.write_mask(mask)
 
     return tmpdir

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -19,7 +19,7 @@ def test_index():
 def test_full_window():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds
-        assert src.window(left, bottom, right, top) == tuple(zip((0, 0), src.shape))
+        assert src.window(left, bottom, right, top) == tuple(zip((0, 0), src.shape[1:]))
 
 
 def test_window_no_exception():

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -21,7 +21,7 @@ class ReaderContextTest(unittest.TestCase):
             self.assertEqual(s.count, 3)
             self.assertEqual(s.width, 791)
             self.assertEqual(s.height, 718)
-            self.assertEqual(s.shape, (718, 791))
+            self.assertEqual(s.shape, (3, 718, 791))
             self.assertEqual(s.dtypes, tuple([rasterio.ubyte] * 3))
             self.assertEqual(s.nodatavals, (0, 0, 0))
             self.assertEqual(s.indexes, (1, 2, 3))
@@ -43,7 +43,7 @@ class ReaderContextTest(unittest.TestCase):
         self.assertEqual(s.count, 3)
         self.assertEqual(s.width, 791)
         self.assertEqual(s.height, 718)
-        self.assertEqual(s.shape, (718, 791))
+        self.assertEqual(s.shape, (3, 718, 791))
         self.assertEqual(s.dtypes, tuple([rasterio.ubyte] * 3))
         self.assertEqual(s.nodatavals, (0, 0, 0))
         self.assertEqual(s.crs['init'], 'epsg:32618')
@@ -185,7 +185,7 @@ class ReaderContextTest(unittest.TestCase):
         the dataset's bounds."""
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             a = s.read(window=((None, 20000), (None, 20000)))
-            self.assertEqual(a.shape, (3,) + s.shape)
+            self.assertEqual(a.shape, s.shape)
 
     def test_read_window_beyond(self):
         """Test graceful Numpy-like handling of windows beyond

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -90,14 +90,14 @@ def test_read_boundless_noshift():
         # the read offsets should be determined by start col/row alone
         # when col stop exceeds image width
         c1 = src.read(boundless=True,
-                      window=((100, 101), (-1, src.shape[1])))[0, 0, 0:9]
+                      window=((100, 101), (-1, src.shape[2])))[0, 0, 0:9]
         c2 = src.read(boundless=True,
-                      window=((100, 101), (-1, src.shape[1] + 1)))[0, 0, 0:9]
+                      window=((100, 101), (-1, src.shape[2] + 1)))[0, 0, 0:9]
         assert numpy.array_equal(c1, c2)
 
         # when row stop exceeds image height
         r1 = src.read(boundless=True,
-                      window=((-1, src.shape[0]), (100, 101)))[0, 0, 0:9]
+                      window=((-1, src.shape[1]), (100, 101)))[0, 0, 0:9]
         r2 = src.read(boundless=True,
-                      window=((-1, src.shape[0] + 1), (100, 101)))[0, 0, 0:9]
+                      window=((-1, src.shape[1] + 1), (100, 101)))[0, 0, 0:9]
         assert numpy.array_equal(r1, r2)

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -12,7 +12,7 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 def test_read_boundless_natural_extent():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         data = src.read(boundless=True)
-        assert data.shape == (3, src.height, src.width)
+        assert data.shape == src.shape
         assert abs(data[0].mean() - src.read(1).mean()) < 0.0001
         assert data.any()
 

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -23,7 +23,7 @@ def test_clip_bounds(runner, tmpdir):
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert out.shape == (420, 173)
+        assert out.shape == (1, 420, 173)
 
 
 def test_clip_like(runner, tmpdir):

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -207,7 +207,7 @@ def test_merge_overlapping(test_data_dir_overlapping):
     assert os.path.exists(outputname)
     with rasterio.open(outputname) as out:
         assert out.count == 1
-        assert out.shape == (15, 15)
+        assert out.shape == (1, 15, 15)
         assert out.bounds == (-114, 43, -111, 46)
         data = out.read(1, masked=False)
         expected = numpy.zeros((15, 15), dtype=rasterio.uint8)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -26,7 +26,7 @@ def test_update_tags(data):
 def test_update_band(data):
     tiffname = str(data.join('RGB.byte.tif'))
     with rasterio.open(tiffname, 'r+') as f:
-        f.write(numpy.zeros(f.shape, dtype=f.dtypes[0]), indexes=1)
+        f.write(numpy.zeros(f.shape[1:], dtype=f.dtypes[0]), indexes=1)
     with rasterio.open(tiffname) as f:
         assert not f.read(1).any()
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -201,7 +201,7 @@ def test_reproject_ndarray():
             nadgrids='@null',
             wktext=True,
             no_defs=True)
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = numpy.empty(src.shape[1:], dtype=numpy.uint8)
         reproject(
             source,
             out,
@@ -219,7 +219,7 @@ def test_reproject_epsg():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:3857'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = numpy.empty(src.shape[1:], dtype=numpy.uint8)
         reproject(
             source,
             out,
@@ -238,7 +238,7 @@ def test_reproject_out_of_bounds():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = numpy.empty(src.shape[1:], dtype=numpy.uint8)
         reproject(
             source,
             out,
@@ -409,7 +409,7 @@ def test_reproject_multi():
             nadgrids='@null',
             wktext=True,
             no_defs=True)
-        destin = numpy.empty(source.shape, dtype=numpy.uint8)
+        destin = numpy.empty(source.shape[1:], dtype=numpy.uint8)
         reproject(
             source,
             destin,
@@ -437,7 +437,7 @@ def test_warp_from_file():
             nadgrids='@null',
             wktext=True,
             no_defs=True)
-        destin = numpy.empty(src.shape, dtype=numpy.uint8)
+        destin = numpy.empty(src.shape[1:], dtype=numpy.uint8)
         reproject(
             rasterio.band(src, 1),
             destin,
@@ -566,7 +566,7 @@ def test_reproject_unsupported_resampling():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = numpy.empty(src.shape[1:], dtype=numpy.uint8)
         with pytest.raises(ValueError):
             reproject(
                 source,
@@ -585,7 +585,7 @@ def test_reproject_unsupported_resampling_guass():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = numpy.empty(src.shape[1:], dtype=numpy.uint8)
         with pytest.raises(ValueError):
             reproject(
                 source,

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -409,7 +409,7 @@ def test_reproject_multi():
             nadgrids='@null',
             wktext=True,
             no_defs=True)
-        destin = numpy.empty(source.shape[1:], dtype=numpy.uint8)
+        destin = numpy.empty(source.shape, dtype=numpy.uint8)
         reproject(
             source,
             destin,

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -60,14 +60,14 @@ def test_context(tmpdir):
         assert s.count == 1
         assert s.width == 100
         assert s.height == 100
-        assert s.shape == (100, 100)
+        assert s.shape == (1, 100, 100)
         assert s.indexes == (1,)
         assert repr(s) == "<open RasterUpdater name='%s' mode='w'>" % name
     assert s.closed == True
     assert s.count == 1
     assert s.width == 100
     assert s.height == 100
-    assert s.shape == (100, 100)
+    assert s.shape == (1, 100, 100)
     assert repr(s) == "<closed RasterUpdater name='%s' mode='w'>" % name
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert "GTiff" in info


### PR DESCRIPTION
I've not managed to run the tests to verify everything has been caught yet and need a little help with this.
Running `py.test` gives a load of import errors and I presume this is because I need to build the cython files. Is this just a case of running `python setup.py` or does it work a different way for development?