### PR TITLE
[WIP] Import sort, and cleanup of unused imports.

### DIFF
--- a/examples/async-rasterio.py
+++ b/examples/async-rasterio.py
@@ -15,6 +15,7 @@ import rasterio
 
 from rasterio._example import compute
 
+
 def main(infile, outfile, with_threads=False):
 
     with rasterio.Env():

--- a/examples/async-rasterio.py
+++ b/examples/async-rasterio.py
@@ -95,4 +95,3 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     main(args.input, args.output, args.with_workers)
-

--- a/examples/concurrent-cpu-bound.py
+++ b/examples/concurrent-cpu-bound.py
@@ -8,10 +8,11 @@ performance.
 With -j 4, the program returns in about 1/4 the time as with -j 1.
 """
 
-import concurrent.futures
 import multiprocessing
 
+import concurrent.futures
 import numpy as np
+
 import rasterio
 from rasterio._example import compute
 

--- a/examples/rasterio_polygonize.py
+++ b/examples/rasterio_polygonize.py
@@ -9,7 +9,6 @@ import fiona
 import rasterio
 from rasterio.features import shapes
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger('rasterio_polygonize')
 

--- a/examples/rasterize_geometry.py
+++ b/examples/rasterize_geometry.py
@@ -1,10 +1,11 @@
 import logging
-import numpy as np
 import sys
+
+import numpy as np
+
 import rasterio
 from rasterio.features import rasterize
 from rasterio.transform import IDENTITY
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger('rasterize_geometry')

--- a/examples/reproject.py
+++ b/examples/reproject.py
@@ -2,9 +2,10 @@ import os
 import subprocess
 
 import numpy as np
+
 import rasterio
 from rasterio import transform
-from rasterio.warp import reproject, RESAMPLING
+from rasterio.warp import RESAMPLING, reproject
 
 tempdir = '/tmp'
 tiffname = os.path.join(tempdir, 'example.tif')

--- a/examples/sieve.py
+++ b/examples/sieve.py
@@ -5,9 +5,9 @@
 import subprocess
 
 import numpy as np
-import rasterio
-from rasterio.features import sieve, shapes
 
+import rasterio
+from rasterio.features import shapes, sieve
 
 # Register GDAL and OGR drivers.
 with rasterio.Env():

--- a/examples/total.py
+++ b/examples/total.py
@@ -1,6 +1,8 @@
-import numpy as np
-import rasterio
 import subprocess
+
+import numpy as np
+
+import rasterio
 
 with rasterio.Env(CPL_DEBUG=True):
 

--- a/rasterio/compat.py
+++ b/rasterio/compat.py
@@ -3,7 +3,6 @@
 import itertools
 import sys
 
-
 if sys.version_info[0] >= 3:   # pragma: no cover
     string_types = str,
     text_type = str

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -13,8 +13,8 @@ here we use mappings:
 import json
 
 from rasterio._base import is_geographic_crs, is_projected_crs, is_same_crs
-from rasterio.errors import CRSError
 from rasterio.compat import string_types
+from rasterio.errors import CRSError
 
 
 def is_valid_crs(crs):

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -2,14 +2,13 @@
 
 import logging
 
-from rasterio._drivers import (
-    GDALEnv, del_gdal_config, get_gdal_config, set_gdal_config)
+from rasterio._drivers import (GDALEnv, del_gdal_config, get_gdal_config,
+                               set_gdal_config)
+from rasterio.compat import string_types
 from rasterio.dtypes import check_dtype
 from rasterio.errors import EnvError
-from rasterio.compat import string_types
 from rasterio.transform import guard_transform
 from rasterio.vfs import parse_path, vsi_path
-
 
 # The currently active GDAL/AWS environment is a private attribute.
 _env = None

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -8,11 +8,10 @@ import warnings
 import numpy as np
 
 import rasterio
-from rasterio._features import _shapes, _sieve, _rasterize, _bounds
+from rasterio._features import _bounds, _rasterize, _shapes, _sieve
+from rasterio.dtypes import can_cast_dtype, get_minimum_dtype, validate_dtype
 from rasterio.env import ensure_env
 from rasterio.transform import IDENTITY, guard_transform
-from rasterio.dtypes import validate_dtype, can_cast_dtype, get_minimum_dtype
-
 
 log = logging.getLogger(__name__)
 

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -11,7 +11,6 @@ import numpy as np
 from rasterio._base import get_window
 from rasterio.transform import Affine
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -13,6 +13,7 @@ import warnings
 import numpy as np
 
 import rasterio
+from rasterio.compat import zip_longest
 
 try:
     import matplotlib.pyplot as plt
@@ -28,7 +29,6 @@ except RuntimeError as e:  # pragma: no cover
     plt = None
 
 
-from rasterio.compat import zip_longest
 
 logger = logging.getLogger(__name__)
 

--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -2,15 +2,16 @@ import logging
 import os
 
 import click
-from cligj import (
-    precision_opt, indent_opt, compact_opt, projection_geographic_opt,
-    projection_mercator_opt, projection_projected_opt, sequence_opt,
-    use_rs_opt, geojson_type_feature_opt, geojson_type_bbox_opt,
-    geojson_type_collection_opt)
+from cligj import (compact_opt, geojson_type_bbox_opt,
+                   geojson_type_collection_opt, geojson_type_feature_opt,
+                   indent_opt, precision_opt, projection_geographic_opt,
+                   projection_mercator_opt, projection_projected_opt,
+                   sequence_opt, use_rs_opt)
 
-from .helpers import write_features, to_lower
 import rasterio
 from rasterio.warp import transform_bounds
+
+from .helpers import to_lower, write_features
 
 logger = logging.getLogger('rio')
 

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -1,17 +1,18 @@
 # Calc command.
 
-from distutils.version import LooseVersion
 import logging
+from distutils.version import LooseVersion
 
 import click
 import snuggs
 from cligj import files_inout_arg
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
-from rasterio.fill import fillnodata
 from rasterio.features import sieve
+from rasterio.fill import fillnodata
+
+from . import options
+from .helpers import resolve_inout
 
 
 def get_bands(inputs, d, i=None):

--- a/rasterio/rio/clip.py
+++ b/rasterio/rio/clip.py
@@ -3,10 +3,11 @@
 import click
 from cligj import format_opt
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
 from rasterio.coords import disjoint_bounds
+
+from . import options
+from .helpers import resolve_inout
 
 
 # Clip command

--- a/rasterio/rio/convert.py
+++ b/rasterio/rio/convert.py
@@ -3,12 +3,13 @@
 import logging
 
 import click
-from cligj import format_opt
 import numpy as np
+from cligj import format_opt
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
+
+from . import options
+from .helpers import resolve_inout
 
 
 @click.command(short_help="Copy and convert raster dataset.")

--- a/rasterio/rio/edit_info.py
+++ b/rasterio/rio/edit_info.py
@@ -5,10 +5,11 @@ import logging
 
 import click
 
-from . import options
 import rasterio
 import rasterio.crs
 from rasterio.transform import guard_transform
+
+from . import options
 
 
 # Handlers for info module options.

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -4,8 +4,9 @@ import json
 
 import click
 
-from . import options
 import rasterio.crs
+
+from . import options
 
 
 @click.command(short_help="Print information about a data file.")

--- a/rasterio/rio/insp.py
+++ b/rasterio/rio/insp.py
@@ -2,17 +2,18 @@
 from __future__ import absolute_import
 
 import code
+import collections
 import logging
 import sys
-import collections
 import warnings
 
-import numpy as np
 import click
+import numpy as np
 
-from . import options
 import rasterio
 from rasterio.plot import show, show_hist
+
+from . import options
 
 try:
     import matplotlib.pyplot as plt

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -32,15 +32,16 @@ so that other ``rio`` users may find it.
 
 
 import logging
-from pkg_resources import iter_entry_points
 import sys
 
-from click_plugins import with_plugins
 import click
 import cligj
+from click_plugins import with_plugins
+from pkg_resources import iter_entry_points
+
+import rasterio
 
 from . import options
-import rasterio
 
 
 def configure_logging(verbosity):

--- a/rasterio/rio/mask.py
+++ b/rasterio/rio/mask.py
@@ -5,9 +5,10 @@ import shutil
 import click
 import cligj
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
+
+from . import options
+from .helpers import resolve_inout
 
 logger = logging.getLogger('rio')
 

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -5,9 +5,10 @@ import logging
 import click
 from cligj import files_inout_arg, format_opt
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
+
+from . import options
+from .helpers import resolve_inout
 
 
 @click.command(short_help="Merge a stack of raster datasets.")

--- a/rasterio/rio/overview.py
+++ b/rasterio/rio/overview.py
@@ -1,15 +1,16 @@
 # coding: utf-8
 """Manage overviews of a dataset."""
 
-from functools import reduce
 import logging
 import operator
+from functools import reduce
 
 import click
 
-from . import options
 import rasterio
 from rasterio.enums import Resampling
+
+from . import options
 
 
 def build_handler(ctx, param, value):

--- a/rasterio/rio/rasterize.py
+++ b/rasterio/rio/rasterize.py
@@ -1,17 +1,17 @@
 import json
 import logging
-from math import ceil
 import os
+from math import ceil
 
 import click
 import cligj
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
-from rasterio.transform import Affine
 from rasterio.coords import disjoint_bounds
+from rasterio.transform import Affine
 
+from . import options
+from .helpers import resolve_inout
 
 logger = logging.getLogger('rio')
 

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -4,10 +4,11 @@ import os
 import click
 import cligj
 
-from .helpers import coords, write_features
-from . import options
 import rasterio
 from rasterio.transform import Affine
+
+from . import options
+from .helpers import coords, write_features
 
 logger = logging.getLogger('rio')
 

--- a/rasterio/rio/stack.py
+++ b/rasterio/rio/stack.py
@@ -5,10 +5,11 @@ import logging
 import click
 from cligj import files_inout_arg, format_opt
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
 from rasterio.compat import zip_longest
+
+from . import options
+from .helpers import resolve_inout
 
 
 # Stack command.

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -1,19 +1,19 @@
 import logging
-from math import ceil
 import warnings
+from math import ceil
 
 import click
 from cligj import files_inout_arg, format_opt
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
 from rasterio import crs
 from rasterio.errors import CRSError
 from rasterio.transform import Affine
-from rasterio.warp import (
-    reproject, Resampling, calculate_default_transform, transform_bounds)
+from rasterio.warp import (Resampling, calculate_default_transform, reproject,
+                           transform_bounds)
 
+from . import options
+from .helpers import resolve_inout
 
 # Improper usage of rio-warp can lead to accidental creation of
 # extremely large datasets. We'll put a hard limit on the size of

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -1,12 +1,10 @@
 """Geospatial transforms"""
 
-from __future__ import absolute_import
-from __future__ import division
+from __future__ import absolute_import, division
 
 import warnings
 
 from affine import Affine
-
 
 IDENTITY = Affine.identity()
 

--- a/rasterio/vfs.py
+++ b/rasterio/vfs.py
@@ -4,7 +4,6 @@ import os
 
 from rasterio.compat import urlparse
 
-
 # NB: As not to propagate fallacies of distributed computing, Rasterio
 # does not support HTTP or FTP URLs via GDAL's vsicurl handler. Only
 # the following local filesystem schemes are supported.

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -1,21 +1,19 @@
 """Raster warping and reprojection."""
 
-from __future__ import absolute_import
-from __future__ import division
+from __future__ import absolute_import, division
 
-from math import ceil
 import warnings
+from math import ceil
 
-from affine import Affine
 import numpy as np
+from affine import Affine
 
 from rasterio._base import _transform
-from rasterio._warp import (
-    _transform_geom, _reproject, _calculate_default_transform)
+from rasterio._warp import (_calculate_default_transform, _reproject,
+                            _transform_geom)
 from rasterio.enums import Resampling
 from rasterio.env import ensure_env
 from rasterio.transform import guard_transform
-
 
 RESAMPLING = Resampling
 warnings.warn(

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -1,7 +1,7 @@
 """Windows and related functions."""
 
-import functools
 import collections
+import functools
 
 
 def iter_args(function):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,10 @@ import os
 import shutil
 import sys
 
-from click.testing import CliRunner
+import numpy as np
 import py
 import pytest
-import numpy as np
-
+from click.testing import CliRunner
 
 DEFAULT_SHAPE = (10, 10)
 

--- a/tests/test_band.py
+++ b/tests/test_band.py
@@ -3,7 +3,6 @@ import logging
 import rasterio
 import rasterio.env
 
-
 logging.basicConfig(level=logging.DEBUG)
 
 def test_band():

--- a/tests/test_band.py
+++ b/tests/test_band.py
@@ -5,6 +5,7 @@ import rasterio.env
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 def test_band():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         b = rasterio.band(src, 1)

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -8,7 +8,6 @@ import rasterio
 from rasterio.enums import MaskFlags
 from rasterio.errors import NodataShadowWarning
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -41,6 +41,7 @@ def tiffs(tmpdir):
 
     return tmpdir
 
+
 def test_mask_flags():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         for flags in src.mask_flags:
@@ -68,7 +69,7 @@ def test_mask_flags_shadow(tiffs):
 
 
 def test_warning_no():
-    """No shadow warning is raised"""
+    """No shadow warning is raised."""
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             rm, gm, bm = src.read_masks()
@@ -77,7 +78,7 @@ def test_warning_no():
 
 
 def test_warning_shadow(tiffs):
-    """Shadow warning is raised"""
+    """Shadow warning is raised."""
     filename = str(tiffs.join('shadowed.tif'))
     with rasterio.open(filename) as src:
         with pytest.warns(NodataShadowWarning):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -10,7 +10,6 @@ import numpy as np
 
 import rasterio
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 class WindowTest(unittest.TestCase):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -12,39 +12,46 @@ import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
+
 class WindowTest(unittest.TestCase):
+
     def test_window_shape_errors(self):
         # Positive height and width are needed when stop is None.
         self.assertRaises(
             ValueError,
             rasterio.window_shape,
-            (((10, 20),(10, None)),) )
+            (((10, 20), (10, None)),))
         self.assertRaises(
             ValueError,
             rasterio.window_shape,
-            (((None, 10),(10, 20)),) )
+            (((None, 10), (10, 20)),))
+
     def test_window_shape_None_start(self):
         self.assertEqual(
-            rasterio.window_shape(((None,4),(None,102))),
+            rasterio.window_shape(((None, 4), (None, 102))),
             (4, 102))
+
     def test_window_shape_None_stop(self):
         self.assertEqual(
-            rasterio.window_shape(((10, None),(10, None)), 100, 90),
+            rasterio.window_shape(((10, None), (10, None)), 100, 90),
             (90, 80))
+
     def test_window_shape_positive(self):
         self.assertEqual(
-            rasterio.window_shape(((0,4),(1,102))),
+            rasterio.window_shape(((0, 4), (1, 102))),
             (4, 101))
+
     def test_window_shape_negative(self):
         self.assertEqual(
-            rasterio.window_shape(((-10, None),(-10, None)), 100, 90),
+            rasterio.window_shape(((-10, None), (-10, None)), 100, 90),
             (10, 10))
         self.assertEqual(
-            rasterio.window_shape(((~0, None),(~0, None)), 100, 90),
+            rasterio.window_shape(((~0, None), (~0, None)), 100, 90),
             (1, 1))
         self.assertEqual(
-            rasterio.window_shape(((None, ~0),(None, ~0)), 100, 90),
+            rasterio.window_shape(((None, ~0), (None, ~0)), 100, 90),
             (99, 89))
+
     def test_eval(self):
         self.assertEqual(
             rasterio.eval_window(((-10, None), (-10, None)), 100, 90),
@@ -53,44 +60,50 @@ class WindowTest(unittest.TestCase):
             rasterio.eval_window(((None, -10), (None, -10)), 100, 90),
             ((0, 90), (0, 80)))
 
+
 def test_window_index():
-    idx = rasterio.window_index(((0,4),(1,12)))
+    idx = rasterio.window_index(((0, 4), (1, 12)))
     assert len(idx) == 2
     r, c = idx
     assert r.start == 0
     assert r.stop == 4
     assert c.start == 1
     assert c.stop == 12
-    arr = np.ones((20,20))
+    arr = np.ones((20, 20))
     assert arr[idx].shape == (4, 11)
 
+
 class RasterBlocksTest(unittest.TestCase):
+
     def test_blocks(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(len(s.block_shapes), 3)
             self.assertEqual(s.block_shapes, ((3, 791), (3, 791), (3, 791)))
             windows = s.block_windows(1)
-            (j,i), first = next(windows)
-            self.assertEqual((j,i), (0, 0))
+            (j, i), first = next(windows)
+            self.assertEqual((j, i), (0, 0))
             self.assertEqual(first, ((0, 3), (0, 791)))
             windows = s.block_windows()
-            (j,i), first = next(windows)
-            self.assertEqual((j,i), (0, 0))
+            (j, i), first = next(windows)
+            self.assertEqual((j, i), (0, 0))
             self.assertEqual(first, ((0, 3), (0, 791)))
             (j, i), second = next(windows)
-            self.assertEqual((j,i), (1, 0))
+            self.assertEqual((j, i), (1, 0))
             self.assertEqual(second, ((3, 6), (0, 791)))
             (j, i), last = list(windows)[~0]
-            self.assertEqual((j,i), (239, 0))
+            self.assertEqual((j, i), (239, 0))
             self.assertEqual(last, ((717, 718), (0, 791)))
+
     def test_block_coverage(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(
-                s.width*s.height,
-                sum((w[0][1]-w[0][0])*(w[1][1]-w[1][0])
+                s.width * s.height,
+                sum((w[0][1] - w[0][0]) * (w[1][1] - w[1][0])
                     for ji, w in s.block_windows(1)))
 
+
 class WindowReadTest(unittest.TestCase):
+
     def test_read_window(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             windows = s.block_windows(1)
@@ -101,11 +114,15 @@ class WindowReadTest(unittest.TestCase):
                 first_block.shape,
                 rasterio.window_shape(first_window))
 
+
 class WindowWriteTest(unittest.TestCase):
+
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
+
     def tearDown(self):
         shutil.rmtree(self.tempdir)
+
     def test_write_window(self):
         name = os.path.join(self.tempdir, "test_write_window.tif")
         a = np.ones((50, 50), dtype=rasterio.ubyte) * 127

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -24,7 +24,7 @@ def test_checksum_band_window_min():
 def test_checksum_band_window_quarter():
     """A quarter window's checksum is different from the full image's"""
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        window = ((0, src.height//2), (0, src.width//2))
+        window = ((0, src.height // 2), (0, src.width // 2))
         checksums = [src.checksum(i, window=window) for i in src.indexes]
         assert checksums != [25420, 29131, 37860]
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,6 +1,5 @@
-from pkg_resources import iter_entry_points
-
 from click.testing import CliRunner
+from pkg_resources import iter_entry_points
 
 import rasterio
 from rasterio.rio.main import main_group

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -4,7 +4,6 @@ import sys
 
 import rasterio
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -1,5 +1,4 @@
 import logging
-import subprocess
 import sys
 
 import rasterio

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -5,6 +5,7 @@ def test_bounds():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src.bounds == (101985.0, 2611485.0, 339315.0, 2826915.0)
 
+
 def test_ul():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src.ul(0, 0) == (101985.0, 2826915.0)
@@ -13,6 +14,7 @@ def test_ul():
         assert tuple(
             round(v, 6) for v in src.ul(~0, ~0)
             ) == (339014.962073, 2611785.041783)
+
 
 def test_res():
     with rasterio.open('tests/data/RGB.byte.tif') as src:

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,5 +1,6 @@
 import rasterio
 
+
 def test_bounds():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src.bounds == (101985.0, 2611485.0, 339315.0, 2826915.0)

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,10 +1,10 @@
 import logging
 import os.path
-import unittest
 import shutil
 import subprocess
 import sys
 import tempfile
+import unittest
 
 import rasterio
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -1,16 +1,16 @@
+import json
 import logging
-import pytest
 import subprocess
 import sys
-import json
+
+import pytest
 
 import rasterio
-from rasterio._base import _can_create_osr
 from rasterio import crs
-from rasterio.crs import (
-    is_geographic_crs, is_projected_crs, is_same_crs, is_valid_crs)
+from rasterio._base import _can_create_osr
+from rasterio.crs import (is_geographic_crs, is_projected_crs, is_same_crs,
+                          is_valid_crs)
 from rasterio.errors import CRSError
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -20,6 +20,7 @@ def test_read_epsg(tmpdir):
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src.crs == {'init': 'epsg:32618'}
 
+
 def test_read_epsg3857(tmpdir):
     tiffname = str(tmpdir.join('lol.tif'))
     subprocess.call([
@@ -29,6 +30,8 @@ def test_read_epsg3857(tmpdir):
         assert src.crs == {'init': 'epsg:3857'}
 
 # Ensure that CRS sticks when we write a file.
+
+
 def test_write_3857(tmpdir):
     src_path = str(tmpdir.join('lol.tif'))
     subprocess.call([
@@ -73,12 +76,21 @@ def test_from_epsg_string():
 
 
 def test_from_string():
-    wgs84_crs = crs.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
-    assert wgs84_crs == {'no_defs': True, 'ellps': 'WGS84', 'datum': 'WGS84', 'proj': 'longlat'}
+    wgs84_crs = crs.from_string(
+        '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+    assert wgs84_crs == {
+        'no_defs': True,
+        'ellps': 'WGS84',
+        'datum': 'WGS84',
+        'proj': 'longlat'}
 
-    # Make sure this doesn't get handled using the from_epsg() even though 'epsg' is in the string
+    # Make sure this doesn't get handled using the from_epsg() even though
+    # 'epsg' is in the string
     epsg_init_crs = crs.from_string('+units=m +init=epsg:26911 +no_defs=True')
-    assert epsg_init_crs == {'units': 'm', 'init': 'epsg:26911', 'no_defs': True}
+    assert epsg_init_crs == {
+        'units': 'm',
+        'init': 'epsg:26911',
+        'no_defs': True}
 
 
 def test_bare_parameters():
@@ -87,10 +99,12 @@ def test_bare_parameters():
     which makes presents bare parameters as key=<bool>."""
 
     # Example produced by pyproj
