### PR TITLE
Standardize on import numpy as np.

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -298,9 +298,9 @@ def pad(array, transform, pad_width, mode=None, **kwargs):
     See numpy docs for details on mode and other kwargs:
     http://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.pad.html
     """
-    import numpy
+    import numpy as np
     transform = guard_transform(transform)
-    padded_array = numpy.pad(array, pad_width, mode, **kwargs)
+    padded_array = np.pad(array, pad_width, mode, **kwargs)
     padded_trans = list(transform)
     padded_trans[2] -= pad_width * padded_trans[0]
     padded_trans[5] -= pad_width * padded_trans[4]

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -100,10 +100,10 @@ def get_minimum_dtype(values):
     -------
     rasterio dtype string
     """
-    import numpy
+    import numpy as np
 
     if not is_ndarray(values):
-        values = numpy.array(values)
+        values = np.array(values)
 
     min_value = values.min()
     max_value = values.max()
@@ -129,9 +129,9 @@ def get_minimum_dtype(values):
 
 def is_ndarray(array):
     """Check if array is a ndarray."""
-    import numpy
+    import numpy as np
 
-    return isinstance(array, numpy.ndarray) or hasattr(array, '__array__')
+    return isinstance(array, np.ndarray) or hasattr(array, '__array__')
 
 
 def can_cast_dtype(values, dtype):
@@ -147,19 +147,19 @@ def can_cast_dtype(values, dtype):
     boolean
         True if values can be cast to data type.
     """
-    import numpy
+    import numpy as np
 
     if not is_ndarray(values):
-        values = numpy.array(values)
+        values = np.array(values)
 
-    if values.dtype.name == numpy.dtype(dtype).name:
+    if values.dtype.name == np.dtype(dtype).name:
         return True
 
     elif values.dtype.kind == 'f':
-        return numpy.allclose(values, values.astype(dtype))
+        return np.allclose(values, values.astype(dtype))
 
     else:
-        return numpy.array_equal(values, values.astype(dtype))
+        return np.array_equal(values, values.astype(dtype))
 
 
 def validate_dtype(values, valid_dtypes):
@@ -176,10 +176,10 @@ def validate_dtype(values, valid_dtypes):
     boolean:
         True if dtype of values is one of valid_dtypes
     """
-    import numpy
+    import numpy as np
 
     if not is_ndarray(values):
-        values = numpy.array(values)
+        values = np.array(values)
 
     return (values.dtype.name in valid_dtypes or
             get_minimum_dtype(values) in valid_dtypes)

--- a/rasterio/rio/insp.py
+++ b/rasterio/rio/insp.py
@@ -8,7 +8,7 @@ import sys
 import collections
 import warnings
 
-import numpy
+import numpy as np
 import click
 
 from . import options
@@ -45,12 +45,12 @@ def stats(source):
         arr = source[0].read(source[1])
     else:
         arr = source
-    return Stats(numpy.min(arr), numpy.max(arr), numpy.mean(arr))
+    return Stats(np.min(arr), np.max(arr), np.mean(arr))
 
 
 def main(banner, dataset, alt_interpreter=None):
     """ Main entry point for use with python interpreter """
