### PR TITLE
per-dataset mask

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1122,14 +1122,14 @@ cdef class RasterReader(_base.DatasetReader):
         return out
 
 
-    def dataset_mask(self, **kwargs):
+    def dataset_mask(self, *args, window=None, boundless=False):
         """Calculate the dataset's 2D mask. Derived from the individual band masks
         provided by read_masks().
 
         Parameters
         ----------
-        All kwargs except indexes are passed to read_masks()
-        See read_masks for details
+        position args ignored
+        window and boundless are passed directly to read_masks()
         
         Returns
         -------
@@ -1150,7 +1150,10 @@ cdef class RasterReader(_base.DatasetReader):
         in that it applies per-dataset, not per-band
         (see https://trac.osgeo.org/gdal/wiki/rfc15_nodatabitmask)
         """
-        del kwargs['indexes']  # this method determines indexes
+        del args
+        kwargs = {
+            'window': window,
+            'boundless': boundless}
 
         # GDAL found dataset-wide alpha band or mask
         # All band masks are equal so we can return the first

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1122,6 +1122,53 @@ cdef class RasterReader(_base.DatasetReader):
         return out
 
 
+    def dataset_mask(self, **kwargs):
+        """Calculate the dataset's 2D mask. Derived from the individual band masks
+        provided by read_masks().
+
+        Parameters
+        ----------
+        All kwargs except indexes are passed to read_masks()
+        See read_masks for details
+        
+        Returns
+        -------
+        ndarray, shape=(self.height, self.width), dtype='uint8'
+        0 = nodata, 255 = valid data
+
+        The dataset mask is calculate based on the individual band masks according to
+        the following logic, in order of precedence:
+
+        1. If a .msk file, dataset-wide alpha or internal mask exists,
+           it will be used as the dataset mask.
+        2. If an 4-band RGBA with a shadow nodata value,
+           band 4 will be used as the dataset mask.
+        3. If a nodata value exists, use the binary OR (|) of the band masks
+        4. If no nodata value exists, return a mask filled with 255
+
+        Note that this differs from read_masks and GDAL RFC15
+        in that it applies per-dataset, not per-band
+        (see https://trac.osgeo.org/gdal/wiki/rfc15_nodatabitmask)
+        """
+        del kwargs['indexes']  # this method determines indexes
+
+        # GDAL found dataset-wide alpha band or mask
+        # All band masks are equal so we can return the first
+        if self.mask_flags[0] & MaskFlags.per_dataset:
+            return self.read_masks(1, **kwargs)
+
+        # use Alpha mask if available and looks like RGB, even if nodata is shadowing
+        elif self.count == 4 and self.colorinterp(1) == ColorInterp.red:
+            return self.read_masks(4, **kwargs)
+
+        # Or use the binary OR intersection of all GDALGetMaskBands
+        else:
+            mask = self.read_masks(1, **kwargs)
+            for i in range(1, self.count):
+                mask = mask | self.read_masks(i, **kwargs)
+            return mask
+        
+
     def read_mask(self, indexes=None, out=None, window=None, boundless=False):
         """Read the mask band into an `out` array if provided, 
         otherwise return a new array containing the dataset's

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1122,13 +1122,12 @@ cdef class RasterReader(_base.DatasetReader):
         return out
 
 
-    def dataset_mask(self, *args, window=None, boundless=False):
+    def dataset_mask(self, window=None, boundless=False):
         """Calculate the dataset's 2D mask. Derived from the individual band masks
         provided by read_masks().
 
         Parameters
         ----------
-        position args ignored
         window and boundless are passed directly to read_masks()
         
         Returns