-    crs_dict = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
+    crs_dict = crs.from_string(
+        '+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     assert crs_dict.get('no_defs', False) is True
 
-    crs_dict = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=False +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
+    crs_dict = crs.from_string(
+        '+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=False +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     assert crs_dict.get('no_defs', True) is False
 
 
@@ -98,13 +112,16 @@ def test_is_geographic():
     assert is_geographic_crs({'init': 'EPSG:4326'}) is True
     assert is_geographic_crs({'init': 'EPSG:3857'}) is False
 
-    wgs84_crs = crs.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+    wgs84_crs = crs.from_string(
+        '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
     assert is_geographic_crs(wgs84_crs) is True
 
-    nad27_crs = crs.from_string('+proj=longlat +ellps=clrk66 +datum=NAD27 +no_defs')
+    nad27_crs = crs.from_string(
+        '+proj=longlat +ellps=clrk66 +datum=NAD27 +no_defs')
     assert is_geographic_crs(nad27_crs) is True
 
-    lcc_crs = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
+    lcc_crs = crs.from_string(
+        '+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     assert is_geographic_crs(lcc_crs) is False
 
 
@@ -112,10 +129,12 @@ def test_is_projected():
     assert is_projected_crs({'init': 'EPSG:3857'}) is True
     assert is_projected_crs({'init': 'EPSG:4326'}) is False
 
-    lcc_crs = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
+    lcc_crs = crs.from_string(
+        '+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     assert is_projected_crs(lcc_crs) is True
 
-    wgs84_crs = crs.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+    wgs84_crs = crs.from_string(
+        '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
     assert is_projected_crs(wgs84_crs) is False
 
 
@@ -126,12 +145,15 @@ def test_is_same_crs():
     assert is_same_crs(crs1, crs1) is True
     assert is_same_crs(crs1, crs2) is False
 
-    wgs84_crs = crs.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+    wgs84_crs = crs.from_string(
+        '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
     assert is_same_crs(crs1, wgs84_crs) is True
 
     # Make sure that same projection with different parameter are not equal
-    lcc_crs1 = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
-    lcc_crs2 = crs.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=45 +lat_0=0')
+    lcc_crs1 = crs.from_string(
+        '+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
+    lcc_crs2 = crs.from_string(
+        '+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=45 +lat_0=0')
     assert is_same_crs(lcc_crs1, lcc_crs2) is False
 
 

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -46,6 +46,7 @@ alp_shift_lr = np.array([[1, 1, 0],
                          [0, 1, 0],
                          [0, 0, 0]]).astype('uint8') * 255
 
+
 @pytest.fixture(scope='function')
 def tiffs(tmpdir):
 
@@ -133,19 +134,23 @@ def test_no_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgb_no_ndv.tif'))) as src:
         assert np.array_equal(src.dataset_mask(), alldata)
 
+
 def test_rgb_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
         assert np.array_equal(src.dataset_mask(), alp)
 
+
 def test_rgba_no_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgba_no_ndv.tif'))) as src:
         assert np.array_equal(src.dataset_mask(), alp)
+
 
 def test_rgba_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgba_ndv.tif'))) as src:
         with pytest.warns(NodataShadowWarning):
             res = src.dataset_mask()
         assert np.array_equal(res, alp)
+
 
 def test_rgb_msk(tiffs):
     with rasterio.open(str(tiffs.join('rgb_msk.tif'))) as src:
@@ -154,14 +159,17 @@ def test_rgb_msk(tiffs):
         for bmask in src.read_masks():
             assert np.array_equal(bmask, msk)
 
+
 def test_rgb_msk_int(tiffs):
     with rasterio.open(str(tiffs.join('rgb_msk_internal.tif'))) as src:
         assert np.array_equal(src.dataset_mask(), msk)
+
 
 def test_rgba_msk(tiffs):
     with rasterio.open(str(tiffs.join('rgba_msk.tif'))) as src:
         # mask takes precendent over alpha
         assert np.array_equal(src.dataset_mask(), msk)
+
 
 def test_kwargs(tiffs):
     with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -3,12 +3,11 @@ import sys
 
 import numpy as np
 import pytest
-
 from affine import Affine
+
 import rasterio
 from rasterio.enums import MaskFlags
 from rasterio.errors import NodataShadowWarning
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -8,13 +8,9 @@ import pytest
 
 # New modules
 import rasterio
-from rasterio import windows
-
 # Deprecated modules
-from rasterio import (
-    get_data_window, window_intersection, window_union, windows_intersect
-)
-
+from rasterio import (get_data_window, window_intersection, window_union,
+                      windows, windows_intersect)
 
 DATA_WINDOW = ((3, 5), (2, 6))
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -8,9 +8,11 @@ import pytest
 
 # New modules
 import rasterio
+from rasterio import windows
+
 # Deprecated modules
 from rasterio import (get_data_window, window_intersection, window_union,
-                      windows, windows_intersect)
+                      windows_intersect)
 
 DATA_WINDOW = ((3, 5), (2, 6))
 

--- a/tests/test_driver_management.py
+++ b/tests/test_driver_management.py
@@ -7,14 +7,14 @@ from rasterio._drivers import driver_count
 def test_drivers():
     with rasterio.Env() as m:
         assert driver_count() > 0
-        assert type(m) == rasterio.Env
+        assert isinstance(m, rasterio.Env)
     assert driver_count() > 0
 
 
 def test_drivers_bwd_compat():
     with rasterio.Env() as m:
         assert driver_count() > 0
-        assert type(m) == rasterio.Env
+        assert isinstance(m, rasterio.Env)
     assert driver_count() > 0
 
 

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -2,12 +2,10 @@ import numpy as np
 import pytest
 
 import rasterio
-from rasterio import (
-    ubyte, uint8, uint16, uint32, int16, int32, float32, float64, complex_)
-from rasterio.dtypes import (
-    _gdal_typename, is_ndarray, check_dtype, get_minimum_dtype, can_cast_dtype,
-    validate_dtype
-)
+from rasterio import (complex_, float32, float64, int16, int32, ubyte, uint8,
+                      uint16, uint32)
+from rasterio.dtypes import (_gdal_typename, can_cast_dtype, check_dtype,
+                             get_minimum_dtype, is_ndarray, validate_dtype)
 
 
 def test_is_ndarray():

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,16 +5,14 @@ import logging
 import sys
 
 import boto3
-from packaging.version import parse
 import pytest
+from packaging.version import parse
 
 import rasterio
-from rasterio._drivers import (del_gdal_config, get_gdal_config,
-                               set_gdal_config)
-from rasterio.env import defenv, delenv, getenv, setenv, ensure_env
+from rasterio._drivers import del_gdal_config, get_gdal_config, set_gdal_config
+from rasterio.env import defenv, delenv, ensure_env, getenv, setenv
 from rasterio.errors import EnvError
 from rasterio.rio.main import main_group
-
 
 # Custom markers.
 mingdalversion = pytest.mark.skipif(

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -115,8 +115,10 @@ def test_aws_session_credentials(gdalenv):
 
 def test_with_aws_session_credentials(gdalenv):
     """Create an Env with a boto3 session."""
-    with rasterio.Env(aws_access_key_id='id', aws_secret_access_key='key',
-             aws_session_token='token', region_name='null-island-1') as s:
+    with rasterio.Env(aws_access_key_id='id',
+                      aws_secret_access_key='key',
+                      aws_session_token='token',
+                      region_name='null-island-1') as s:
         assert getenv() == rasterio.env._env.options == {}
         s.get_aws_credentials()
         assert getenv() == rasterio.env._env.options == {

--- a/tests/test_err.py
+++ b/tests/test_err.py
@@ -3,8 +3,8 @@
 import pytest
 
 import rasterio
-from rasterio.env import Env
 from rasterio._err import CPLError
+from rasterio.env import Env
 from rasterio.errors import RasterioIOError
 
 

--- a/tests/test_err.py
+++ b/tests/test_err.py
@@ -4,13 +4,14 @@ import pytest
 
 import rasterio
 from rasterio._err import CPLError
-from rasterio.env import Env
 from rasterio.errors import RasterioIOError
 
 
 def test_io_error(tmpdir):
     """RasterioIOError is raised when a disk file can't be opened.
-    Newlines are removed from GDAL error messages."""
+
+    Newlines are removed from GDAL error messages.
+    """
     with pytest.raises(RasterioIOError) as exc_info:
         rasterio.open(str(tmpdir.join('foo.tif')))
     msg, = exc_info.value.args

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,12 +1,12 @@
 import logging
 import sys
+
 import numpy as np
 import pytest
-
 from affine import Affine
-import rasterio
-from rasterio.features import bounds, geometry_mask, rasterize, sieve, shapes
 
+import rasterio
+from rasterio.features import bounds, geometry_mask, rasterize, shapes, sieve
 
 DEFAULT_SHAPE = (10, 10)
 

--- a/tests/test_fillnodata.py
+++ b/tests/test_fillnodata.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+
 import numpy as np
 import pytest
 

--- a/tests/test_fillnodata.py
+++ b/tests/test_fillnodata.py
@@ -4,10 +4,10 @@ import sys
 import numpy as np
 import pytest
 
-import rasterio
 from rasterio.fill import fillnodata
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
 
 def test_fillnodata():
     """Test filling nodata values in an ndarray"""
@@ -20,12 +20,14 @@ def test_fillnodata():
     result = fillnodata(a, mask)
     assert(np.all((np.ones([3, 3]) * 42) == result))
 
+
 def test_fillnodata_invalid_types():
     a = np.ones([3, 3])
     with pytest.raises(ValueError):
         fillnodata(None, a)
     with pytest.raises(ValueError):
         fillnodata(a, 42)
+
 
 def test_fillnodata_mask_ones():
     # when mask is all ones, image should be unmodified

--- a/tests/test_image_structure.py
+++ b/tests/test_image_structure.py
@@ -1,5 +1,4 @@
 import rasterio
-
 from rasterio.enums import Compression, Interleaving
 
 

--- a/tests/test_image_structure.py
+++ b/tests/test_image_structure.py
@@ -66,7 +66,7 @@ def test_interleaving_pixel():
         assert src.profile['interleave'] == 'pixel'
 
 
-def test_interleaving_pixel():
+def test_interleaving_band():
     with rasterio.open('tests/data/rgb_deflate.tif') as src:
         assert src.interleaving.name == 'band'
         assert src.interleaving.value == 'BAND'

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -18,11 +18,7 @@ def test_index():
 
 def test_full_window():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        left, bottom, right, top = src.bounds
-        assert src.window(
-            left, bottom, right, top) == tuple(
-            zip((0, 0),
-                src.shape))
+        assert src.window(*src.bounds) == tuple(zip((0, 0), src.shape))
 
 
 def test_window_no_exception():
@@ -45,14 +41,13 @@ def test_window():
         left, bottom, right, top = src.bounds
         dx, dy = src.res
         eps = 1.0e-8
-        assert src.window(
-            left+eps, bottom+eps, right-eps, top-eps) == ((0, src.height),
-                                                          (0, src.width))
+        window = src.window(left+eps, bottom+eps, right-eps, top-eps)
+        assert window == ((0, src.height), (0, src.width))
         assert src.index(left+400, top-400) == (1, 1)
         assert src.index(left+dx+eps, top-dy-eps) == (1, 1)
         assert src.window(left, top-400, left+400, top) == ((0, 2), (0, 2))
-        assert src.window(left, top-2*dy-eps, left+2*dx-eps,
-                          top) == ((0, 2), (0, 2))
+        window = src.window(left, top-2*dy-eps, left+2*dx-eps, top)
+        assert window == ((0, 2), (0, 2))
 
 
 def test_window_bounds_roundtrip():

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -19,7 +19,10 @@ def test_index():
 def test_full_window():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds
-        assert src.window(left, bottom, right, top) == tuple(zip((0, 0), src.shape))
+        assert src.window(
+            left, bottom, right, top) == tuple(
+            zip((0, 0),
+                src.shape))
 
 
 def test_window_no_exception():
@@ -48,7 +51,8 @@ def test_window():
         assert src.index(left+400, top-400) == (1, 1)
         assert src.index(left+dx+eps, top-dy-eps) == (1, 1)
         assert src.window(left, top-400, left+400, top) == ((0, 2), (0, 2))
-        assert src.window(left, top-2*dy-eps, left+2*dx-eps, top) == ((0, 2), (0, 2))
+        assert src.window(left, top-2*dy-eps, left+2*dx-eps,
+                          top) == ((0, 2), (0, 2))
 
 
 def test_window_bounds_roundtrip():

--- a/tests/test_nodata.py
+++ b/tests/test_nodata.py
@@ -3,11 +3,10 @@ import re
 import subprocess
 import sys
 
-import pytest
-
 import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
 
 def test_nodata(tmpdir):
     dst_path = str(tmpdir.join('lol.tif'))
@@ -24,6 +23,7 @@ def test_nodata(tmpdir):
     assert re.search(pattern, info, re.DOTALL) is not None
     pattern = b'Band 2.*?NoData Value=0'
     assert re.search(pattern, info, re.DOTALL) is not None
+
 
 def test_set_nodata(tmpdir):
     dst_path = str(tmpdir.join('lol.tif'))

--- a/tests/test_nodata.py
+++ b/tests/test_nodata.py
@@ -1,8 +1,9 @@
 import logging
-import pytest
 import re
 import subprocess
 import sys
+
+import pytest
 
 import rasterio
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,4 +1,5 @@
 import pytest
+
 import rasterio
 
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,5 +1,6 @@
 import click
 import pytest
+
 from rasterio.rio import options
 
 

--- a/tests/test_overviews.py
+++ b/tests/test_overviews.py
@@ -3,12 +3,11 @@
 import logging
 import sys
 
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
 
 import rasterio
 from rasterio.enums import Resampling
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_overviews.py
+++ b/tests/test_overviews.py
@@ -4,7 +4,6 @@ import logging
 import sys
 
 import pytest
-from click.testing import CliRunner
 
 import rasterio
 from rasterio.enums import Resampling

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -12,4 +12,3 @@ def test_pad():
     assert arr2.shape == (14, 14)
     assert trans2.xoff ==  -2.0
     assert trans2.yoff ==  12.0
-

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -10,5 +10,5 @@ def test_pad():
     trans = affine.Affine(1.0, 0.0, 0.0, 0.0, -1.0, 10.0)
     arr2, trans2 = rasterio.pad(arr, trans, 2, 'edge')
     assert arr2.shape == (14, 14)
-    assert trans2.xoff ==  -2.0
-    assert trans2.yoff ==  12.0
+    assert trans2.xoff == -2.0
+    assert trans2.yoff == 12.0

--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -1,8 +1,10 @@
 import logging
+import re
 import subprocess
 import sys
-import re
+
 import numpy as np
+
 import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)

--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import subprocess
 import sys
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,8 +1,8 @@
 import pytest
 
 import rasterio
-from rasterio.profiles import Profile, DefaultGTiffProfile
-from rasterio.profiles import default_gtiff_profile
+from rasterio.profiles import (DefaultGTiffProfile, Profile,
+                               default_gtiff_profile)
 
 
 def test_base_profile():

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,13 +1,12 @@
-from hashlib import md5
 import logging
 import sys
 import unittest
+from hashlib import md5
 
 import numpy as np
 import pytest
 
 import rasterio
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -278,7 +278,6 @@ class ReaderContextTest(unittest.TestCase):
     ((3, 72, 80), None)     # All bands
 ])
 def test_out_shape(path_rgb_byte_tif, shape, indexes):
-
     """Test read(out_shape) and read_masks(out_shape).  The tests are identical
     aside from the method call.
 
@@ -289,7 +288,6 @@ def test_out_shape(path_rgb_byte_tif, shape, indexes):
 
     The resulting images have been decimated by a factor of 10.
     """
-
     with rasterio.open(path_rgb_byte_tif) as src:
 
         for attr in 'read', 'read_masks':

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -2,7 +2,6 @@ import logging
 import sys
 
 import numpy as np
-import pytest
 
 import rasterio
 
@@ -36,7 +35,7 @@ def test_read_boundless_overlap():
         data = src.read(window=((-200, 200), (-200, 200)), boundless=True)
         assert data.shape == (3, 400, 400)
         assert data.any()
-        assert data[0,399,399] == 13
+        assert data[0, 399, 399] == 13
 
 
 def test_read_boundless_resample():
@@ -49,7 +48,7 @@ def test_read_boundless_resample():
                 boundless=True)
         assert data.shape == (3, 800, 800)
         assert data.any()
-        assert data[0,798,798] == 13
+        assert data[0, 798, 798] == 13
 
 
 def test_read_boundless_masked_no_overlap():
@@ -67,8 +66,8 @@ def test_read_boundless_masked_overlap():
         assert data.shape == (3, 400, 400)
         assert data.mask.any()
         assert not data.mask.all()
-        assert data.mask[0,399,399] == False
-        assert data.mask[0,0,0] == True
+        assert data.mask[0, 399, 399] == False
+        assert data.mask[0, 0, 0] == True
 
 
 def test_read_boundless_zero_stop():
@@ -84,6 +83,7 @@ def test_read_boundless_masks_zero_stop():
         data = src.read_masks(window=((-200, 0), (-200, 0)), boundless=True)
         assert data.shape == (3, 200, 200)
         assert data.min() == data.max() == src.nodata
+
 
 def test_read_boundless_noshift():
     with rasterio.open('tests/data/rgb4.tif') as src:

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -6,7 +6,6 @@ import pytest
 
 import rasterio
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_reshape_image.py
+++ b/tests/test_reshape_image.py
@@ -8,6 +8,7 @@ def test_reshape():
         im_data = rasterio.plot.reshape_as_image(src.read())
         assert im_data.shape == (718, 791, 3)
 
+
 def test_roundtrip_reshape():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         data = src.read()

--- a/tests/test_reshape_image.py
+++ b/tests/test_reshape_image.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import rasterio
 
+
 def test_reshape():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         im_data = rasterio.plot.reshape_as_image(src.read())

--- a/tests/test_revolvingdoor.py
+++ b/tests/test_revolvingdoor.py
@@ -34,4 +34,3 @@ class RevolvingDoorTest(unittest.TestCase):
 
         with rasterio.open(tiffname) as src:
             pass
-

--- a/tests/test_revolvingdoor.py
+++ b/tests/test_revolvingdoor.py
@@ -3,7 +3,6 @@
 import logging
 import os.path
 import shutil
-import subprocess
 import sys
 import tempfile
 import unittest
@@ -13,11 +12,12 @@ import rasterio
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 log = logging.getLogger('rasterio.tests')
 
+
 class RevolvingDoorTest(unittest.TestCase):
 
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
-    
+
     def tearDown(self):
         shutil.rmtree(self.tempdir)
 
@@ -28,7 +28,7 @@ class RevolvingDoorTest(unittest.TestCase):
             meta = src.meta
 
         tiffname = os.path.join(self.tempdir, 'foo.tif')
-        
+
         with rasterio.open(tiffname, 'w', **meta) as dst:
             dst.write(shade, indexes=1)
 

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -1,11 +1,10 @@
-import sys
 import logging
+import sys
 
 from click.testing import CliRunner
 
 import rasterio
 from rasterio.rio.calc import calc
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -1,13 +1,13 @@
-import sys
-import os
 import logging
+import os
+import sys
+
 import numpy as np
 from click.testing import CliRunner
 
 import rasterio
-from rasterio.rio.main import main_group
 from rasterio.rio.convert import convert
-
+from rasterio.rio.main import main_group
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -9,9 +9,7 @@ from affine import Affine
 
 import rasterio
 from rasterio.rio.main import main_group
-from rasterio.rio.mask import mask
 from rasterio.rio.rasterize import rasterize
-from rasterio.rio.shapes import shapes
 
 DEFAULT_SHAPE = (10, 10)
 
@@ -200,7 +198,8 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
             out.read(1, masked=True).filled(0))
 
 
-def test_mask_crop_inverted_y(runner, tmpdir, basic_feature, pixelated_image_file):
+def test_mask_crop_inverted_y(runner, tmpdir, basic_feature,
+                              pixelated_image_file):
     """
     --crop option should also work if raster has a positive y pixel size
     (e.g., Affine.identity() ).
@@ -632,7 +631,8 @@ def test_rasterize_like_raster_src_crs_mismatch(tmpdir, runner, basic_feature,
     output = str(tmpdir.join('test.tif'))
     result = runner.invoke(
         main_group,
-        ['rasterize', output, '--like', pixelated_image_file, '--src-crs', 'EPSG:3857'],
+        ['rasterize', output, '--like', pixelated_image_file, '--src-crs',
+         'EPSG:3857'],
         input=json.dumps(basic_feature))
 
     assert result.exit_code == 2

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -1,17 +1,17 @@
+import json
 import logging
 import os
 import re
 import sys
+
 import numpy as np
-import json
 from affine import Affine
 
 import rasterio
-from rasterio.rio.mask import mask
-from rasterio.rio.shapes import shapes
-from rasterio.rio.rasterize import rasterize
 from rasterio.rio.main import main_group
-
+from rasterio.rio.mask import mask
+from rasterio.rio.rasterize import rasterize
+from rasterio.rio.shapes import shapes
 
 DEFAULT_SHAPE = (10, 10)
 

--- a/tests/test_rio_helpers.py
+++ b/tests/test_rio_helpers.py
@@ -29,6 +29,7 @@ def test_fail_overwrite(tmpdir):
         helpers.resolve_inout(files=[str(x) for x in tmpdir.listdir()])
         assert "file exists and won't be overwritten without use of the " in str(excinfo.value)
 
+
 def test_force_overwrite(tmpdir):
     """Forced overwrite of existing file succeeds."""
     foo_tif = tmpdir.join('foo.tif')

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -3,16 +3,15 @@ import logging
 import sys
 
 import click
+import pytest
 from click import Context
 from click.testing import CliRunner
-import pytest
 
 import rasterio
 from rasterio.rio import info
-from rasterio.rio.edit_info import (edit, all_handler, crs_handler,
+from rasterio.rio.edit_info import (all_handler, crs_handler, edit,
                                     tags_handler, transform_handler)
 from rasterio.rio.main import main_group
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -4,11 +4,9 @@ import sys
 
 import click
 import pytest
-from click import Context
 from click.testing import CliRunner
 
 import rasterio
-from rasterio.rio import info
 from rasterio.rio.edit_info import (all_handler, crs_handler, edit,
                                     tags_handler, transform_handler)
 from rasterio.rio.main import main_group
@@ -589,6 +587,7 @@ def test_bounds_seq_rs():
     assert result.exit_code == 0
     assert result.output == (
         '\x1e[-78.96, 23.56, -76.57, 25.55]\n\x1e[-78.96, 23.56, -76.57, 25.55]\n')
+
 
 def test_insp():
     runner = CliRunner()

--- a/tests/test_rio_main.py
+++ b/tests/test_rio_main.py
@@ -2,12 +2,11 @@ import logging
 import re
 import sys
 
+import pytest
 from click.testing import CliRunner
 from packaging.version import parse
-import pytest
 
 from rasterio.rio.main import main_group
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_rio_main.py
+++ b/tests/test_rio_main.py
@@ -1,8 +1,6 @@
 import logging
-import re
 import sys
 
-import pytest
 from click.testing import CliRunner
 from packaging.version import parse
 

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 
-import click
 import numpy as np
 from click.testing import CliRunner
 from pytest import fixture
@@ -343,7 +342,8 @@ def test_merge_tiny_res_bounds(tiffs):
     inputs = [str(x) for x in tiffs.listdir()]
     inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(merge, inputs + [outputname, '--res', 2, '--bounds', 1, 0, 5, 4])
+    result = runner.invoke(merge, inputs +
+                           [outputname, '--res', 2, '--bounds', 1, 0, 5, 4])
     assert result.exit_code == 0
 
     # Output should be
@@ -364,7 +364,8 @@ def test_merge_tiny_res_high_precision(tiffs):
     inputs = [str(x) for x in tiffs.listdir()]
     inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(merge, inputs + [outputname, '--res', 2, '--precision', 15])
+    result = runner.invoke(merge, inputs +
+                           [outputname, '--res', 2, '--precision', 15])
     assert result.exit_code == 0
 
     # Output should be

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -1,6 +1,7 @@
-import sys
-import os
 import logging
+import os
+import sys
+
 import click
 import numpy as np
 from click.testing import CliRunner
@@ -9,7 +10,6 @@ from pytest import fixture
 import rasterio
 from rasterio.rio.merge import merge
 from rasterio.transform import Affine
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -45,13 +45,15 @@ def test_file_in_handler_with_vfs_nonexistent():
     ctx = MockContext()
     with pytest.raises(click.BadParameter):
         _ = file_in_handler(
-            ctx, 'INPUT', 'zip://{0}/files.zip!/inputs/RGB.byte.tif'.format(uuid.uuid4()))
+            ctx, 'INPUT', 'zip://{0}/files.zip!/inputs/RGB.byte.tif'.format(
+                uuid.uuid4()))
 
 
 def test_file_in_handler_with_vfs():
     """vfs file path path is expanded"""
     ctx = MockContext()
-    retval = file_in_handler(ctx, 'INPUT', 'zip://tests/data/files.zip!/inputs/RGB.byte.tif')
+    retval = file_in_handler(ctx, 'INPUT',
+                             'zip://tests/data/files.zip!/inputs/RGB.byte.tif')
     assert retval.startswith('zip:///')
     assert retval.endswith('tests/data/files.zip!/inputs/RGB.byte.tif')
 

--- a/tests/test_rio_overview.py
+++ b/tests/test_rio_overview.py
@@ -6,7 +6,6 @@ from click.testing import CliRunner
 import rasterio
 from rasterio.rio.main import main_group as cli
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_rio_sample.py
+++ b/tests/test_rio_sample.py
@@ -1,10 +1,8 @@
 import logging
 import sys
 
-import click
 from click.testing import CliRunner
 
-import rasterio
 from rasterio.rio.main import main_group
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -44,7 +42,8 @@ def test_sample_bidx():
     runner = CliRunner()
     result = runner.invoke(
         main_group,
-        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '1,2', "[220650.0, 2719200.0]"],
+        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '1,2',
+         "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.strip() == '[18, 25]'
@@ -54,7 +53,8 @@ def test_sample_bidx2():
     runner = CliRunner()
     result = runner.invoke(
         main_group,
-        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '1..2', "[220650.0, 2719200.0]"],
+        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '1..2',
+         "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.strip() == '[18, 25]'
@@ -64,7 +64,8 @@ def test_sample_bidx3():
     runner = CliRunner()
     result = runner.invoke(
         main_group,
-        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '..2', "[220650.0, 2719200.0]"],
+        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '..2',
+         "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.strip() == '[18, 25]'
@@ -74,7 +75,8 @@ def test_sample_bidx4():
     runner = CliRunner()
     result = runner.invoke(
         main_group,
-        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '3', "[220650.0, 2719200.0]"],
+        ['sample', 'tests/data/RGB.byte.tif', '--bidx', '3',
+         "[220650.0, 2719200.0]"],
         catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.strip() == '[14]'

--- a/tests/test_rio_sample.py
+++ b/tests/test_rio_sample.py
@@ -7,7 +7,6 @@ from click.testing import CliRunner
 import rasterio
 from rasterio.rio.main import main_group
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -142,7 +142,7 @@ def test_warp_no_reproject_dimensions(runner, tmpdir):
             assert output.width == 100
             assert output.height == 100
             assert np.allclose([97.839396, 97.839396],
-                                  [output.affine.a, -output.affine.e])
+                               [output.affine.a, -output.affine.e])
 
 
 def test_warp_no_reproject_res(runner, tmpdir):
@@ -165,8 +165,8 @@ def test_warp_no_reproject_bounds(runner, tmpdir):
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
-    result = runner.invoke(warp.warp,[srcname, outputname,
-                                      '--bounds'] + out_bounds)
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--bounds'] + out_bounds)
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 
@@ -175,7 +175,7 @@ def test_warp_no_reproject_bounds(runner, tmpdir):
             assert output.crs == src.crs
             assert np.allclose(output.bounds, out_bounds)
             assert np.allclose([src.affine.a, src.affine.e],
-                                  [output.affine.a, output.affine.e])
+                               [output.affine.a, output.affine.e])
             assert output.width == 105
             assert output.height == 210
 
@@ -184,9 +184,9 @@ def test_warp_no_reproject_bounds_res(runner, tmpdir):
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
-    result = runner.invoke(warp.warp,[srcname, outputname,
-                                      '--res', 30,
-                                      '--bounds', ] + out_bounds)
+    result = runner.invoke(warp.warp, [srcname, outputname,
+                                       '--res', 30,
+                                       '--bounds', ] + out_bounds)
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 
@@ -214,8 +214,8 @@ def test_warp_reproject_dst_crs(runner, tmpdir):
             assert output.width == 835
             assert output.height == 696
             assert np.allclose(output.bounds,
-                                  [-78.95864996545055, 23.564787976164418,
-                                   -76.5759177302349, 25.550873767433984])
+                               [-78.95864996545055, 23.564787976164418,
+                                -76.5759177302349, 25.550873767433984])
 
 
 def test_warp_reproject_dst_crs_proj4(runner, tmpdir):
@@ -262,7 +262,7 @@ def test_warp_reproject_dimensions(runner, tmpdir):
             assert output.width == 100
             assert output.height == 100
             assert np.allclose([0.0008789062498762235, 0.0006771676143921468],
-                                  [output.affine.a, -output.affine.e])
+                               [output.affine.a, -output.affine.e])
 
 
 def test_warp_reproject_bounds_no_res(runner, tmpdir):
@@ -280,10 +280,9 @@ def test_warp_reproject_multi_bounds_fail(runner, tmpdir):
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
-    result = runner.invoke(warp.warp, [srcname, outputname,
-                                       '--dst-crs', 'EPSG:4326',
-                                       '--x-dst-bounds'] + out_bounds +
-                                       ['--bounds'] + out_bounds)
+    result = runner.invoke(warp.warp, [srcname, outputname, '--dst-crs',
+                                       'EPSG:4326', '--x-dst-bounds'] +
+                                       out_bounds + ['--bounds'] + out_bounds)
     assert result.exit_code == 2
 
 
@@ -292,10 +291,9 @@ def test_warp_reproject_bounds_crossup_fail(runner, tmpdir):
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
-    result = runner.invoke(warp.warp, [srcname, outputname,
-                                       '--dst-crs', 'EPSG:4326',
-                                       '--res', 0.001, '--x-dst-bounds', ]
-                                       + out_bounds)
+    result = runner.invoke(
+        warp.warp, [srcname, outputname, '--dst-crs', 'EPSG:4326',
+                    '--res', 0.001, '--x-dst-bounds', ] + out_bounds)
     assert result.exit_code == 2
 
 
@@ -305,8 +303,8 @@ def test_warp_reproject_bounds_res_future_warning(runner, tmpdir):
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
     result = runner.invoke(
-                warp.warp, [srcname, outputname, '--dst-crs', 'EPSG:4326',
-                            '--res', 0.001, '--bounds'] + out_bounds)
+        warp.warp, [srcname, outputname, '--dst-crs', 'EPSG:4326',
+                    '--res', 0.001, '--bounds'] + out_bounds)
     assert "Future Warning" in result.output
 
 
@@ -325,9 +323,9 @@ def test_warp_reproject_src_bounds_res(runner, tmpdir):
         with rasterio.open(outputname) as output:
             assert output.crs == {'init': 'epsg:4326'}
             assert np.allclose(output.bounds[:],
-                                  [-106.45036, 39.6138, -106.44136, 39.6278])
+                               [-106.45036, 39.6138, -106.44136, 39.6278])
             assert np.allclose([0.001, 0.001],
-                                  [output.affine.a, -output.affine.e])
+                               [output.affine.a, -output.affine.e])
             assert output.width == 9
             assert output.height == 14
 
@@ -347,15 +345,15 @@ def test_warp_reproject_dst_bounds(runner, tmpdir):
         with rasterio.open(outputname) as output:
             assert output.crs == {'init': 'epsg:4326'}
             assert np.allclose(output.bounds[0::3],
-                                  [-106.45036, 39.6278])
+                               [-106.45036, 39.6278])
             assert np.allclose([0.001, 0.001],
-                                  [output.affine.a, -output.affine.e])
+                               [output.affine.a, -output.affine.e])
 
             # XXX: an extra row and column is produced in the dataset
             # because we're using ceil instead of floor internally.
             # Not necessarily a bug, but may change in the future.
             assert np.allclose([output.bounds[2]-0.001, output.bounds[1]+0.001],
-                                  [-106.44136, 39.6138])
+                               [-106.44136, 39.6138])
             assert output.width == 10
             assert output.height == 15
 