-    local = dict(funcs, src=dataset, np=numpy, rio=rasterio, plt=plt)
+    local = dict(funcs, src=dataset, np=np, rio=rasterio, plt=plt)
     if not alt_interpreter:
         code.interact(banner, local=local)
     elif alt_interpreter == 'ipython':  # pragma: no cover

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -88,7 +88,7 @@ def shapes(
       $ rio shapes --as-mask --bidx 1 tests/data/RGB.byte.tif
     """
     # These import numpy, which we don't want to do unless it's needed.
-    import numpy
+    import numpy as np
     import rasterio.features
     import rasterio.warp
 
@@ -145,14 +145,14 @@ def shapes(
                         msk_shape = (
                             src.height // sampling, src.width // sampling)
                         if bidx is None:
-                            msk = numpy.zeros(
+                            msk = np.zeros(
                                 (src.count,) + msk_shape, 'uint8')
                         else:
-                            msk = numpy.zeros(msk_shape, 'uint8')
+                            msk = np.zeros(msk_shape, 'uint8')
                         msk = src.read_masks(bidx, msk)
 
                     if bidx is None:
-                        msk = numpy.logical_or.reduce(msk).astype('uint8')
+                        msk = np.logical_or.reduce(msk).astype('uint8')
 
                     # Possibly overridden below.
                     img = msk
@@ -162,7 +162,7 @@ def shapes(
                     if sampling == 1:
                         img = src.read(bidx, masked=False)
                     else:
-                        img = numpy.zeros(
+                        img = np.zeros(
                             (src.height // sampling, src.width // sampling),
                             dtype=src.dtypes[src.indexes.index(bidx)])
                         img = src.read(bidx, img, masked=False)
@@ -172,7 +172,7 @@ def shapes(
                 # categories to 2 and likely reduces the number of
                 # shapes.
                 if as_mask:
-                    tmp = numpy.ones_like(img, 'uint8') * 255
+                    tmp = np.ones_like(img, 'uint8') * 255
                     tmp[img == 0] = 0
                     img = tmp
                     if not with_nodata:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import sys
 from click.testing import CliRunner
 import py
 import pytest
-import numpy
+import numpy as np
 
 
 DEFAULT_SHAPE = (10, 10)
@@ -107,10 +107,10 @@ def basic_image():
     Returns
     -------
 
-    numpy ndarray
+    np ndarray
     """
 
-    image = numpy.zeros(DEFAULT_SHAPE, dtype=numpy.uint8)
+    image = np.zeros(DEFAULT_SHAPE, dtype=np.uint8)
     image[2:5, 2:5] = 1
 
     return image
@@ -126,10 +126,10 @@ def basic_image_2x2():
     Returns
     -------
 
-    numpy ndarray
+    np ndarray
     """
 
-    image = numpy.zeros(DEFAULT_SHAPE, dtype=numpy.uint8)
+    image = np.zeros(DEFAULT_SHAPE, dtype=np.uint8)
     image[2:4, 2:4] = 1
 
     return image
@@ -144,7 +144,7 @@ def pixelated_image(basic_image):
     Returns
     -------
 
-    numpy ndarray
+    np ndarray
     """
 
     image = basic_image.copy()
@@ -162,11 +162,11 @@ def diagonal_image():
     Returns
     -------
 
-    numpy ndarray
+    np ndarray
     """
 
-    image = numpy.zeros(DEFAULT_SHAPE, dtype=numpy.uint8)
-    numpy.fill_diagonal(image, 1)
+    image = np.zeros(DEFAULT_SHAPE, dtype=np.uint8)
+    np.fill_diagonal(image, 1)
     return image
 
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import unittest
 
-import numpy
+import numpy as np
 
 import rasterio
 
@@ -18,11 +18,11 @@ class WindowTest(unittest.TestCase):
         # Positive height and width are needed when stop is None.
         self.assertRaises(
             ValueError,
-            rasterio.window_shape, 
+            rasterio.window_shape,
             (((10, 20),(10, None)),) )
         self.assertRaises(
             ValueError,
-            rasterio.window_shape, 
+            rasterio.window_shape,
             (((None, 10),(10, 20)),) )
     def test_window_shape_None_start(self):
         self.assertEqual(
@@ -62,7 +62,7 @@ def test_window_index():
     assert r.stop == 4
     assert c.start == 1
     assert c.stop == 12
-    arr = numpy.ones((20,20))
+    arr = np.ones((20,20))
     assert arr[idx].shape == (4, 11)
 
 class RasterBlocksTest(unittest.TestCase):
@@ -88,7 +88,7 @@ class RasterBlocksTest(unittest.TestCase):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(
                 s.width*s.height,
-                sum((w[0][1]-w[0][0])*(w[1][1]-w[1][0]) 
+                sum((w[0][1]-w[0][0])*(w[1][1]-w[1][0])
                     for ji, w in s.block_windows(1)))
 
 class WindowReadTest(unittest.TestCase):
@@ -99,7 +99,7 @@ class WindowReadTest(unittest.TestCase):
             first_block = s.read(1, window=first_window)
             self.assertEqual(first_block.dtype, rasterio.ubyte)
             self.assertEqual(
-                first_block.shape, 
+                first_block.shape,
                 rasterio.window_shape(first_window))
 
 class WindowWriteTest(unittest.TestCase):
@@ -109,10 +109,10 @@ class WindowWriteTest(unittest.TestCase):
         shutil.rmtree(self.tempdir)
     def test_write_window(self):
         name = os.path.join(self.tempdir, "test_write_window.tif")
-        a = numpy.ones((50, 50), dtype=rasterio.ubyte) * 127
+        a = np.ones((50, 50), dtype=rasterio.ubyte) * 127
         with rasterio.open(
-                name, 'w', 
-                driver='GTiff', width=100, height=100, count=1, 
+                name, 'w',
+                driver='GTiff', width=100, height=100, count=1,
                 dtype=a.dtype) as s:
             s.write(a, indexes=1, window=((30, 80), (10, 60)))
         # subprocess.call(["open", name])

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -6,21 +6,23 @@ import subprocess
 import sys
 import tempfile
 
-import numpy
-
 import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
+
 class CopyTest(unittest.TestCase):
+
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
+
     def tearDown(self):
         shutil.rmtree(self.tempdir)
+
     def test_copy(self):
         name = os.path.join(self.tempdir, 'test_copy.tif')
         rasterio.copy(
-            'tests/data/RGB.byte.tif', 
+            'tests/data/RGB.byte.tif',
             name)
         info = subprocess.check_output(["gdalinfo", name])
         self.assert_("GTiff" in info.decode('utf-8'))

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -3,7 +3,7 @@
 # on the way to stabilizing the API for 1.0
 import warnings
 
-import numpy
+import numpy as np
 import pytest
 
 # New modules
@@ -21,7 +21,7 @@ DATA_WINDOW = ((3, 5), (2, 6))
 
 @pytest.fixture
 def data():
-    data = numpy.zeros((10, 10), dtype='uint8')
+    data = np.zeros((10, 10), dtype='uint8')
     data[slice(*DATA_WINDOW[0]), slice(*DATA_WINDOW[1])] = 1
     return data
 
@@ -85,7 +85,7 @@ def test_stats(recwarn):
         assert recwarn.pop(DeprecationWarning)
         new = stats_new((src, 1))
         assert len(recwarn) == 0
-        assert numpy.allclose(numpy.array(new), numpy.array(old))
+        assert np.allclose(np.array(new), np.array(old))
 
 
 # xfail because for unknown reasons, travis fails with matplotlib errors
@@ -135,7 +135,7 @@ def test_mask(recwarn, basic_image_file, basic_geometry):
                        nodata=nodata_val, invert=True)
         assert len(recwarn) == nwarn
         for parts in zip(new, old):
-            assert numpy.allclose(parts[0], parts[1])
+            assert np.allclose(parts[0], parts[1])
 
 
 def test_merge(recwarn, tmpdir):
@@ -154,4 +154,4 @@ def test_merge(recwarn, tmpdir):
     new = merge_new(in_sources)
     assert len(recwarn) == nwarn
     for parts in zip(new, old):
-        assert numpy.allclose(parts[0], parts[1])
+        assert np.allclose(parts[0], parts[1])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-import numpy
+import numpy as np
 import pytest
 
 from affine import Affine
@@ -61,7 +61,7 @@ def test_bounds_existing_bbox(basic_featurecollection):
 
 def test_geometry_mask(basic_geometry, basic_image_2x2):
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image_2x2 == 0,
             geometry_mask(
                 [basic_geometry],
@@ -73,7 +73,7 @@ def test_geometry_mask(basic_geometry, basic_image_2x2):
 
 def test_geometry_mask_invert(basic_geometry, basic_image_2x2):
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image_2x2,
             geometry_mask(
                 [basic_geometry],
@@ -88,20 +88,20 @@ def test_rasterize(basic_geometry, basic_image_2x2):
     """ Rasterize operation should succeed for both an out_shape and out """
 
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image_2x2,
             rasterize([basic_geometry], out_shape=DEFAULT_SHAPE)
         )
 
-        out = numpy.zeros(DEFAULT_SHAPE)
+        out = np.zeros(DEFAULT_SHAPE)
         rasterize([basic_geometry], out=out)
-        assert numpy.array_equal(basic_image_2x2, out)
+        assert np.array_equal(basic_image_2x2, out)
 
 
 def test_rasterize_invalid_out_dtype(basic_geometry):
     """ A non-supported data type for out should raise an exception """
 
-    out = numpy.zeros(DEFAULT_SHAPE, dtype=numpy.int64)
+    out = np.zeros(DEFAULT_SHAPE, dtype=np.int64)
     with Env():
         with pytest.raises(ValueError):
             rasterize([basic_geometry], out=out)
@@ -110,7 +110,7 @@ def test_rasterize_invalid_out_dtype(basic_geometry):
 def test_rasterize_shapes_out_dtype_mismatch(basic_geometry):
     """ Shape values must be able to fit in data type for out """
 
-    out = numpy.zeros(DEFAULT_SHAPE, dtype=numpy.uint8)
+    out = np.zeros(DEFAULT_SHAPE, dtype=np.uint8)
     with Env():
         with pytest.raises(ValueError):
             rasterize([(basic_geometry, 10000000)], out=out)
@@ -151,7 +151,7 @@ def test_rasterize_default_value(basic_geometry, basic_image_2x2):
     truth = basic_image_2x2 * default_value
 
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             truth,
             rasterize(
                 [basic_geometry], out_shape=DEFAULT_SHAPE,
@@ -176,7 +176,7 @@ def test_rasterize_fill_value(basic_geometry, basic_image_2x2):
 
     default_value = 2
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image_2x2 + 1,
             rasterize(
                 [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1,
@@ -203,13 +203,13 @@ def test_rasterize_fill_value_dtype_mismatch(basic_geometry):
         with pytest.raises(ValueError):
             rasterize(
                 [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1000000,
-                default_value=2, dtype=numpy.uint8
+                default_value=2, dtype=np.uint8
             )
 
 
 def test_rasterize_all_touched(basic_geometry, basic_image):
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image,
             rasterize(
                 [basic_geometry], out_shape=DEFAULT_SHAPE, all_touched=True
@@ -225,7 +225,7 @@ def test_rasterize_value(basic_geometry, basic_image_2x2):
 
     value = 5
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image_2x2 * value,
             rasterize(
                 [(basic_geometry, value)], out_shape=DEFAULT_SHAPE
@@ -260,7 +260,7 @@ def test_rasterize_supported_dtype(basic_geometry):
         )
 
         for dtype, default_value in supported_types:
-            truth = numpy.zeros(DEFAULT_SHAPE, dtype=dtype)
+            truth = np.zeros(DEFAULT_SHAPE, dtype=dtype)
             truth[2:4, 2:4] = default_value
 
             result = rasterize(
@@ -269,17 +269,17 @@ def test_rasterize_supported_dtype(basic_geometry):
                 default_value=default_value,
                 dtype=dtype
             )
-            assert numpy.array_equal(result, truth)
-            assert numpy.dtype(result.dtype) == numpy.dtype(truth.dtype)
+            assert np.array_equal(result, truth)
+            assert np.dtype(result.dtype) == np.dtype(truth.dtype)
 
             result = rasterize(
                 [(basic_geometry, default_value)],
                 out_shape=DEFAULT_SHAPE
             )
-            if numpy.dtype(dtype).kind == 'f':
-                assert numpy.allclose(result, truth)
+            if np.dtype(dtype).kind == 'f':
+                assert np.allclose(result, truth)
             else:
-                assert numpy.array_equal(result, truth)
+                assert np.array_equal(result, truth)
             # Since dtype is auto-detected, it may not match due to upcasting
 
 
@@ -336,12 +336,12 @@ def test_rasterize_geometries_symmetric():
     """ Make sure that rasterize is symmetric with shapes """
 
     transform = (1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
-    truth = numpy.zeros(DEFAULT_SHAPE, dtype=rasterio.ubyte)
+    truth = np.zeros(DEFAULT_SHAPE, dtype=rasterio.ubyte)
     truth[2:5, 2:5] = 1
     with Env():
         s = shapes(truth, transform=transform)
         result = rasterize(s, out_shape=DEFAULT_SHAPE, transform=transform)
-        assert numpy.array_equal(result, truth)
+        assert np.array_equal(result, truth)
 
 
 def test_rasterize_internal_driver_manager(basic_geometry):
@@ -423,7 +423,7 @@ def test_shapes_connectivity_invalid(diagonal_image):
 def test_shapes_mask(basic_image):
     """ Only pixels not masked out should be converted to features """
 
-    mask = numpy.ones(basic_image.shape, dtype=rasterio.bool_)
+    mask = np.ones(basic_image.shape, dtype=rasterio.bool_)
     mask[4:5, 4:5] = False
 
     with Env():
@@ -445,10 +445,10 @@ def test_shapes_blank_mask(basic_image):
     """ Mask is blank so results should mask shapes without mask """
 
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             list(shapes(
                 basic_image,
-                mask=numpy.ones(basic_image.shape, dtype=rasterio.bool_))
+                mask=np.ones(basic_image.shape, dtype=rasterio.bool_))
             ),
             list(shapes(basic_image))
         )
@@ -461,7 +461,7 @@ def test_shapes_invalid_mask_shape(basic_image):
         with pytest.raises(ValueError):
             next(shapes(
                 basic_image,
-                mask=numpy.ones(
+                mask=np.ones(
                     (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
                     dtype=rasterio.bool_
                 )
@@ -476,7 +476,7 @@ def test_shapes_invalid_mask_dtype(basic_image):
             with pytest.raises(ValueError):
                 next(shapes(
                     basic_image,
-                    mask=numpy.ones(basic_image.shape, dtype=dtype)
+                    mask=np.ones(basic_image.shape, dtype=dtype)
                 ))
 
 
@@ -494,7 +494,7 @@ def test_shapes_supported_dtypes(basic_image):
     with Env():
         for dtype, test_value in supported_types:
             shape, value = next(shapes(basic_image.astype(dtype) * test_value))
-            assert numpy.allclose(value, test_value)
+            assert np.allclose(value, test_value)
 
 
 def test_shapes_unsupported_dtypes(basic_image):
@@ -527,7 +527,7 @@ def test_sieve_small(basic_image, pixelated_image):
     """
 
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image,
             sieve(pixelated_image, basic_image.sum())
         )
