### PR TITLE
Corrects error message in rio warp wrt overwrites

### DIFF
--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -88,7 +88,7 @@ def resolve_inout(input=None, output=None, files=None, force_overwrite=False):
             resolved_output):
         raise FileOverwriteError(
             "file exists and won't be overwritten without use of the "
-            "`-f` or `-o` options.")
+            "`--force-overwrite` or `--output` options.")
     resolved_inputs = (
         [input] if input else [] +
         list(files[:-1 if not output else None]) if files else [])


### PR DESCRIPTION
The FileOverwriteError in rio/helpers.py used incorrect abbrevation (-f)
for --force-overwrite. This change fixes #747, but using the long form
options in the error message.