### PR TITLE
Use CHECK_WITH_INVERT_PROJ=True in default Env

### DIFF
--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -154,6 +154,11 @@ def defenv():
         log.debug("Environment %r exists", _env)
     else:
         _env = GDALEnv()
+        # Rasterio defaults
+        options = {
+            'CHECK_WITH_INVERT_PROJ': True
+        }
+        _env.update_config_options(**options)
         log.debug(
             "New GDAL environment %r created", _env)
 

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -16,6 +16,10 @@ _env = None
 
 log = logging.getLogger(__name__)
 
+# Rasterio defaults
+default_options = {
+    'CHECK_WITH_INVERT_PROJ': True
+}
 
 class Env(object):
     """Abstraction for GDAL and AWS configuration
@@ -154,11 +158,7 @@ def defenv():
         log.debug("Environment %r exists", _env)
     else:
         _env = GDALEnv()
-        # Rasterio defaults
-        options = {
-            'CHECK_WITH_INVERT_PROJ': True
-        }
-        _env.update_config_options(**options)
+        _env.update_config_options(**default_options)
         log.debug(
             "New GDAL environment %r created", _env)
 

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -320,7 +320,7 @@ def calculate_default_transform(
 
     Note
     ----
-    Should be called within a raster.env.Env() context
+    Should be called within a rasterio.Env() context
 
     Some behavior of this function is determined by the
     CHECK_WITH_INVERT_PROJ environment variable

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -629,19 +629,6 @@ def test_resample_default_invert_proj(method):
 
         out = np.empty(shape=(dst_height, dst_width), dtype=np.uint8)
 
-        # nearest works fine
-        reproject(
-            source,
-            out,
-            src_transform=src.transform,
-            src_crs=src.crs,
-            dst_transform=dst_affine,
-            dst_crs=dst_crs,
-            resampling=Resampling.nearest)
-
-        assert out.mean() > 0
-
-        # some other methods succeed but produce blank images
         out = np.empty(src.shape, dtype=np.uint8)
         reproject(
             source,
@@ -680,19 +667,7 @@ def test_resample_no_invert_proj(method):
 
         out = np.empty(shape=(dst_height, dst_width), dtype=np.uint8)
 
-        # nearest works fine
-        reproject(
-            source,
-            out,
-            src_transform=src.transform,
-            src_crs=src.crs,
-            dst_transform=dst_affine,
-            dst_crs=dst_crs,
-            resampling=Resampling.nearest)
-
-        assert out.mean() > 0
-
-        # some other methods succeed but produce blank images
+        # see #614, some resamplin methods succeed but produce blank images
         out = np.empty(src.shape, dtype=np.uint8)
         reproject(
             source,

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 from affine import Affine
 import numpy as np
+from packaging.version import parse
 
 import rasterio
 from rasterio.enums import Resampling
@@ -16,6 +17,13 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 DST_TRANSFORM = Affine.from_gdal(-8789636.708, 300.0, 0.0, 2943560.235, 0.0, -300.0)
+
+
+is_gdal1 = parse(rasterio.__gdal_version__) < parse('2.0')
+
+gdal2plus_only = (
+    Resampling.max, Resampling.min, Resampling.med,
+    Resampling.q1, Resampling.q3)
 
 
 reproj_expected = (
@@ -610,8 +618,8 @@ def test_resample_default_invert_proj(method):
     """Nearest and bilinear should produce valid results
     with the default Env
     """
-    if method == Resampling.gauss:
-        pytest.skip()  # not supported
+    if method == Resampling.gauss or (is_gdal1 and method in gdal2plus_only):
+        pytest.skip()
 
     with rasterio.Env():
         with rasterio.open('tests/data/world.rgb.tif') as src:
@@ -648,8 +656,8 @@ def test_resample_no_invert_proj(method):
     """Nearest and bilinear should produce valid results with
     CHECK_WITH_INVERT_PROJ = False
     """
-    if method == Resampling.gauss:
-        pytest.skip()  # not supported
+    if method == Resampling.gauss or (is_gdal1 and method in gdal2plus_only):
+        pytest.skip()
 
     with rasterio.Env(CHECK_WITH_INVERT_PROJ=False):
         with rasterio.open('tests/data/world.rgb.tif') as src:


### PR DESCRIPTION
Resolves #613 

By making the default env `CHECK_WITH_INVERT_PROJ=True`, we more closely match the behavior of GDAL (which uses it as a de-facto default in gdalwarp) and we greatly reduce the chances of hitting #614 

This is our first case of explicitly defining a default env variable on behalf of the user. Is this the correct way to implement it @sgillies ? see changes in `rasterio/env.py`