@@ -539,7 +539,7 @@ def test_sieve_large(basic_image):
     """
 
     with Env():
-        assert not numpy.any(sieve(basic_image, basic_image.sum() + 1))
+        assert not np.any(sieve(basic_image, basic_image.sum() + 1))
 
 
 def test_sieve_invalid_size(basic_image):
@@ -552,7 +552,7 @@ def test_sieve_invalid_size(basic_image):
 def test_sieve_connectivity_rook(diagonal_image):
     """ Diagonals are not connected, so feature is removed """
 
-    assert not numpy.any(
+    assert not np.any(
         sieve(diagonal_image, diagonal_image.sum(), connectivity=4)
     )
 
@@ -560,7 +560,7 @@ def test_sieve_connectivity_rook(diagonal_image):
 def test_sieve_connectivity_queen(diagonal_image):
     """ Diagonals are connected, so feature is retained """
 
-    assert numpy.array_equal(
+    assert np.array_equal(
         diagonal_image,
         sieve(diagonal_image, diagonal_image.sum(), connectivity=8)
     )
@@ -575,11 +575,11 @@ def test_sieve_out(basic_image):
     """ Output array passed in should match the returned array """
 
     with Env():
-        output = numpy.zeros_like(basic_image)
+        output = np.zeros_like(basic_image)
         output[1:3, 1:3] = 5
         sieved_image = sieve(basic_image, basic_image.sum(), out=output)
-        assert numpy.array_equal(basic_image, sieved_image)
-        assert numpy.array_equal(output, sieved_image)
+        assert np.array_equal(basic_image, sieved_image)
+        assert np.array_equal(output, sieved_image)
 
 
 def test_sieve_invalid_out(basic_image):
@@ -589,13 +589,13 @@ def test_sieve_invalid_out(basic_image):
         with pytest.raises(ValueError):
             sieve(
                 basic_image, basic_image.sum(),
-                out=numpy.zeros(basic_image.shape, dtype=rasterio.int32)
+                out=np.zeros(basic_image.shape, dtype=rasterio.int32)
             )
 
         with pytest.raises(ValueError):
             sieve(
                 basic_image, basic_image.sum(),
-                out=numpy.zeros(
+                out=np.zeros(
                     (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
                     dtype=rasterio.ubyte
                 )
@@ -608,20 +608,20 @@ def test_sieve_mask(basic_image):
     as mask is a bool or uint8 dtype.
     """
 
-    mask = numpy.ones(basic_image.shape, dtype=rasterio.bool_)
+    mask = np.ones(basic_image.shape, dtype=rasterio.bool_)
     mask[4:5, 4:5] = False
-    truth = basic_image * numpy.invert(mask)
+    truth = basic_image * np.invert(mask)
 
     with Env():
         sieved_image = sieve(basic_image, basic_image.sum(), mask=mask)
         assert sieved_image.sum() > 0
 