@@ -402,7 +400,8 @@ def test_warp_reproject_nolostdata(runner, tmpdir):
 
     with rasterio.open(outputname) as output:
         arr = output.read()
-        # 50 column swath on the right edge should have some ones (gdalwarped has 7223)
+        # 50 column swath on the right edge should have some ones (gdalwarped
+        # has 7223)
         assert arr[0, :, -50:].sum() > 7000
         assert output.crs == {'init': 'epsg:3857'}
 

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -10,7 +10,6 @@ import rasterio.crs
 from rasterio.rio import warp
 from rasterio.rio.main import main_group
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -8,6 +8,7 @@ import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
+
 def test_tags_read():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         assert src.tags() == {'AREA_OR_POINT': 'Area'}
@@ -17,15 +18,16 @@ def test_tags_read():
         with pytest.raises(IndexError):
             tags = src.tags(4)
 
+
 def test_tags_update(tmpdir):
     tiffname = str(tmpdir.join('foo.tif'))
     with rasterio.open(
-            tiffname, 
-            'w', 
-            driver='GTiff', 
-            count=1, 
-            dtype=rasterio.uint8, 
-            width=10, 
+            tiffname,
+            'w',
+            driver='GTiff',
+            count=1,
+            dtype=rasterio.uint8,
+            width=10,
             height=10) as dst:
 
         dst.update_tags(a='1', b='2')
