### PR TITLE
Unsupported write drivers

### DIFF
--- a/docs/writing.rst
+++ b/docs/writing.rst
@@ -3,7 +3,6 @@ Writing Datasets
 
 .. todo::
 
-    * supported drivers
     * appending to existing data
     * context manager
     * write 3d vs write 2d
@@ -45,3 +44,20 @@ An array is written to a new single band TIFF.
 
 Writing data mostly works as with a Python file. There are a few format-
 specific differences.
+
+Supported Drivers
+-----------------
+``GTiff`` is the only driver that supports writing directly to disk.
+GeoTiffs use the ``RasterUpdater`` and leverage the full capabilities 
+of the ``GDALCreate`` function. We highly recommend using GeoTiff 
+driver for writing as it is the best-tested and best-supported format.
+
+Some other formats that are writable by GDAL can also be written by
+Rasterio. These use an ``IndirectRasterUpdater`` which does not create
+directly but uses a temporary in-memory dataset and ``GDALCreateCopy``
+to produce the final output.
+
+Some formats are known to produce invalid results using the
+``IndirectRasterUpdater``. These formats will raise a ``RasterioIOError``
+if you attempt to write to the. Currently this applies to the ``netCDF``
+driver but please let us know if you experience problems writing other formats.

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -34,6 +34,11 @@ from rasterio.vfs import parse_path, vsi_path
 log = logging.getLogger(__name__)
 
 
+# These drivers are known to produce invalid results with
+# IndirectRasterUpdater. Save users the trouble and fail fast.
+BAD_WRITE_DRIVERS = ("netCDF", )
+
+
 cdef bint in_dtype_range(value, dtype):
     """Returns True if value is in the range of dtype, else False."""
     infos = {
@@ -2170,14 +2175,10 @@ def writer(path, mode, **kwargs):
             "VFS '{0}' datasets can not be created or updated.".format(
                 scheme))
 
-    # These drivers are known to produce invalid results with
-    # IndirectRasterUpdater. Save users the trouble and fail fast.
-    bad_write_drivers = ("netCDF", )
-
     if mode == 'w' and 'driver' in kwargs:
         if kwargs['driver'] == 'GTiff':
             return RasterUpdater(path, mode, **kwargs)
-        elif kwargs['driver'] in bad_write_drivers:
+        elif kwargs['driver'] in BAD_WRITE_DRIVERS:
             raise RasterioIOError(
                 "Rasterio does not support writing "
                 "with {} driver".format(kwargs['driver']))
@@ -2203,7 +2204,7 @@ def writer(path, mode, **kwargs):
 
         if driver == 'GTiff':
             return RasterUpdater(path, mode)
-        elif kwargs['driver'] in bad_write_drivers:
+        elif kwargs['driver'] in BAD_WRITE_DRIVERS:
             raise RasterioIOError(
                 "Rasterio does not support updating "
                 "with {} driver".format(kwargs['driver']))

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import rasterio
+from rasterio.errors import RasterioIOError
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -272,3 +273,12 @@ def test_write_noncontiguous(tmpdir):
     with rasterio.open(name, 'w', **kwargs) as dst:
         for i in range(BANDS):
             dst.write(arr[:, :, i], indexes=i + 1)
+
+
+def test_write_blacklist(tmpdir):
+    name = str(tmpdir.join("sst.nc"))
+    with pytest.raises(RasterioIOError) as exc_info:
+        rasterio.open(name, 'w', driver='netCDF', width=100, height=100,
+                      count=1, dtype='uint8')
+    exc = str(exc_info.value)
+    assert 'Rasterio does not support writing with netCDF driver' in exc

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -8,6 +8,7 @@ import pytest
 
 import rasterio
 from rasterio.errors import RasterioIOError
+from rasterio._io import BAD_WRITE_DRIVERS
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -275,10 +276,11 @@ def test_write_noncontiguous(tmpdir):
             dst.write(arr[:, :, i], indexes=i + 1)
 
 
-def test_write_blacklist(tmpdir):
-    name = str(tmpdir.join("sst.nc"))
+@pytest.mark.parametrize("driver", BAD_WRITE_DRIVERS)
+def test_write_blacklist(tmpdir, driver):
+    name = str(tmpdir.join("data.test"))
     with pytest.raises(RasterioIOError) as exc_info:
-        rasterio.open(name, 'w', driver='netCDF', width=100, height=100,
+        rasterio.open(name, 'w', driver=driver, width=100, height=100,
                       count=1, dtype='uint8')
     exc = str(exc_info.value)
-    assert 'Rasterio does not support writing with netCDF driver' in exc
+    assert "Rasterio does not support writing with {} driver".format(driver) in exc


### PR DESCRIPTION
This PR blacklists the netCDF driver which has [known problems](https://github.com/mapbox/rasterio/issues/638) with writing via the `IndirectRasterUpdater`.

Also documents the write driver situation.

Fixes #647, fixs #731