-        assert numpy.array_equal(
+        assert np.array_equal(
             truth,
             sieved_image
         )
 
-        assert numpy.array_equal(
+        assert np.array_equal(
             truth.astype(rasterio.uint8),
             sieved_image
         )
@@ -630,9 +630,9 @@ def test_sieve_mask(basic_image):
 def test_sieve_blank_mask(basic_image):
     """ A blank mask should have no effect """
 
-    mask = numpy.ones(basic_image.shape, dtype=rasterio.bool_)
+    mask = np.ones(basic_image.shape, dtype=rasterio.bool_)
     with Env():
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image,
             sieve(basic_image, basic_image.sum(), mask=mask)
         )
@@ -645,7 +645,7 @@ def test_sieve_invalid_mask_shape(basic_image):
         with pytest.raises(ValueError):
             sieve(
                 basic_image, basic_image.sum(),
-                mask=numpy.ones(
+                mask=np.ones(
                     (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
                     dtype=rasterio.bool_
                 )
@@ -660,7 +660,7 @@ def test_sieve_invalid_mask_dtype(basic_image):
             with pytest.raises(ValueError):
                 sieve(
                     basic_image, basic_image.sum(),
-                    mask=numpy.ones(basic_image.shape, dtype=dtype)
+                    mask=np.ones(basic_image.shape, dtype=dtype)
                 )
 
 
@@ -678,8 +678,8 @@ def test_sieve_supported_dtypes(basic_image):
         for dtype, test_value in supported_types:
             truth = (basic_image).astype(dtype) * test_value
             sieved_image = sieve(truth, basic_image.sum())
-            assert numpy.array_equal(truth, sieved_image)
-            assert numpy.dtype(sieved_image.dtype) == numpy.dtype(dtype)
+            assert np.array_equal(truth, sieved_image)
+            assert np.dtype(sieved_image.dtype) == np.dtype(dtype)
 
 
 def test_sieve_unsupported_dtypes(basic_image):
@@ -711,10 +711,10 @@ def test_sieve_band(pixelated_image, pixelated_image_file):
 
         with rasterio.open(pixelated_image_file) as src:
             band = rasterio.band(src, 1)
-            assert numpy.array_equal(truth, sieve(band, 9))
+            assert np.array_equal(truth, sieve(band, 9))
 
             # Mask band should also work but will be a no-op
-            assert numpy.array_equal(
+            assert np.array_equal(
                 pixelated_image,
                 sieve(band, 9, mask=band)
             )
@@ -723,7 +723,7 @@ def test_sieve_band(pixelated_image, pixelated_image_file):
 def test_sieve_internal_driver_manager(basic_image, pixelated_image):
     """ Sieve should work without explicitly calling driver manager """
 
-    assert numpy.array_equal(
+    assert np.array_equal(
         basic_image,
         sieve(pixelated_image, basic_image.sum())
     )

--- a/tests/test_fillnodata.py
+++ b/tests/test_fillnodata.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-import numpy
+import numpy as np
 import pytest
 
 import rasterio
@@ -11,16 +11,16 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 def test_fillnodata():
     """Test filling nodata values in an ndarray"""
     # create a 5x5 array, with some missing data
-    a = numpy.ones([3, 3]) * 42
+    a = np.ones([3, 3]) * 42
     a[1][1] = 0
     # find the missing data
     mask = ~(a == 0)
     # fill the missing data using interpolation from the edges
     result = fillnodata(a, mask)
-    assert(numpy.all((numpy.ones([3, 3]) * 42) == result))
+    assert(np.all((np.ones([3, 3]) * 42) == result))
 
 def test_fillnodata_invalid_types():
-    a = numpy.ones([3, 3])
+    a = np.ones([3, 3])
     with pytest.raises(ValueError):
         fillnodata(None, a)
     with pytest.raises(ValueError):
@@ -28,15 +28,15 @@ def test_fillnodata_invalid_types():
 
 def test_fillnodata_mask_ones():
     # when mask is all ones, image should be unmodified
-    a = numpy.ones([3, 3]) * 42
+    a = np.ones([3, 3]) * 42
     a[1][1] = 0
-    mask = numpy.ones([3, 3])
+    mask = np.ones([3, 3])
     result = fillnodata(a, mask)
-    assert(numpy.all(a == result))
+    assert(np.all(a == result))
 
 '''
 def test_fillnodata_smooth():
-    a = numpy.array([[1,3,3,1],[2,0,0,2],[2,0,0,2],[1,3,3,1]], dtype=numpy.float64)
+    a = np.array([[1,3,3,1],[2,0,0,2],[2,0,0,2],[1,3,3,1]], dtype=np.float64)
     mask = ~(a == 0)
     result = fillnodata(a, mask, max_search_distance=1, smoothing_iterations=0)
     assert(result[1][1] == 3)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 
 import rasterio
@@ -77,7 +77,7 @@ def test_window_full_cover():
 
 @pytest.fixture
 def data():
-    data = numpy.zeros((10, 10), dtype='uint8')
+    data = np.zeros((10, 10), dtype='uint8')
     data[slice(*DATA_WINDOW[0]), slice(*DATA_WINDOW[1])] = 1
     return data
 
@@ -88,7 +88,7 @@ def test_data_window_unmasked(data):
 
 
 def test_data_window_masked(data):
-    data = numpy.ma.masked_array(data, data == 0)
+    data = np.ma.masked_array(data, data == 0)
     window = windows.get_data_window(data)
     assert window == DATA_WINDOW
 
@@ -97,12 +97,12 @@ def test_data_window_nodata(data):
     window = windows.get_data_window(data, nodata=0)
     assert window == DATA_WINDOW
 
-    window = windows.get_data_window(numpy.ones_like(data), nodata=0)
+    window = windows.get_data_window(np.ones_like(data), nodata=0)
     assert window == ((0, data.shape[0]), (0, data.shape[1]))
 
 
 def test_data_window_nodata_disjunct():
-    data = numpy.zeros((3, 10, 10), dtype='uint8')
+    data = np.zeros((3, 10, 10), dtype='uint8')
     data[0, :4, 1:4] = 1
     data[1, 2:5, 2:8] = 1
     data[2, 1:6, 1:6] = 1
@@ -111,7 +111,7 @@ def test_data_window_nodata_disjunct():
 
 
 def test_data_window_empty_result():
-    data = numpy.zeros((3, 10, 10), dtype='uint8')
+    data = np.zeros((3, 10, 10), dtype='uint8')
     window = windows.get_data_window(data, nodata=0)
     assert window == ((0, 0), (0, 0))
 

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -1,12 +1,12 @@
 
 import affine
-import numpy
+import numpy as np
 
 import rasterio
 
 
 def test_pad():
-    arr = numpy.ones((10, 10))
+    arr = np.ones((10, 10))
     trans = affine.Affine(1.0, 0.0, 0.0, 0.0, -1.0, 10.0)
     arr2, trans2 = rasterio.pad(arr, trans, 2, 'edge')
     assert arr2.shape == (14, 14)

--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 import sys
 import re
-import numpy
+import numpy as np
 import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -10,10 +10,10 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 def test_write_ubyte(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte.png"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     with rasterio.open(
-            name, 'w', 
-            driver='PNG', width=100, height=100, count=1, 
+            name, 'w',
+            driver='PNG', width=100, height=100, count=1,
             dtype=a.dtype) as s:
         s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import unittest
 
-import numpy
+import numpy as np
 import pytest
 
 import rasterio
@@ -86,13 +86,13 @@ class ReaderContextTest(unittest.TestCase):
 
     def test_read_ubyte_out(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
-            a = numpy.zeros((718, 791), dtype=rasterio.ubyte)
+            a = np.zeros((718, 791), dtype=rasterio.ubyte)
             a = s.read(1, a)
             self.assertEqual(a.dtype, rasterio.ubyte)
 
     def test_read_out_dtype_fail(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
-            a = numpy.zeros((718, 791), dtype=rasterio.float32)
+            a = np.zeros((718, 791), dtype=rasterio.float32)
             try:
                 s.read(1, a)
             except ValueError as e:
@@ -215,34 +215,34 @@ class ReaderContextTest(unittest.TestCase):
     def test_read_out(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             # regular array, without mask
-            a = numpy.empty((3, 718, 791), numpy.ubyte)
+            a = np.empty((3, 718, 791), np.ubyte)
             b = s.read(out=a)
             self.assertFalse(hasattr(a, 'mask'))
             self.assertFalse(hasattr(b, 'mask'))
             # with masked array
-            a = numpy.ma.empty((3, 718, 791), numpy.ubyte)
+            a = np.ma.empty((3, 718, 791), np.ubyte)
             b = s.read(out=a)
             self.assertEqual(id(a.data), id(b.data))
             # TODO: is there a way to id(a.mask)?
             self.assertTrue(hasattr(a, 'mask'))
             self.assertTrue(hasattr(b, 'mask'))
             # use all parameters
-            a = numpy.empty((1, 20, 10), numpy.ubyte)
+            a = np.empty((1, 20, 10), np.ubyte)
             b = s.read([2], a, ((310, 330), (320, 330)), False)
             self.assertEqual(id(a), id(b))
             # pass 2D array with index
-            a = numpy.empty((20, 10), numpy.ubyte)
+            a = np.empty((20, 10), np.ubyte)
             b = s.read(2, a, ((310, 330), (320, 330)), False)
             self.assertEqual(id(a), id(b))
             self.assertEqual(a.ndim, 2)
             # different data types
-            a = numpy.empty((3, 718, 791), numpy.float64)
+            a = np.empty((3, 718, 791), np.float64)
             self.assertRaises(ValueError, s.read, out=a)
             # different number of array dimensions
-            a = numpy.empty((20, 10), numpy.ubyte)
+            a = np.empty((20, 10), np.ubyte)
             self.assertRaises(ValueError, s.read, [2], out=a)
             # different number of array shape in 3D
-            a = numpy.empty((2, 20, 10), numpy.ubyte)
+            a = np.empty((2, 20, 10), np.ubyte)
             self.assertRaises(ValueError, s.read, [2], out=a)
 
     def test_read_nan_nodata(self):
@@ -251,13 +251,13 @@ class ReaderContextTest(unittest.TestCase):
             self.assertEqual(a.ndim, 3)
             self.assertEqual(a.shape, (1, 2, 3))
             self.assertTrue(hasattr(a, 'mask'))
-            self.assertNotEqual(a.fill_value, numpy.nan)
-            self.assertEqual(str(list(set(s.nodatavals))), str([numpy.nan]))
+            self.assertNotEqual(a.fill_value, np.nan)
+            self.assertEqual(str(list(set(s.nodatavals))), str([np.nan]))
             self.assertEqual(a.dtype, rasterio.float32)
-            self.assertFalse(numpy.isnan(a).any())
+            self.assertFalse(np.isnan(a).any())
             a = s.read(masked=False)
             self.assertFalse(hasattr(a, 'mask'))
-            self.assertTrue(numpy.isnan(a).any())
+            self.assertTrue(np.isnan(a).any())
             # Window does not contain a nodatavalue, result is still masked
             a = s.read(window=((0, 2), (0, 2)), masked=True)
             self.assertEqual(a.ndim, 3)

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-import numpy
+import numpy as np
 import pytest
 
 import rasterio
@@ -42,7 +42,7 @@ def test_read_boundless_overlap():
 
 def test_read_boundless_resample():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        out = numpy.zeros((3, 800, 800), dtype=numpy.uint8)
+        out = np.zeros((3, 800, 800), dtype=np.uint8)
         data = src.read(
                 out=out,
                 window=((-200, 200), (-200, 200)),
@@ -94,19 +94,19 @@ def test_read_boundless_noshift():
                       window=((100, 101), (-1, src.shape[1])))[0, 0, 0:9]
         c2 = src.read(boundless=True,
                       window=((100, 101), (-1, src.shape[1] + 1)))[0, 0, 0:9]
-        assert numpy.array_equal(c1, c2)
+        assert np.array_equal(c1, c2)
 
         # when row stop exceeds image height
         r1 = src.read(boundless=True,
                       window=((-1, src.shape[0]), (100, 101)))[0, 0, 0:9]
         r2 = src.read(boundless=True,
                       window=((-1, src.shape[0] + 1), (100, 101)))[0, 0, 0:9]
-        assert numpy.array_equal(r1, r2)
+        assert np.array_equal(r1, r2)
 
 
-def test_numpy_warning(recwarn):
+def test_np_warning(recwarn):
     """Ensure no deprecation warnings
-    On numpy 1.11 and previous versions of rasterio you might see:
+    On np 1.11 and previous versions of rasterio you might see:
         VisibleDeprecationWarning: using a non-integer number
         instead of an integer will result in an error in the future
     """

--- a/tests/test_read_resample.py
+++ b/tests/test_read_resample.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 
 import rasterio
 
@@ -10,9 +10,9 @@ import rasterio
 
 def test_read_out_shape_resample_down():
     with rasterio.open('tests/data/RGB.byte.tif') as s:
-        out = numpy.zeros((8, 8), dtype=rasterio.ubyte)
+        out = np.zeros((8, 8), dtype=rasterio.ubyte)
         data = s.read(1, out=out)
-        expected = numpy.array([
+        expected = np.array([
             [  0,   0,  20,  15,   0,   0,   0,   0],
             [  0,   6, 193,   9, 255, 127,  23,  39],
             [  0,   7,  27, 255, 193,  14,  28,  34],
@@ -20,7 +20,7 @@ def test_read_out_shape_resample_down():
             [  0,   9,  69,  49,  17,  22, 255,   0],
             [ 11,   7,  13,  25,  13,  29,  33,   0],
             [  8,  10,  88,  27,  20,  33,  25,   0],
-            [  0,   0,   0,   0,  98,  23,   0,   0]], dtype=numpy.uint8)
+            [  0,   0,   0,   0,  98,  23,   0,   0]], dtype=np.uint8)
         assert (data == expected).all() # all True.
 
 
@@ -28,7 +28,7 @@ def test_read_out_shape_resample_up():
     # Instead of testing array items, test statistics. Upsampling by an even
     # constant factor shouldn't change the mean.
     with rasterio.open('tests/data/RGB.byte.tif') as s:
-        out = numpy.zeros((7180, 7910), dtype=rasterio.ubyte)
+        out = np.zeros((7180, 7910), dtype=rasterio.ubyte)
         data = s.read(1, out=out, masked=True)
         assert data.shape == (7180, 7910)
         assert data.mean() == s.read(1, masked=True).mean()
@@ -37,7 +37,7 @@ def test_read_out_shape_resample_up():
 def test_read_downsample_alpha():
     with rasterio.Env(GTIFF_IMPLICIT_JPEG_OVR=False):
         with rasterio.open('tests/data/alpha.tif') as src:
-            out = numpy.zeros((100, 100), dtype=rasterio.ubyte)
+            out = np.zeros((100, 100), dtype=rasterio.ubyte)
             assert src.width == 1223
             assert src.height == 1223
             assert src.count == 4

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import logging
-import numpy
+import numpy as np
 from click.testing import CliRunner
 
 import rasterio
@@ -38,7 +38,7 @@ def test_clip_like(runner, tmpdir):
     with rasterio.open('tests/data/shade.tif') as template_ds:
         with rasterio.open(output) as out:
             assert out.shape == template_ds.shape
-            assert numpy.allclose(out.bounds, template_ds.bounds)
+            assert np.allclose(out.bounds, template_ds.bounds)
 
 
 def test_clip_missing_params(runner, tmpdir):

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 import sys
-import numpy
+import numpy as np
 import json
 from affine import Affine
 
@@ -33,7 +33,7 @@ def test_mask(runner, tmpdir, basic_feature, basic_image_2x2,
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image_2x2,
             out.read(1, masked=True).filled(0)
         )
@@ -54,7 +54,7 @@ def test_mask_all_touched(runner, tmpdir, basic_feature, basic_image,
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image,
             out.read(1, masked=True).filled(0)
         )
@@ -77,7 +77,7 @@ def test_mask_invert(runner, tmpdir, basic_feature, pixelated_image,
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert numpy.array_equal(
+        assert np.array_equal(
             truth,
             out.read(1, masked=True).filled(0))
 
@@ -95,7 +95,7 @@ def test_mask_featurecollection(runner, tmpdir, basic_featurecollection,
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert numpy.array_equal(
+        assert np.array_equal(
             basic_image_2x2,
             out.read(1, masked=True).filled(0))
 
@@ -107,7 +107,7 @@ def test_mask_out_of_bounds(runner, tmpdir, basic_feature,
     blank image.
     """
 
-    coords = numpy.array(basic_feature['geometry']['coordinates']) - 10
+    coords = np.array(basic_feature['geometry']['coordinates']) - 10
     basic_feature['geometry']['coordinates'] = coords.tolist()
 
     output = str(tmpdir.join('test.tif'))
@@ -121,7 +121,7 @@ def test_mask_out_of_bounds(runner, tmpdir, basic_feature,
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert not numpy.any(out.read(1, masked=True).filled(0))
+        assert not np.any(out.read(1, masked=True).filled(0))
 
 
 def test_mask_no_geojson(runner, tmpdir, pixelated_image, pixelated_image_file):
@@ -136,7 +136,7 @@ def test_mask_no_geojson(runner, tmpdir, pixelated_image, pixelated_image_file):
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert numpy.array_equal(
+        assert np.array_equal(
             pixelated_image,
             out.read(1, masked=True).filled(0))
 
@@ -185,7 +185,7 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
 
     output = str(tmpdir.join('test.tif'))
 
-    truth = numpy.zeros((4, 3))
+    truth = np.zeros((4, 3))
     truth[1:3, 0:2] = 1
 
     result = runner.invoke(
@@ -195,7 +195,7 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.array_equal(
+        assert np.array_equal(
             truth,
             out.read(1, masked=True).filled(0))
 
@@ -208,7 +208,7 @@ def test_mask_crop_inverted_y(runner, tmpdir, basic_feature, pixelated_image_fil
 
     output = str(tmpdir.join('test.tif'))
 
-    truth = numpy.zeros((4, 3))
+    truth = np.zeros((4, 3))
     truth[1:3, 0:2] = 1
 
     result = runner.invoke(
@@ -220,7 +220,7 @@ def test_mask_crop_inverted_y(runner, tmpdir, basic_feature, pixelated_image_fil
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.array_equal(
+        assert np.array_equal(
             truth,
             out.read(1, masked=True).filled(0))
 
@@ -232,7 +232,7 @@ def test_mask_crop_out_of_bounds(runner, tmpdir, basic_feature,
     --crop option.
     """
 
-    coords = numpy.array(basic_feature['geometry']['coordinates']) - 10
+    coords = np.array(basic_feature['geometry']['coordinates']) - 10
     basic_feature['geometry']['coordinates'] = coords.tolist()
 
     output = str(tmpdir.join('test.tif'))
@@ -267,7 +267,7 @@ def test_shapes(runner, pixelated_image_file):
     assert result.exit_code == 0
     assert result.output.count('"FeatureCollection"') == 1
     assert result.output.count('"Feature"') == 4
-    assert numpy.allclose(
+    assert np.allclose(
         json.loads(result.output)['features'][0]['geometry']['coordinates'],
         [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]])
 
@@ -393,7 +393,7 @@ def test_shapes_mask(runner, pixelated_image, pixelated_image_file):
     assert result.output.count('"FeatureCollection"') == 1
     assert result.output.count('"Feature"') == 1
 
-    assert numpy.allclose(
+    assert np.allclose(
         json.loads(result.output)['features'][0]['geometry']['coordinates'],
         [[[3, 5], [3, 10], [8, 10], [8, 8], [9, 8], [10, 8], [10, 5], [3, 5]]])
 
@@ -418,7 +418,7 @@ def test_shapes_mask_sampling(runner, pixelated_image, pixelated_image_file):
     assert result.output.count('"FeatureCollection"') == 1
     assert result.output.count('"Feature"') == 1
 
-    assert numpy.allclose(
+    assert np.allclose(
         json.loads(result.output)['features'][0]['geometry']['coordinates'],
         [[[5, 5], [5, 10], [10, 10], [10, 5], [5, 5]]])
 
@@ -441,7 +441,7 @@ def test_shapes_band1_as_mask(runner, pixelated_image, pixelated_image_file):
     assert result.exit_code == 0
     assert result.output.count('"FeatureCollection"') == 1
     assert result.output.count('"Feature"') == 3
-    assert numpy.allclose(
+    assert np.allclose(
         json.loads(result.output)['features'][1]['geometry']['coordinates'],
         [[[2, 2], [2, 5], [5, 5], [5, 2], [2, 2]]])
 
@@ -457,10 +457,10 @@ def test_rasterize(tmpdir, runner, basic_feature):
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.allclose(out.bounds, (2, 2, 4.25, 4.25))
+        assert np.allclose(out.bounds, (2, 2, 4.25, 4.25))
         data = out.read(1, masked=False)
         assert data.shape == DEFAULT_SHAPE
-        assert numpy.all(data)
+        assert np.all(data)
 
 
 def test_rasterize_bounds(tmpdir, runner, basic_feature, basic_image_2x2):
@@ -474,9 +474,9 @@ def test_rasterize_bounds(tmpdir, runner, basic_feature, basic_image_2x2):
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.allclose(out.bounds, (0, 10, 10, 0))
+        assert np.allclose(out.bounds, (0, 10, 10, 0))
         data = out.read(1, masked=False)
-        assert numpy.array_equal(basic_image_2x2, data)
+        assert np.array_equal(basic_image_2x2, data)
         assert data.shape == DEFAULT_SHAPE
 
 
@@ -490,10 +490,10 @@ def test_rasterize_resolution(tmpdir, runner, basic_feature):
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.allclose(out.bounds, (2, 2, 4.25, 4.25))
+        assert np.allclose(out.bounds, (2, 2, 4.25, 4.25))
         data = out.read(1, masked=False)
         assert data.shape == (15, 15)
-        assert numpy.all(data)
+        assert np.all(data)
 
 
 def test_rasterize_multiresolution(tmpdir, runner, basic_feature):
@@ -507,10 +507,10 @@ def test_rasterize_multiresolution(tmpdir, runner, basic_feature):
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.allclose(out.bounds, (2, 2, 4.25, 4.25))
+        assert np.allclose(out.bounds, (2, 2, 4.25, 4.25))
         data = out.read(1, masked=False)
         assert data.shape == (15, 15)
-        assert numpy.all(data)
+        assert np.all(data)
 
 
 def test_rasterize_src_crs(tmpdir, runner, basic_feature):
@@ -533,7 +533,7 @@ def test_rasterize_mismatched_src_crs(tmpdir, runner, basic_feature):
     world bounds should fail.
     """
 
-    coords = numpy.array(basic_feature['geometry']['coordinates']) * 100000
+    coords = np.array(basic_feature['geometry']['coordinates']) * 100000
     basic_feature['geometry']['coordinates'] = coords.tolist()
 
     output = str(tmpdir.join('test.tif'))
@@ -565,7 +565,7 @@ def test_rasterize_existing_output(tmpdir, runner, basic_feature):
     The final result should include rasterized pixels from both
     """
 
-    truth = numpy.zeros(DEFAULT_SHAPE)
+    truth = np.zeros(DEFAULT_SHAPE)
     truth[2:4, 2:4] = 1
     truth[4:6, 4:6] = 1
 
@@ -580,7 +580,7 @@ def test_rasterize_existing_output(tmpdir, runner, basic_feature):
     assert result.exit_code == 0
     assert os.path.exists(output)
 
-    coords = numpy.array(basic_feature['geometry']['coordinates']) + 2
+    coords = np.array(basic_feature['geometry']['coordinates']) + 2
     basic_feature['geometry']['coordinates'] = coords.tolist()
 
     result = runner.invoke(
@@ -592,7 +592,7 @@ def test_rasterize_existing_output(tmpdir, runner, basic_feature):
     assert result.exit_code == 0
 
     with rasterio.open(output) as out:
-        assert numpy.array_equal(truth, out.read(1, masked=False))
+        assert np.array_equal(truth, out.read(1, masked=False))
 
 
 def test_rasterize_like_raster(tmpdir, runner, basic_feature, basic_image_2x2,
@@ -608,7 +608,7 @@ def test_rasterize_like_raster(tmpdir, runner, basic_feature, basic_image_2x2,
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.array_equal(basic_image_2x2, out.read(1, masked=False))
+        assert np.array_equal(basic_image_2x2, out.read(1, masked=False))
 
         with rasterio.open(pixelated_image_file) as src:
             assert out.crs == src.crs
@@ -683,10 +683,10 @@ def test_rasterize_property_value(tmpdir, runner, basic_feature):
     assert result.exit_code == 0
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert numpy.allclose(out.bounds, (2, 2, 4.25, 4.25))
+        assert np.allclose(out.bounds, (2, 2, 4.25, 4.25))
         data = out.read(1, masked=False)
         assert data.shape == DEFAULT_SHAPE
-        assert numpy.all(data == basic_feature['properties']['val'])
+        assert np.all(data == basic_feature['properties']['val'])
 
 
 def test_rasterize_like_raster_outside_bounds(tmpdir, runner, basic_feature,
@@ -696,7 +696,7 @@ def test_rasterize_like_raster_outside_bounds(tmpdir, runner, basic_feature,
     in a blank image
     """
 
-    coords = numpy.array(basic_feature['geometry']['coordinates']) + 100
+    coords = np.array(basic_feature['geometry']['coordinates']) + 100
     basic_feature['geometry']['coordinates'] = coords.tolist()
 
     output = str(tmpdir.join('test.tif'))
@@ -710,7 +710,7 @@ def test_rasterize_like_raster_outside_bounds(tmpdir, runner, basic_feature,
     assert 'outside bounds' in result.output
     assert os.path.exists(output)
     with rasterio.open(output) as out:
-        assert not numpy.any(out.read(1, masked=False))
+        assert not np.any(out.read(1, masked=False))
 
 
 def test_rasterize_invalid_stdin(tmpdir, runner):

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -2,7 +2,7 @@ import sys
 import os
 import logging
 import click
-import numpy
+import numpy as np
 from click.testing import CliRunner
 from pytest import fixture
 
@@ -29,12 +29,12 @@ def test_data_dir_1(tmpdir):
     }
 
     with rasterio.open(str(tmpdir.join('b.tif')), 'w', **kwargs) as dst:
-        data = numpy.ones((10, 10), dtype=rasterio.uint8)
+        data = np.ones((10, 10), dtype=rasterio.uint8)
         data[0:6, 0:6] = 255
         dst.write(data, indexes=1)
 
     with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
-        data = numpy.ones((10, 10), dtype=rasterio.uint8)
+        data = np.ones((10, 10), dtype=rasterio.uint8)
         data[4:8, 4:8] = 254
         dst.write(data, indexes=1)
 
@@ -55,12 +55,12 @@ def test_data_dir_2(tmpdir):
     }
 
     with rasterio.open(str(tmpdir.join('b.tif')), 'w', **kwargs) as dst:
-        data = numpy.zeros((10, 10), dtype=rasterio.uint8)
+        data = np.zeros((10, 10), dtype=rasterio.uint8)
         data[0:6, 0:6] = 255
         dst.write(data, indexes=1)
 
     with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
-        data = numpy.zeros((10, 10), dtype=rasterio.uint8)
+        data = np.zeros((10, 10), dtype=rasterio.uint8)
         data[4:8, 4:8] = 254
         dst.write(data, indexes=1)
 
@@ -78,10 +78,10 @@ def test_merge_with_nodata(test_data_dir_1):
     with rasterio.open(outputname) as out:
         assert out.count == 1
         data = out.read(1, masked=False)
-        expected = numpy.ones((10, 10), dtype=rasterio.uint8)
+        expected = np.ones((10, 10), dtype=rasterio.uint8)
         expected[0:6, 0:6] = 255
         expected[4:8, 4:8] = 254
-        assert numpy.all(data == expected)
+        assert np.all(data == expected)
 
 
 def test_merge_warn(test_data_dir_1):
@@ -106,10 +106,10 @@ def test_merge_without_nodata(test_data_dir_2):
     with rasterio.open(outputname) as out:
         assert out.count == 1
         data = out.read(1, masked=False)
-        expected = numpy.zeros((10, 10), dtype=rasterio.uint8)
+        expected = np.zeros((10, 10), dtype=rasterio.uint8)
         expected[0:6, 0:6] = 255
         expected[4:8, 4:8] = 254
-        assert numpy.all(data == expected)
+        assert np.all(data == expected)
 
 
 def test_merge_output_exists(tmpdir):
@@ -181,12 +181,12 @@ def test_data_dir_overlapping(tmpdir):
     }
 
     with rasterio.open(str(tmpdir.join('se.tif')), 'w', **kwargs) as dst:
-        data = numpy.ones((10, 10), dtype=rasterio.uint8)
+        data = np.ones((10, 10), dtype=rasterio.uint8)
         dst.write(data, indexes=1)
 
     kwargs['transform'] = (-113, 0.2, 0, 45, 0, -0.2)
     with rasterio.open(str(tmpdir.join('nw.tif')), 'w', **kwargs) as dst:
-        data = numpy.ones((10, 10), dtype=rasterio.uint8) * 2
+        data = np.ones((10, 10), dtype=rasterio.uint8) * 2
         dst.write(data, indexes=1)
 
     return tmpdir
@@ -205,10 +205,10 @@ def test_merge_overlapping(test_data_dir_overlapping):
         assert out.shape == (15, 15)
         assert out.bounds == (-114, 43, -111, 46)
         data = out.read(1, masked=False)
-        expected = numpy.zeros((15, 15), dtype=rasterio.uint8)
+        expected = np.zeros((15, 15), dtype=rasterio.uint8)
         expected[0:10, 0:10] = 1
         expected[5:, 5:] = 2
-        assert numpy.all(data == expected)
+        assert np.all(data == expected)
 
 
 # Fixture to create test datasets within temporary directory
@@ -226,12 +226,12 @@ def test_data_dir_float(tmpdir):
     }
 
     with rasterio.open(str(tmpdir.join('two.tif')), 'w', **kwargs) as dst:
-        data = numpy.zeros((10, 10), dtype=rasterio.float64)
+        data = np.zeros((10, 10), dtype=rasterio.float64)
         data[0:6, 0:6] = 255
         dst.write(data, indexes=1)
 
     with rasterio.open(str(tmpdir.join('one.tif')), 'w', **kwargs) as dst:
-        data = numpy.zeros((10, 10), dtype=rasterio.float64)
+        data = np.zeros((10, 10), dtype=rasterio.float64)
         data[4:8, 4:8] = 254
         dst.write(data, indexes=1)
     return tmpdir
@@ -248,10 +248,10 @@ def test_merge_float(test_data_dir_float):
     with rasterio.open(outputname) as out:
         assert out.count == 1
         data = out.read(1, masked=False)
-        expected = numpy.ones((10, 10), dtype=rasterio.float64) * -1.5
+        expected = np.ones((10, 10), dtype=rasterio.float64) * -1.5
         expected[0:6, 0:6] = 255
         expected[4:8, 4:8] = 254
-        assert numpy.all(data == expected)
+        assert np.all(data == expected)
 
 
 # Test below comes from issue #288. There was an off-by-one error in
@@ -260,7 +260,7 @@ def test_merge_float(test_data_dir_float):
 @fixture(scope='function')
 def tiffs(tmpdir):
 
-    data = numpy.ones((1, 1, 1), 'uint8')
+    data = np.ones((1, 1, 1), 'uint8')
 
     kwargs = {
         'count': '1',

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-import numpy
+import numpy as np
 import pytest
 
 import rasterio
@@ -70,9 +70,9 @@ def test_warp_no_reproject(runner, tmpdir):
             assert output.count == src.count
             assert output.crs == src.crs
             assert output.nodata == src.nodata
-            assert numpy.allclose(output.bounds, src.bounds)
+            assert np.allclose(output.bounds, src.bounds)
             assert output.affine.almost_equals(src.affine)
-            assert numpy.allclose(output.read(1), src.read(1))
+            assert np.allclose(output.read(1), src.read(1))
 
 
 def test_warp_no_reproject_dimensions(runner, tmpdir):
@@ -88,7 +88,7 @@ def test_warp_no_reproject_dimensions(runner, tmpdir):
             assert output.crs == src.crs
             assert output.width == 100
             assert output.height == 100
-            assert numpy.allclose([97.839396, 97.839396],
+            assert np.allclose([97.839396, 97.839396],
                                   [output.affine.a, -output.affine.e])
 
 
@@ -103,7 +103,7 @@ def test_warp_no_reproject_res(runner, tmpdir):
     with rasterio.open(srcname) as src:
         with rasterio.open(outputname) as output:
             assert output.crs == src.crs
-            assert numpy.allclose([30, 30], [output.affine.a, -output.affine.e])
+            assert np.allclose([30, 30], [output.affine.a, -output.affine.e])
             assert output.width == 327
             assert output.height == 327
 
@@ -120,8 +120,8 @@ def test_warp_no_reproject_bounds(runner, tmpdir):
     with rasterio.open(srcname) as src:
         with rasterio.open(outputname) as output:
             assert output.crs == src.crs
-            assert numpy.allclose(output.bounds, out_bounds)
-            assert numpy.allclose([src.affine.a, src.affine.e],
+            assert np.allclose(output.bounds, out_bounds)
+            assert np.allclose([src.affine.a, src.affine.e],
                                   [output.affine.a, output.affine.e])
             assert output.width == 105
             assert output.height == 210
@@ -140,8 +140,8 @@ def test_warp_no_reproject_bounds_res(runner, tmpdir):
     with rasterio.open(srcname) as src:
         with rasterio.open(outputname) as output:
             assert output.crs == src.crs
-            assert numpy.allclose(output.bounds, out_bounds)
-            assert numpy.allclose([30, 30], [output.affine.a, -output.affine.e])
+            assert np.allclose(output.bounds, out_bounds)
+            assert np.allclose([30, 30], [output.affine.a, -output.affine.e])
             assert output.width == 34
             assert output.height == 67
 
@@ -160,7 +160,7 @@ def test_warp_reproject_dst_crs(runner, tmpdir):
             assert output.crs == {'init': 'epsg:4326'}
             assert output.width == 835
             assert output.height == 696
-            assert numpy.allclose(output.bounds,
+            assert np.allclose(output.bounds,
                                   [-78.95864996545055, 23.564787976164418,
                                    -76.5759177302349, 25.550873767433984])
 
@@ -189,7 +189,7 @@ def test_warp_reproject_res(runner, tmpdir):
 
     with rasterio.open(outputname) as output:
         assert output.crs == {'init': 'epsg:4326'}
-        assert numpy.allclose([0.01, 0.01], [output.affine.a, -output.affine.e])
+        assert np.allclose([0.01, 0.01], [output.affine.a, -output.affine.e])
         assert output.width == 9
         assert output.height == 7
 
@@ -208,7 +208,7 @@ def test_warp_reproject_dimensions(runner, tmpdir):
             assert output.crs == {'init': 'epsg:4326'}
             assert output.width == 100
             assert output.height == 100
-            assert numpy.allclose([0.0008789062498762235, 0.0006771676143921468],
+            assert np.allclose([0.0008789062498762235, 0.0006771676143921468],
                                   [output.affine.a, -output.affine.e])
 
 
@@ -271,9 +271,9 @@ def test_warp_reproject_src_bounds_res(runner, tmpdir):
     with rasterio.open(srcname) as src:
         with rasterio.open(outputname) as output:
             assert output.crs == {'init': 'epsg:4326'}
-            assert numpy.allclose(output.bounds[:],
+            assert np.allclose(output.bounds[:],
                                   [-106.45036, 39.6138, -106.44136, 39.6278])
-            assert numpy.allclose([0.001, 0.001],
+            assert np.allclose([0.001, 0.001],
                                   [output.affine.a, -output.affine.e])
             assert output.width == 9
             assert output.height == 14
@@ -293,15 +293,15 @@ def test_warp_reproject_dst_bounds(runner, tmpdir):
     with rasterio.open(srcname) as src:
         with rasterio.open(outputname) as output:
             assert output.crs == {'init': 'epsg:4326'}
-            assert numpy.allclose(output.bounds[0::3],
+            assert np.allclose(output.bounds[0::3],
                                   [-106.45036, 39.6278])
-            assert numpy.allclose([0.001, 0.001],
+            assert np.allclose([0.001, 0.001],
                                   [output.affine.a, -output.affine.e])
 
             # XXX: an extra row and column is produced in the dataset
             # because we're using ceil instead of floor internally.
             # Not necessarily a bug, but may change in the future.
-            assert numpy.allclose([output.bounds[2]-0.001, output.bounds[1]+0.001],
+            assert np.allclose([output.bounds[2]-0.001, output.bounds[1]+0.001],
                                   [-106.44136, 39.6138])
             assert output.width == 10
             assert output.height == 15
@@ -322,7 +322,7 @@ def test_warp_reproject_like(runner, tmpdir):
 
     with rasterio.drivers():
         with rasterio.open(likename, 'w', **kwargs) as dst:
-            data = numpy.zeros((10, 10), dtype=rasterio.uint8)
+            data = np.zeros((10, 10), dtype=rasterio.uint8)
             dst.write(data, indexes=1)
 
     srcname = 'tests/data/shade.tif'
@@ -334,7 +334,7 @@ def test_warp_reproject_like(runner, tmpdir):
 
     with rasterio.open(outputname) as output:
         assert output.crs == {'init': 'epsg:4326'}
-        assert numpy.allclose([0.001, 0.001], [output.affine.a, -output.affine.e])
+        assert np.allclose([0.001, 0.001], [output.affine.a, -output.affine.e])
         assert output.width == 10
         assert output.height == 10
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -4,7 +4,7 @@ import subprocess
 import re
 
 import affine
-import numpy
+import numpy as np
 import pytest
 
 import rasterio
@@ -25,7 +25,7 @@ def test_update_tags(data):
 def test_update_band(data):
     tiffname = str(data.join('RGB.byte.tif'))
     with rasterio.open(tiffname, 'r+') as f:
-        f.write(numpy.zeros(f.shape, dtype=f.dtypes[0]), indexes=1)
+        f.write(np.zeros(f.shape, dtype=f.dtypes[0]), indexes=1)
     with rasterio.open(tiffname) as f:
         assert not f.read(1).any()
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import pytest
 from affine import Affine
-import numpy
+import numpy as np
 
 import rasterio
 from rasterio.enums import Resampling
@@ -57,19 +57,19 @@ def test_transform():
     ECEF_crs = {'init': 'EPSG:4978'}
     ECEF_points = ([4642610.], [1028584.], [4236562.])
     ECEF_result = transform(WGS84_crs, ECEF_crs, *WGS84_points)
-    assert numpy.allclose(numpy.array(ECEF_result), numpy.array(ECEF_points))
+    assert np.allclose(np.array(ECEF_result), np.array(ECEF_points))
 
     UTM33_crs = {'init': 'EPSG:32633'}
     UTM33_points = ([291952], [4640623])
     UTM33_result = transform(WGS84_crs, UTM33_crs, *WGS84_points[:2])
-    assert numpy.allclose(numpy.array(UTM33_result), numpy.array(UTM33_points))
+    assert np.allclose(np.array(UTM33_result), np.array(UTM33_points))
 
 
 def test_transform_bounds():
     with Env():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             l, b, r, t = src.bounds
-            assert numpy.allclose(
+            assert np.allclose(
                 transform_bounds(src.crs, {'init': 'EPSG:4326'}, l, b, r, t),
                 (
                     -78.95864996545055, 23.564991210854686,
@@ -83,7 +83,7 @@ def test_transform_bounds_densify():
     # a different result than otherwise
     src_crs = {'init': 'EPSG:4326'}
     dst_crs = {'init': 'EPSG:32610'}
-    assert numpy.allclose(
+    assert np.allclose(
         transform_bounds(
             src_crs,
             dst_crs,
@@ -96,7 +96,7 @@ def test_transform_bounds_densify():
         )
     )
 
-    assert numpy.allclose(
+    assert np.allclose(
         transform_bounds(
             src_crs,
             dst_crs,
@@ -115,7 +115,7 @@ def test_transform_bounds_no_change():
     with Env():
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             l, b, r, t = src.bounds
-            assert numpy.allclose(
+            assert np.allclose(
                 transform_bounds(src.crs, src.crs, l, b, r, t),
                 src.bounds
             )
@@ -202,7 +202,7 @@ def test_reproject_ndarray():
             nadgrids='@null',
             wktext=True,
             no_defs=True)
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = np.empty(src.shape, dtype=np.uint8)
         reproject(
             source,
             out,
@@ -220,7 +220,7 @@ def test_reproject_epsg():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:3857'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = np.empty(src.shape, dtype=np.uint8)
         reproject(
             source,
             out,
@@ -239,7 +239,7 @@ def test_reproject_out_of_bounds():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = np.empty(src.shape, dtype=np.uint8)
         reproject(
             source,
             out,
@@ -256,8 +256,8 @@ def test_reproject_nodata():
     nodata = 215
 
     with Env():
-        source = numpy.ones((params.width, params.height), dtype=numpy.uint8)
-        out = numpy.zeros((params.dst_width, params.dst_height),
+        source = np.ones((params.width, params.height), dtype=np.uint8)
+        out = np.zeros((params.dst_width, params.dst_height),
                           dtype=source.dtype)
         out.fill(120)  # Fill with arbitrary value
 
@@ -281,8 +281,8 @@ def test_reproject_nodata_nan():
     params = default_reproject_params()
 
     with Env():
-        source = numpy.ones((params.width, params.height), dtype=numpy.float32)
-        out = numpy.zeros((params.dst_width, params.dst_height),
+        source = np.ones((params.width, params.height), dtype=np.float32)
+        out = np.zeros((params.dst_width, params.dst_height),
                           dtype=source.dtype)
         out.fill(120)  # Fill with arbitrary value
 
@@ -291,14 +291,14 @@ def test_reproject_nodata_nan():
             out,
             src_transform=params.src_transform,
             src_crs=params.src_crs,
-            src_nodata=numpy.nan,
+            src_nodata=np.nan,
             dst_transform=params.dst_transform,
             dst_crs=params.dst_crs,
-            dst_nodata=numpy.nan
+            dst_nodata=np.nan
         )
 
         assert (out == 1).sum() == 6215
-        assert numpy.isnan(out).sum() == (params.dst_width *
+        assert np.isnan(out).sum() == (params.dst_width *
                                           params.dst_height - 6215)
 
 
@@ -311,8 +311,8 @@ def test_reproject_dst_nodata_default():
     params = default_reproject_params()
 
     with Env():
-        source = numpy.ones((params.width, params.height), dtype=numpy.uint8)
-        out = numpy.zeros((params.dst_width, params.dst_height),
+        source = np.ones((params.width, params.height), dtype=np.uint8)
+        out = np.zeros((params.dst_width, params.dst_height),
                           dtype=source.dtype)
         out.fill(120)  # Fill with arbitrary value
 
@@ -335,7 +335,7 @@ def test_reproject_invalid_dst_nodata():
     params = default_reproject_params()
 
     with Env():
-        source = numpy.ones((params.width, params.height), dtype=numpy.uint8)
+        source = np.ones((params.width, params.height), dtype=np.uint8)
         out = source.copy()
 
         with pytest.raises(ValueError):
@@ -356,7 +356,7 @@ def test_reproject_missing_src_nodata():
     params = default_reproject_params()
 
     with Env():
-        source = numpy.ones((params.width, params.height), dtype=numpy.uint8)
+        source = np.ones((params.width, params.height), dtype=np.uint8)
         out = source.copy()
 
         with pytest.raises(ValueError):
@@ -376,7 +376,7 @@ def test_reproject_invalid_src_nodata():
     params = default_reproject_params()
 
     with Env():
-        source = numpy.ones((params.width, params.height), dtype=numpy.uint8)
+        source = np.ones((params.width, params.height), dtype=np.uint8)
         out = source.copy()
 
         with pytest.raises(ValueError):
@@ -410,7 +410,7 @@ def test_reproject_multi():
             nadgrids='@null',
             wktext=True,
             no_defs=True)
-        destin = numpy.empty(source.shape, dtype=numpy.uint8)
+        destin = np.empty(source.shape, dtype=np.uint8)
         reproject(
             source,
             destin,
@@ -438,7 +438,7 @@ def test_warp_from_file():
             nadgrids='@null',
             wktext=True,
             no_defs=True)
-        destin = numpy.empty(src.shape, dtype=numpy.uint8)
+        destin = np.empty(src.shape, dtype=np.uint8)
         reproject(
             rasterio.band(src, 1),
             destin,
@@ -567,7 +567,7 @@ def test_reproject_unsupported_resampling():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = np.empty(src.shape, dtype=np.uint8)
         with pytest.raises(ValueError):
             reproject(
                 source,
@@ -586,7 +586,7 @@ def test_reproject_unsupported_resampling_guass():
             source = src.read(1)
 
         dst_crs = {'init': 'EPSG:32619'}
-        out = numpy.empty(src.shape, dtype=numpy.uint8)
+        out = np.empty(src.shape, dtype=np.uint8)
         with pytest.raises(ValueError):
             reproject(
                 source,

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import sys
 
-import numpy
+import numpy as np
 import pytest
 
 import rasterio
@@ -42,7 +42,7 @@ def test_no_crs(tmpdir):
     with rasterio.open(
             name, 'w', driver='GTiff', width=100, height=100, count=1,
             dtype=rasterio.uint8) as dst:
-        dst.write(numpy.ones((100, 100), dtype=rasterio.uint8), indexes=1)
+        dst.write(np.ones((100, 100), dtype=rasterio.uint8), indexes=1)
 
 def test_context(tmpdir):
     name = str(tmpdir.join("test_context.tif"))
@@ -73,7 +73,7 @@ def test_context(tmpdir):
 
 def test_write_ubyte(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     with rasterio.open(
             name, 'w',
             driver='GTiff', width=100, height=100, count=1,
@@ -83,7 +83,7 @@ def test_write_ubyte(tmpdir):
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
 def test_write_ubyte_multi(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte_multi.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     with rasterio.open(
             name, 'w',
             driver='GTiff', width=100, height=100, count=1,
@@ -93,7 +93,7 @@ def test_write_ubyte_multi(tmpdir):
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
 def test_write_ubyte_multi_list(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte_multi_list.tif"))
-    a = numpy.array([numpy.ones((100, 100), dtype=rasterio.ubyte) * 127])
+    a = np.array([np.ones((100, 100), dtype=rasterio.ubyte) * 127])
     with rasterio.open(
             name, 'w',
             driver='GTiff', width=100, height=100, count=1,
@@ -103,7 +103,7 @@ def test_write_ubyte_multi_list(tmpdir):
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
 def test_write_ubyte_multi_3(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte_multi_list.tif"))
-    arr = numpy.array(3 * [numpy.ones((100, 100), dtype=rasterio.ubyte) * 127])
+    arr = np.array(3 * [np.ones((100, 100), dtype=rasterio.ubyte) * 127])
     with rasterio.open(
             name, 'w',
             driver='GTiff', width=100, height=100, count=3,
@@ -114,7 +114,7 @@ def test_write_ubyte_multi_3(tmpdir):
 
 def test_write_float(tmpdir):
     name = str(tmpdir.join("test_write_float.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.float32) * 42.0
+    a = np.ones((100, 100), dtype=rasterio.float32) * 42.0
     with rasterio.open(
             name, 'w',
             driver='GTiff', width=100, height=100, count=2,
@@ -127,7 +127,7 @@ def test_write_float(tmpdir):
 
 def test_write_crs_transform(tmpdir):
     name = str(tmpdir.join("test_write_crs_transform.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     transform = [101985.0, 300.0379266750948, 0.0,
                  2826915.0, 0.0, -300.041782729805]
     with rasterio.open(
@@ -147,7 +147,7 @@ def test_write_crs_transform(tmpdir):
 
 def test_write_crs_transform_affine(tmpdir):
     name = str(tmpdir.join("test_write_crs_transform.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     transform = [101985.0, 300.0379266750948, 0.0,
                  2826915.0, 0.0, -300.041782729805]
     with rasterio.open(
@@ -168,7 +168,7 @@ def test_write_crs_transform_affine(tmpdir):
 def test_write_crs_transform_2(tmpdir):
     """Using 'EPSG:32618' as CRS."""
     name = str(tmpdir.join("test_write_crs_transform.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     transform = [101985.0, 300.0379266750948, 0.0,
                  2826915.0, 0.0, -300.041782729805]
     with rasterio.open(
@@ -188,7 +188,7 @@ def test_write_crs_transform_2(tmpdir):
 def test_write_crs_transform_3(tmpdir):
     """Using WKT as CRS."""
     name = str(tmpdir.join("test_write_crs_transform.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     transform = [101985.0, 300.0379266750948, 0.0,
                  2826915.0, 0.0, -300.041782729805]
     crs_wkt = 'PROJCS["UTM Zone 18, Northern Hemisphere",GEOGCS["WGS 84",DATUM["unknown",SPHEROID["WGS84",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-75],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]'
@@ -208,7 +208,7 @@ def test_write_crs_transform_3(tmpdir):
 
 def test_write_meta(tmpdir):
     name = str(tmpdir.join("test_write_meta.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     meta = dict(driver='GTiff', width=100, height=100, count=1)
     with rasterio.open(name, 'w', dtype=a.dtype, **meta) as s:
         s.write(a, indexes=1)
@@ -217,7 +217,7 @@ def test_write_meta(tmpdir):
 
 def test_write_nodata(tmpdir):
     name = str(tmpdir.join("test_write_nodata.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     with rasterio.open(
             name, 'w',
             driver='GTiff', width=100, height=100, count=2,
@@ -230,7 +230,7 @@ def test_write_nodata(tmpdir):
 
 def test_guard_nodata(tmpdir):
     name = str(tmpdir.join("test_guard_nodata.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     with pytest.raises(ValueError):
         rasterio.open(
             name, 'w',
@@ -240,7 +240,7 @@ def test_guard_nodata(tmpdir):
 
 def test_write_lzw(tmpdir):
     name = str(tmpdir.join("test_write_lzw.tif"))
-    a = numpy.ones((100, 100), dtype=rasterio.ubyte) * 127
+    a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
     with rasterio.open(
             name, 'w',
             driver='GTiff',
@@ -259,9 +259,9 @@ def test_write_noncontiguous(tmpdir):
     BANDS = 6
     # Create a 3-D random int array (rows, columns, bands)
     total = ROWS * COLS * BANDS
-    arr = numpy.random.randint(
+    arr = np.random.randint(
         0, 10, size=total).reshape(
-            (ROWS, COLS, BANDS), order='F').astype(numpy.int32)
+            (ROWS, COLS, BANDS), order='F').astype(np.int32)
     kwargs = {
         'driver': 'GTiff',
         'width': COLS,


### PR DESCRIPTION
Fixes the majority of #727 

Not sure if these need to be addressed, but they are not something I wanted to tackle at this time:
./rasterio/_example.c:17132: * import numpy
./rasterio/_example.c:17156: * import numpy
./rasterio/_example.pyx:3:import numpy

I know the sprints don't technically start until the morning, but I will be at work all day, so I started a bit early. I wanted to make sure everything was still set up right on this machine, and figured this was a quick one to do.