@@ -34,8 +36,8 @@ def test_tags_update(tmpdir):
             dst.update_tags(4, d=4)
 
         assert dst.tags() == {'a': '1', 'b': '2'}
-        assert dst.tags(1) == {'c': '3' }
-        
+        assert dst.tags(1) == {'c': '3'}
+
         # Assert that unicode tags work.
         # Russian text appropriated from pytest issue #319
         # https://bitbucket.org/hpk42/pytest/issue/319/utf-8-output-in-assertion-error-converted
@@ -47,9 +49,10 @@ def test_tags_update(tmpdir):
         assert src.tags(1) == {'c': '3'}
         assert src.tags(ns='rasterio_testing') == {'rus': u'другая строка'}
 
+
 def test_tags_update_twice():
     with rasterio.open(
-            'test.tif', 'w', 
+            'test.tif', 'w',
             'GTiff', 3, 4, 1, dtype=rasterio.ubyte) as dst:
         dst.update_tags(a=1, b=2)
         assert dst.tags() == {'a': '1', 'b': '2'}
@@ -59,7 +62,7 @@ def test_tags_update_twice():
 
 def test_tags_eq():
     with rasterio.open(
-            'test.tif', 'w', 
+            'test.tif', 'w',
             'GTiff', 3, 4, 1, dtype=rasterio.ubyte) as dst:
         dst.update_tags(a="foo=bar")
         assert dst.tags() == {'a': "foo=bar"}

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -3,6 +3,7 @@ import logging
 import sys
 
 import pytest
