### PR TITLE
Add out_shape to read() and read_masks()

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -639,7 +639,7 @@ cdef class RasterReader(_base.DatasetReader):
 
 
     def read(self, indexes=None, out=None, window=None, masked=False,
-            boundless=False):
+            out_shape=None, boundless=False):
         """Read raster bands as a multidimensional array
 
         Parameters
@@ -648,7 +648,7 @@ cdef class RasterReader(_base.DatasetReader):
             If `indexes` is a list, the result is a 3D array, but is
             a 2D array if it is a band index number.
 
-        out: numpy ndarray, optional
+        out : numpy ndarray, optional
             As with Numpy ufuncs, this is an optional reference to an
             output array with the same dimensions and shape into which
             data will be placed.
@@ -656,6 +656,14 @@ cdef class RasterReader(_base.DatasetReader):
             *Note*: the method's return value may be a view on this
             array. In other words, `out` is likely to be an
             incomplete representation of the method's results.
+
+            Cannot be combined with `out_shape`.
+
+        out_shape : tuple, optional
+            A tuple describing the output array's shape.  Allows for decimated
+            reads without constructing an output Numpy array.
+
+            Cannot be combined with `out`.
 
         window : a pair (tuple) of pairs of ints, optional
             The optional `window` argument is a 2 item tuple. The first
@@ -753,7 +761,13 @@ cdef class RasterReader(_base.DatasetReader):
         else:
             win_shape += self.shape
 
-        if out is not None:
+        if out is not None and out_shape is not None:
+            raise ValueError("out and out_shape are exclusive")
+        elif out is not None or out_shape is not None:
+            if out_shape:
+                if len(out_shape) == 2:
+                    out_shape = (1, ) + out_shape
+                out = np.empty(out_shape, dtype=dtype)
             if out.dtype != dtype:
                 raise ValueError(
                     "the array's dtype '%s' does not match "

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -764,10 +764,9 @@ cdef class RasterReader(_base.DatasetReader):
         if out is not None and out_shape is not None:
             raise ValueError("out and out_shape are exclusive")
         elif out_shape is not None:
-            if out_shape:
-                if len(out_shape) == 2:
-                    out_shape = (1,) + out_shape
-                out = np.empty(out_shape, dtype=dtype)
+            if len(out_shape) == 2:
+                out_shape = (1,) + out_shape
+            out = np.empty(out_shape, dtype=dtype)
 
         if out is not None:
             if out.dtype != dtype:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,3 +249,8 @@ def gdalenv(request):
             rasterio.env.delenv()
             rasterio.env._env = None
     request.addfinalizer(fin)
+
+
+@pytest.fixture(scope='module')
+def path_rgb_byte_tif():
+    return os.path.join('tests', 'data', 'RGB.byte.tif')

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -274,39 +274,52 @@ class ReaderContextTest(unittest.TestCase):
 
 
 @pytest.mark.parametrize("shape,indexes", [
-    ((72, 80), 1),           # Single band
+    ((72, 80), 1),          # Single band
     ((2, 72, 80), (1, 3)),  # Multiband
     ((3, 72, 80), None)     # All bands
 ])
 def test_out_shape(path_rgb_byte_tif, shape, indexes):
 
-    """Test read(out_shape)
+    """Test read(out_shape) and read_masks(out_shape).  The tests are identical
+    aside from the method call.
 
     The pytest parameters are:
 
         * shape - tuple passed to out_shape
         * indexes - The bands to read
+
+    The resulting images have been decimated by a factor of 10.
     """
 
     with rasterio.open(path_rgb_byte_tif) as src:
 
-        out_shape = src.read(indexes, out_shape=shape)
-        out = src.read(indexes, out=np.empty(shape, dtype=src.dtypes[0]))
+        for attr in 'read', 'read_masks':
 
-        assert shape[-2:] == (72, 80)
-        assert out_shape.shape == out.shape
-        assert (out_shape == out).all()
+            reader = getattr(src, attr)
+
+            out_shape = reader(indexes, out_shape=shape)
+            out = reader(indexes, out=np.empty(shape, dtype=src.dtypes[0]))
+
+            assert out_shape.shape == out.shape
+            assert (out_shape == out).all()
+
+            # Sanity check fo the test itself
+            assert shape[-2:] == (72, 80)
 
 
 def test_out_shape_exceptions(path_rgb_byte_tif):
 
     with rasterio.open(path_rgb_byte_tif) as src:
-        with pytest.raises(ValueError):
-            out = np.empty((src.count, src.height, src.width))
-            out_shape = (src.count, src.height, src.width)
-            src.read(out=out, out_shape=out_shape)
 
-    with rasterio.open(path_rgb_byte_tif) as src:
-        with pytest.raises(ValueError):
-            out_shape = (5, src.height, src.width)
-            src.read(1, out_shape=out_shape)
+        for attr in 'read', 'read_masks':
+
+            reader = getattr(src, attr)
+
+            with pytest.raises(ValueError):
+                out = np.empty((src.count, src.height, src.width))
+                out_shape = (src.count, src.height, src.width)
+                reader(out=out, out_shape=out_shape)
+
+            with pytest.raises(ValueError):
+                out_shape = (5, src.height, src.width)
+                reader(1, out_shape=out_shape)


### PR DESCRIPTION
Closes https://github.com/mapbox/rasterio/issues/706

Ready to go.

This kind of gets into #322 and `src.shape` only containing 2 dimensions, but do we ant to enforce `out_shape[0] == indexes[0]`?  In the case of `out` we have to get the data from one array into the another so they _have_ be the same shape, but in the case of `out_shape` we can rely on `indexes` to provide the first dimension.

`read((1, 3), out_shape=(2, 10, 10))` could be replaced with `read((1, 3), out_shape=(10, 10))`