### PR TITLE
Force file paths to be forward slashes even on Windows

### DIFF
--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -83,6 +83,9 @@ def _cb_key_val(ctx, param, value):
                 out[k] = v
         return out
 
+def abspath_forward_slashes(path):
+    """Return forward-slashed version of os.path.abspath"""
+    return '/'.join(os.path.abspath(path).split(os.path.sep))
 
 def file_in_handler(ctx, param, value):
     """Normalize ordinary filesystem and VFS paths"""
@@ -95,14 +98,14 @@ def file_in_handler(ctx, param, value):
         raise click.BadParameter(
             "Input file {0} does not exist".format(path_to_check))
     if archive and scheme:
-        archive = os.path.abspath(archive)
+        archive = abspath_forward_slashes(archive)
         path = "{0}://{1}!{2}".format(scheme, archive, path)
     elif scheme and scheme.startswith('http'):
         path = "{0}://{1}".format(scheme, path)
     elif scheme == 's3':
         path = "{0}://{1}".format(scheme, path)
     else:
-        path = os.path.abspath(path)
+        path = abspath_forward_slashes(path)
     return path
 
 

--- a/rasterio/vfs.py
+++ b/rasterio/vfs.py
@@ -59,8 +59,8 @@ def vsi_path(path, archive=None, scheme=None):
     elif scheme and scheme == 's3':
         result = "/vsis3/{0}".format(path)
     elif scheme and scheme != 'file':
-        path = path.strip(os.path.sep)
-        result = os.path.sep.join(
+        path = path.strip('/')
+        result = '/'.join(
             ['/vsi{0}'.format(scheme), archive, path])
     else:
         result = path

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -28,9 +28,10 @@ def test_file_in_handler_no_vfs_nonexistent():
 
 def test_file_in_handler_no_vfs():
     """file path is expanded to abspath"""
+    from rasterio.rio.options import abspath_forward_slashes
     ctx = MockContext()
     retval = file_in_handler(ctx, 'INPUT', 'tests/data/RGB.byte.tif')
-    assert retval == os.path.abspath('tests/data/RGB.byte.tif')
+    assert retval == abspath_forward_slashes('tests/data/RGB.byte.tif')
 
 
 def test_file_in_handler_bad_scheme():
@@ -52,7 +53,6 @@ def test_file_in_handler_with_vfs():
     """vfs file path path is expanded"""
     ctx = MockContext()
     retval = file_in_handler(ctx, 'INPUT', 'zip://tests/data/files.zip!/inputs/RGB.byte.tif')
-    assert retval.startswith('zip:///')
     assert retval.endswith('tests/data/files.zip!/inputs/RGB.byte.tif')
 
 


### PR DESCRIPTION
Fixes #754.  On Windows systems, VFS filepaths are still expecting forward slashes, rather than the currently implemented `os.path.sep`.  This PR does the following:

* adds utility function `abspath_forward_slashes` to forces forward slashes in absolute paths
* changes `file_in_handler` to return forward-slashed filepaths
* fixes tests and removes triple-slashed zip test in `test_rio_options.py`

There may be better ways to fix this, just wanted to get the ball rolling.