+
 import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -1,13 +1,14 @@
 import numpy as np
 
+import rasterio
+from rasterio.plot import show, show_hist
+from rasterio.rio.insp import stats
+
 try:
     import matplotlib.pyplot as plt
 except ImportError:
     plt = None
 
-import rasterio
-from rasterio.plot import show, show_hist
-from rasterio.rio.insp import stats
 
 def test_stats():
     with rasterio.open('tests/data/RGB.byte.tif') as src:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,3 @@
-import pytest
 from affine import Affine
 
 import rasterio

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,6 @@
-from affine import Affine
 import pytest
+from affine import Affine
+
 import rasterio
 from rasterio import transform
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,6 +1,4 @@
-
 import re
-import shutil
 import subprocess
 
 import affine

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,13 +1,14 @@
 
+import re
 import shutil
 import subprocess
-import re
 
 import affine
 import numpy as np
 import pytest
 
 import rasterio
+
 
 def test_update_tags(data):
     tiffname = str(data.join('RGB.byte.tif'))

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -7,7 +7,6 @@ import rasterio
 from rasterio.profiles import default_gtiff_profile
 from rasterio.vfs import parse_path, vsi_path
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -42,8 +42,8 @@ def test_parse_netcdf():
 
 def test_vsi_path_scheme():
     """Correctly make a vsi path"""