@@ -1150,7 +1149,6 @@ cdef class RasterReader(_base.DatasetReader):
         in that it applies per-dataset, not per-band
         (see https://trac.osgeo.org/gdal/wiki/rfc15_nodatabitmask)
         """
-        del args
         kwargs = {
             'window': window,
             'boundless': boundless}

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -164,14 +164,6 @@ def test_rgba_msk(tiffs):
         # mask takes precendent over alpha
         assert np.array_equal(src.dataset_mask(), msk)
 
-def test_args(tiffs):
-    with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
-        res = src.dataset_mask()
-        assert np.array_equal(res , alp)
-        # positional args ignored
-        other = src.dataset_mask('FOO')
-        assert np.array_equal(res, other)
-
 def test_kwargs(tiffs):
     with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
         # window and boundless are passed along

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -1,0 +1,161 @@
+import logging
+import sys
+
+import numpy as np
+import pytest
+
+from affine import Affine
+import rasterio
+from rasterio.enums import MaskFlags
+from rasterio.errors import NodataShadowWarning
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+# Setup test arrays
+red = np.array([[0, 0, 0],
+                [0, 1, 1],
+                [1, 0, 1]]).astype('uint8') * 255
+
+grn = np.array([[0, 0, 0],
+                [1, 0, 1],
+                [1, 0, 1]]).astype('uint8') * 255
+
+blu = np.array([[0, 0, 0],
+                [1, 1, 0],
+                [1, 0, 1]]).astype('uint8') * 255
+
+# equivalent to alp = red | grn | blu
+# 255 anywhere there is at least on r g b value
+alp = np.array([[0, 0, 0],
+                [1, 1, 1],
+                [1, 0, 1]]).astype('uint8') * 255
+
+# mask might be constructed using different tools
+# and differ from a strict interpretation of rgb values
+msk = np.array([[0, 0, 0],
+                [1, 1, 1],
+                [1, 1, 1]]).astype('uint8') * 255
+
+alldata = np.array([[1, 1, 1],
+                    [1, 1, 1],
+                    [1, 1, 1]]).astype('uint8') * 255
+
+
+@pytest.fixture(scope='function')
+def tiffs(tmpdir):
+
+    _profile = {
+        'affine': Affine(5.0, 0.0, 0.0, 0.0, -5.0, 0.0),
+        'transform': Affine(5.0, 0.0, 0.0, 0.0, -5.0, 0.0),
+        'crs': {'init': 'epsg:4326'},
+        'driver': 'GTiff',
+        'dtype': 'uint8',
+        'height': 3,
+        'width': 3}
+
+    # 1. RGB without nodata value
+    prof = _profile.copy()
+    prof['count'] = 3
+    prof['nodata'] = None
+    with rasterio.open(str(tmpdir.join('rgb_no_ndv.tif')), 'w', **prof) as dst:
+        dst.write(red, 1)
+        dst.write(grn, 2)
+        dst.write(blu, 3)
+
+    # 2. RGB with nodata value
+    prof = _profile.copy()
+    prof['count'] = 3
+    prof['nodata'] = 0
+    with rasterio.open(str(tmpdir.join('rgb_ndv.tif')), 'w', **prof) as dst:
+        dst.write(red, 1)
+        dst.write(grn, 2)
+        dst.write(blu, 3)
+
+    # 3. RGBA without nodata value
+    prof = _profile.copy()
+    prof['count'] = 4
+    prof['nodata'] = None
+    with rasterio.open(str(tmpdir.join('rgba_no_ndv.tif')), 'w', **prof) as dst:
+        dst.write(red, 1)
+        dst.write(grn, 2)
+        dst.write(blu, 3)
+        dst.write(alp, 4)
+
+    # 4. RGBA with nodata value
+    prof = _profile.copy()
+    prof['count'] = 4
+    prof['nodata'] = 0
+    with rasterio.open(str(tmpdir.join('rgba_ndv.tif')), 'w', **prof) as dst:
+        dst.write(red, 1)
+        dst.write(grn, 2)
+        dst.write(blu, 3)
+        dst.write(alp, 4)
+
+    # 5. RGB with msk
+    prof = _profile.copy()
+    prof['count'] = 3
+    with rasterio.open(str(tmpdir.join('rgb_msk.tif')), 'w', **prof) as dst:
+        dst.write(red, 1)
+        dst.write(grn, 2)
+        dst.write(blu, 3)
+        dst.write_mask(msk)
+
+    # 6. RGB with msk (internal)
+    prof = _profile.copy()
+    prof['count'] = 3
+    with rasterio.Env(GDAL_TIFF_INTERNAL_MASK=True) as env:
+        with rasterio.open(str(tmpdir.join('rgb_msk_internal.tif')),
+                           'w', **prof) as dst:
+            dst.write(red, 1)
+            dst.write(grn, 2)
+            dst.write(blu, 3)
+            dst.write_mask(msk)
+
+    # 7. RGBA with msk
+    prof = _profile.copy()
+    prof['count'] = 4
+    with rasterio.open(str(tmpdir.join('rgba_msk.tif')), 'w', **prof) as dst:
+        dst.write(red, 1)
+        dst.write(grn, 2)
+        dst.write(blu, 3)
+        dst.write(alp, 4)
+        dst.write_mask(msk)
+
+    return tmpdir
+
+
+def test_no_ndv(tiffs):
+    with rasterio.open(str(tiffs.join('rgb_no_ndv.tif'))) as src:
+        assert np.array_equal(src.dataset_mask(), alldata)
+
+def test_rgb_ndv(tiffs):
+    with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
+        assert np.array_equal(src.dataset_mask(), alp)
+
+def test_rgba_no_ndv(tiffs):
+    with rasterio.open(str(tiffs.join('rgba_no_ndv.tif'))) as src:
+        assert np.array_equal(src.dataset_mask(), alp)
+
+def test_rgba_ndv(tiffs):
+    with rasterio.open(str(tiffs.join('rgba_ndv.tif'))) as src:
+        with pytest.warns(NodataShadowWarning):
+            res = src.dataset_mask()
+        assert np.array_equal(res, alp)
+
+def test_rgb_msk(tiffs):
+    with rasterio.open(str(tiffs.join('rgb_msk.tif'))) as src:
+        assert np.array_equal(src.dataset_mask(), msk)
+        # each band's mask is also equal
+        for bmask in src.read_masks():
+            assert np.array_equal(bmask, msk)
+
+def test_rgb_msk_int(tiffs):
+    with rasterio.open(str(tiffs.join('rgb_msk_internal.tif'))) as src:
+        assert np.array_equal(src.dataset_mask(), msk)
+
+def test_rgba_msk(tiffs):
+    with rasterio.open(str(tiffs.join('rgba_msk.tif'))) as src:
+        # mask takes precendent over alpha
+        assert np.array_equal(src.dataset_mask(), msk)

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -42,6 +42,10 @@ alldata = np.array([[1, 1, 1],
                     [1, 1, 1],
                     [1, 1, 1]]).astype('uint8') * 255
 
+# boundless window ((1, 4, (1, 4))
+alp_shift_lr = np.array([[1, 1, 0],
+                         [0, 1, 0],
+                         [0, 0, 0]]).astype('uint8') * 255
 
 @pytest.fixture(scope='function')
 def tiffs(tmpdir):
@@ -159,3 +163,21 @@ def test_rgba_msk(tiffs):
     with rasterio.open(str(tiffs.join('rgba_msk.tif'))) as src:
         # mask takes precendent over alpha
         assert np.array_equal(src.dataset_mask(), msk)
+
+def test_args(tiffs):
+    with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
+        res = src.dataset_mask()
+        assert np.array_equal(res , alp)
+        # positional args ignored
+        other = src.dataset_mask('FOO')
+        assert np.array_equal(res, other)
+
+def test_kwargs(tiffs):
+    with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
+        # window and boundless are passes along
+        other = src.dataset_mask(window=((1, 4), (1, 4)), boundless=True)
+        assert np.array_equal(alp_shift_lr, other)
+
+        # band indexes are not supported
+        with pytest.raises(TypeError):
+            src.dataset_mask(indexes=1)

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -27,7 +27,7 @@ blu = np.array([[0, 0, 0],
                 [1, 0, 1]]).astype('uint8') * 255
 
 # equivalent to alp = red | grn | blu
-# 255 anywhere there is at least on r g b value
+# valid data anywhere there is at least one R, G or B value
 alp = np.array([[0, 0, 0],
                 [1, 1, 1],
                 [1, 0, 1]]).astype('uint8') * 255
@@ -174,7 +174,7 @@ def test_args(tiffs):
 
 def test_kwargs(tiffs):
     with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
-        # window and boundless are passes along
+        # window and boundless are passed along
         other = src.dataset_mask(window=((1, 4), (1, 4)), boundless=True)
         assert np.array_equal(alp_shift_lr, other)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -133,9 +133,14 @@ def test_session_env_lazy(monkeypatch, gdalenv):
     monkeypatch.setenv('AWS_SESSION_TOKEN', 'token')
     with Env() as s:
         s.get_aws_credentials()
-        assert getenv() == rasterio.env._env.options == {
-            'aws_access_key_id': 'id', 'aws_secret_access_key': 'key',
+        assert getenv() == rasterio.env._env.options
+        expected = {
+            'aws_access_key_id': 'id',
+            'aws_secret_access_key': 'key',
             'aws_session_token': 'token'}
+        for k, v in expected.items():
+            assert getenv()[k] == v
+
     monkeypatch.undo()
 
 


### PR DESCRIPTION
This PR implements a `RasterReader.dataset_mask` method which calculates a per-dataset mask according to a simple heuristic.

resolves #705 and (unrelated except for getting my local tests to pass) fixes #715 