### PR TITLE
Dealing with non-invertable projection errors

### DIFF
--- a/rasterio/_err.pyx
+++ b/rasterio/_err.pyx
@@ -46,7 +46,7 @@ cdef extern from "cpl_error.h":
 
 class CPLError(Exception):
     """Base CPL error class
-    
+
     Exceptions deriving from this class are intended for use only in
     Rasterio's Cython code. Let's not expose API users to them.
     """
@@ -55,6 +55,12 @@ class CPLError(Exception):
         self.errtype = errtype
         self.errno = errno
         self.errmsg = errmsg
+
+    def __str__(self):
+        return self.__unicode__()
+
+    def __unicode__(self):
+        return "{}".format(self.errmsg)
 
     @property
     def args(self):
@@ -138,7 +144,7 @@ exception_map = {
     9: CPLE_UserInterrupt,
     10: ObjectNull,
 
-    # error numbers 11-16 are introduced in GDAL 2.1. See 
+    # error numbers 11-16 are introduced in GDAL 2.1. See
     # https://github.com/OSGeo/gdal/pull/98.
     11: CPLE_HttpResponse,
     12: CPLE_AWSBucketNotFound,

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -565,8 +565,14 @@ def _calculate_default_transform(
         except CPLE_NotSupported as err:
             raise CRSError(err.errmsg)
         except CPLE_AppDefined as err:
-            log.debug("Encountered points outside of valid dst crs region")
-            pass
+            if "Reprojection failed" in str(err):
+                # This "exception" should be treated as a debug msg, not error
+                # "Reprojection failed, err = -14, further errors will be
+                # suppressed on the transform object."
+                log.debug("Encountered points outside of valid dst crs region")
+                pass
+            else:
+                raise err
         finally:
             if wkt != NULL:
                 _gdal.CPLFree(wkt)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -566,8 +566,7 @@ def _calculate_default_transform(
             raise CRSError(err.errmsg)
         except CPLE_AppDefined as err:
             log.debug("Encountered points outside of valid dst crs region")
-            raise
-            #pass
+            pass
         finally:
             if wkt != NULL:
                 _gdal.CPLFree(wkt)

--- a/tests/test_err.py
+++ b/tests/test_err.py
@@ -4,6 +4,7 @@ import pytest
 
 import rasterio
 from rasterio.env import Env
+from rasterio._err import CPLError
 from rasterio.errors import RasterioIOError
 
 
@@ -24,3 +25,8 @@ def test_io_error_env(tmpdir):
 def test_bogus_band_error():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src._has_band(4) is False
+
+
+def test_cplerror_str():
+    err = CPLError(1, 1, "test123")
+    assert str(err) == "test123"

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -395,7 +395,6 @@ def test_warp_badcrs_src_bounds(runner, tmpdir):
     assert "Invalid value for dst_crs" in result.output
 
 
-@pytest.mark.xfail
 def test_warp_reproject_check_invert(runner, tmpdir):
     srcname = 'tests/data/world.rgb.tif'
     outputname = str(tmpdir.join('test.tif'))


### PR DESCRIPTION
Attempt at #614

So far it's an xfailing test for several (not all) of the resampling methods.

I've also `pass`ed on CPLE errors in warping - this was the behavior as of #657 (see #611 too) but was changed back [here](https://github.com/mapbox/rasterio/commit/12f8fc7e3f73766ee80b8f64813601e56caae618#diff-7519f03c7f3cca2b36a087ca08b1ffd1R570) for reasons that I've since forgotten. Can you refresh my memory on this @sgillies?