-    assert vsi_path(
-        'foo.tif', 'tests/data/files.zip', 'zip') == '/vsizip/tests/data/files.zip/foo.tif'
+    assert vsi_path('foo.tif', 'tests/data/files.zip',
+        'zip') == '/vsizip/tests/data/files.zip/foo.tif'
 
 
 def test_vsi_path_file():
@@ -64,6 +64,7 @@ def test_read_vfs_file():
             'file://tests/data/RGB.byte.tif') as src:
         assert src.name == 'file://tests/data/RGB.byte.tif'
         assert src.count == 3
+
 
 def test_read_vfs_zip_cmp_array():
     with rasterio.open(

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -42,8 +42,8 @@ def test_parse_netcdf():
 
 def test_vsi_path_scheme():
     """Correctly make a vsi path"""
-    assert vsi_path('foo.tif', 'tests/data/files.zip',
-        'zip') == '/vsizip/tests/data/files.zip/foo.tif'
+    vp = vsi_path('foo.tif', 'tests/data/files.zip', 'zip')
+    assert vp == '/vsizip/tests/data/files.zip/foo.tif'
 
 
 def test_vsi_path_file():

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -12,9 +12,7 @@ from rasterio.warp import (calculate_default_transform, reproject, transform,
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
-
-DST_TRANSFORM = Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0,
-                                 -300.0)
+DST_TRANSFORM = Affine.from_gdal(-8789636.708, 300, 0, 2943560.235, 0, -300)
 
 
 class ReprojectParams(object):

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1,4 +1,3 @@
-
 import logging
 import sys
 
@@ -14,7 +13,8 @@ from rasterio.warp import (calculate_default_transform, reproject, transform,
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-DST_TRANSFORM = Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
+DST_TRANSFORM = Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0,
+                                 -300.0)
 
 
 class ReprojectParams(object):
@@ -260,7 +260,7 @@ def test_reproject_nodata():
     with rasterio.Env():
         source = np.ones((params.width, params.height), dtype=np.uint8)
         out = np.zeros((params.dst_width, params.dst_height),
-                          dtype=source.dtype)
+                       dtype=source.dtype)
         out.fill(120)  # Fill with arbitrary value
 
         reproject(
@@ -285,7 +285,7 @@ def test_reproject_nodata_nan():
     with rasterio.Env():
         source = np.ones((params.width, params.height), dtype=np.float32)
         out = np.zeros((params.dst_width, params.dst_height),
-                          dtype=source.dtype)
+                       dtype=source.dtype)
         out.fill(120)  # Fill with arbitrary value
 
         reproject(
@@ -311,7 +311,7 @@ def test_reproject_dst_nodata_default():
     with rasterio.Env():
         source = np.ones((params.width, params.height), dtype=np.uint8)
         out = np.zeros((params.dst_width, params.dst_height),
-                          dtype=source.dtype)
+                       dtype=source.dtype)
         out.fill(120)  # Fill with arbitrary value
 
         reproject(

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1,16 +1,15 @@
 
 import logging
 import sys
+
+import numpy as np
 import pytest
 from affine import Affine
-import numpy as np
 
 import rasterio
 from rasterio.enums import Resampling
-from rasterio.warp import (
-    reproject, transform_geom, transform, transform_bounds,
-    calculate_default_transform)
-
+from rasterio.warp import (calculate_default_transform, reproject, transform,
+                           transform_bounds, transform_geom)
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -12,7 +12,6 @@ from rasterio.warp import transform_bounds
 def test_identity():
     """Get the same transform and dimensions back for same crs."""
     # Tile: [53, 96, 8]
-    # [-11740727.544603072, 4852834.0517692715, -11584184.510675032, 5009377.085697309]
     src_crs = dst_crs = 'EPSG:3857'
     width = height = 1000
     left, bottom, right, top = (
@@ -85,7 +84,7 @@ def test_gdal_transform_fail_src_crs():
 @pytest.mark.xfail(
     os.environ.get('GDALVERSION', 'a.b.c').startswith('1.9'),
                    reason="GDAL 1.9 doesn't catch this error")
-def test_gdal_transform_fail_src_crs():
+def test_gdal_transform_fail_dst_crs_xfail():
     with rasterio.Env():
         with pytest.raises(CRSError):
             dt, dw, dh = _calculate_default_transform(

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -43,6 +43,7 @@ def test_no_crs(tmpdir):
             dtype=rasterio.uint8) as dst:
         dst.write(np.ones((100, 100), dtype=rasterio.uint8), indexes=1)
 
+
 def test_context(tmpdir):
     name = str(tmpdir.join("test_context.tif"))
     with rasterio.open(
@@ -80,6 +81,8 @@ def test_write_ubyte(tmpdir):
         s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
+
+
 def test_write_ubyte_multi(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte_multi.tif"))
     a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
@@ -90,6 +93,8 @@ def test_write_ubyte_multi(tmpdir):
         s.write(a, 1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
+
+
 def test_write_ubyte_multi_list(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte_multi_list.tif"))
     a = np.array([np.ones((100, 100), dtype=rasterio.ubyte) * 127])
@@ -100,6 +105,8 @@ def test_write_ubyte_multi_list(tmpdir):
         s.write(a, [1])
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
+
+
 def test_write_ubyte_multi_3(tmpdir):
     name = str(tmpdir.mkdir("sub").join("test_write_ubyte_multi_list.tif"))
     arr = np.array(3 * [np.ones((100, 100), dtype=rasterio.ubyte) * 127])
@@ -110,6 +117,7 @@ def test_write_ubyte_multi_3(tmpdir):
         s.write(arr)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
+
 
 def test_write_float(tmpdir):
     name = str(tmpdir.join("test_write_float.tif"))
@@ -123,6 +131,7 @@ def test_write_float(tmpdir):
         s.write(a, indexes=2)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=42.000, Maximum=42.000, Mean=42.000, StdDev=0.000" in info
+
 
 def test_write_crs_transform(tmpdir):
     name = str(tmpdir.join("test_write_crs_transform.tif"))
@@ -144,6 +153,7 @@ def test_write_crs_transform(tmpdir):
     # (precision varies slightly by platform)
     assert re.search("Pixel Size = \(300.03792\d+,-300.04178\d+\)", info)
 
+
 def test_write_crs_transform_affine(tmpdir):
     name = str(tmpdir.join("test_write_crs_transform.tif"))
     a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
@@ -164,6 +174,7 @@ def test_write_crs_transform_affine(tmpdir):
     # (precision varies slightly by platform)
     assert re.search("Pixel Size = \(300.03792\d+,-300.04178\d+\)", info)
 
+
 def test_write_crs_transform_2(tmpdir):
     """Using 'EPSG:32618' as CRS."""
     name = str(tmpdir.join("test_write_crs_transform.tif"))
@@ -183,6 +194,7 @@ def test_write_crs_transform_2(tmpdir):
     # make sure that pixel size is nearly the same as transform
     # (precision varies slightly by platform)
     assert re.search("Pixel Size = \(300.03792\d+,-300.04178\d+\)", info)
+
 
 def test_write_crs_transform_3(tmpdir):
     """Using WKT as CRS."""
@@ -205,6 +217,7 @@ def test_write_crs_transform_3(tmpdir):
     # (precision varies slightly by platform)
     assert re.search("Pixel Size = \(300.03792\d+,-300.04178\d+\)", info)
 
+
 def test_write_meta(tmpdir):
     name = str(tmpdir.join("test_write_meta.tif"))
     a = np.ones((100, 100), dtype=rasterio.ubyte) * 127
@@ -213,6 +226,7 @@ def test_write_meta(tmpdir):
         s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
+
 
 def test_write_nodata(tmpdir):
     name = str(tmpdir.join("test_write_nodata.tif"))
@@ -250,6 +264,7 @@ def test_write_lzw(tmpdir):
         s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert "LZW" in info
+
 
 def test_write_noncontiguous(tmpdir):
     name = str(tmpdir.join("test_write_nodata.tif"))

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -8,7 +8,6 @@ import pytest
 
 import rasterio
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 


### PR DESCRIPTION
I started playing with `isort` to standardize import orders.

Then started cleaning up unused imports and included pep8 while I was in the files. Only did this on tests dir so far.

Additionally found two tests which were not ran because of duplicate names.

I will keep working on the other directories later, but this is a good point to take a break.