### PR TITLE
Drop mentions of old libgdal1h package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
 addons:
   apt:
     packages:
-    - libgdal1h
     - gdal-bin
     - libproj-dev
     - libhdf5-serial-dev

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -128,7 +128,7 @@ package manager. For Ubuntu the commands are:
 
     $ sudo add-apt-repository ppa:ubuntugis/ppa
     $ sudo apt-get update
-    $ sudo apt-get install libgdal1h gdal-bin libgdal-dev
+    $ sudo apt-get install gdal-bin libgdal-dev
 
 On OS X, Homebrew is a reliable way to get GDAL.
 

--- a/README.rst
+++ b/README.rst
@@ -235,7 +235,7 @@ The following commands are adapted from Rasterio's Travis-CI configuration.
 
     $ sudo add-apt-repository ppa:ubuntugis/ppa
     $ sudo apt-get update
-    $ sudo apt-get install libgdal1h gdal-bin libgdal-dev
+    $ sudo apt-get install gdal-bin libgdal-dev
     $ pip install -U pip
     $ pip install rasterio
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -76,7 +76,7 @@ The following commands are adapted from Rasterio's Travis-CI configuration.
 
     $ sudo add-apt-repository ppa:ubuntugis/ppa
     $ sudo apt-get update
-    $ sudo apt-get install python-numpy libgdal1h gdal-bin libgdal-dev
+    $ sudo apt-get install python-numpy gdal-bin libgdal-dev
     $ pip install rasterio
 
 Adapt them as necessary for your Linux system.
@@ -155,7 +155,7 @@ GitHub as done in `rio-plugin-example
     before_install:
       - sudo add-apt-repository -y ppa:ubuntugis/ppa
       - sudo apt-get update -qq
-      - sudo apt-get install -y libgdal1h gdal-bin
+      - sudo apt-get install -y libgdal-dev gdal-bin
       - curl -L https://github.com/mapbox/rasterio/releases/download/$RASTERIO_VERSION/rasterio-travis-wheels-$TRAVIS_PYTHON_VERSION.tar.gz > /tmp/wheelhouse.tar.gz
       - tar -xzvf /tmp/wheelhouse.tar.gz -C $HOME
     install:


### PR DESCRIPTION
The libgdal-dev package depends on its respective libgdal package,
there is no need to install the library package explicitly.

The library package name has changed to reflect changes in the libgdal C++ API,
libgdal1h is now only appropriate for older releases.

libgdal1h is used for GDAL >= 1.10.0, included in Debian jessie and Ubuntu trusty.

libgdal1i is used for GDAL >= 1.11.2, included in Ubuntu vivid, wily, and xenial.

libgdal20 is used for GDAL >= 2.0.0, included in Debian testing & unstable, and Ubuntu yakkety.