### PR TITLE
removing --x-dst-bounds

### DIFF
--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -40,11 +40,7 @@ MAX_OUTPUT_HEIGHT = 100000
     help="Determine output extent from source bounds: left bottom right top "
          ". Cannot be used with destination --bounds")
 @click.option(
-    '--dst-bounds', nargs=4, type=float, default=None,
-    help="alias for --bounds")
-@click.option(
-    '--bounds',
-    nargs=4, type=float, default=None,
+    '--bounds', '--dst-bounds', nargs=4, type=float, default=None,
     help="Determine output extent from destination bounds: left bottom right top")
 @options.resolution_opt
 @click.option('--resampling', type=click.Choice([r.name for r in Resampling]),
@@ -62,7 +58,7 @@ MAX_OUTPUT_HEIGHT = 100000
 @options.creation_options
 @click.pass_context
 def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
-         bounds, dst_bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
+         dst_bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
          force_overwrite, creation_options):
     """
     Warp a raster dataset.
@@ -126,7 +122,6 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
             out_kwargs['driver'] = driver
 
             # Sort out the bounds options.
-            dst_bounds = bounds or dst_bounds
             if src_bounds and dst_bounds:
                 raise click.BadParameter(
                     "--src-bounds and destination --bounds may not be specified "

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -33,16 +33,6 @@ def bounds_handler(ctx, param, value):
     return value
 
 
-def x_dst_bounds_handler(ctx, param, value):
-    """Warn about future usage changes."""
-    if value:
-        click.echo(
-            "Future Warning: "
-            "the `--x-dst-bounds` option will be removed in Rasterio version "
-            "1.0 in favor of `--bounds`.", err=True)
-    return value
-
-
 @click.command(short_help='Warp a raster dataset.')
 @files_inout_arg
 @options.output_opt
@@ -58,19 +48,11 @@ def x_dst_bounds_handler(ctx, param, value):
 @click.option(
     '--src-bounds',
     nargs=4, type=float, default=None,
-    help="Determine output extent from source bounds: left bottom right top "
-         "(note: for future backwards compatibility in 1.0).")
-@click.option(
-    '--x-dst-bounds',
-    nargs=4, type=float, default=None, callback=x_dst_bounds_handler,
-    help="Set output extent from bounding values: left bottom right top "
-         "(note: this option will be removed in 1.0).")
+    help="Determine output extent from source bounds: left bottom right top ")
 @click.option(
     '--bounds',
     nargs=4, type=float, default=None, callback=bounds_handler,
-    help="Determine output extent from source bounds: left bottom right top "
-         "(note: the semantics of this option will change to those of "
-         "`--x-dst-bounds` in version 1.0).")
+    help="Determine output extent from destination bounds: left bottom right top")
 @options.resolution_opt
 @click.option('--resampling', type=click.Choice([r.name for r in Resampling]),
               default='nearest', help="Resampling method.",
@@ -87,7 +69,7 @@ def x_dst_bounds_handler(ctx, param, value):
 @options.creation_options
 @click.pass_context
 def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
-         x_dst_bounds, bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
+         bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
          force_overwrite, creation_options):
     """
     Warp a raster dataset.
@@ -151,8 +133,7 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
             out_kwargs['driver'] = driver
 
             # Sort out the bounds options.
-            src_bounds = bounds or src_bounds
-            dst_bounds = x_dst_bounds
+            dst_bounds = bounds
             if src_bounds and dst_bounds:
                 raise click.BadParameter(
                     "Source and destination bounds may not be specified "

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -22,17 +22,6 @@ MAX_OUTPUT_WIDTH = 100000
 MAX_OUTPUT_HEIGHT = 100000
 
 
-def bounds_handler(ctx, param, value):
-    """Warn about future usage changes."""
-    if value:
-        click.echo(
-            "Future Warning: "
-            "the semantics of the `--bounds` option will change in Rasterio "
-            "version 1.0 from bounds of the source dataset to bounds of the "
-            "destination dataset.", err=True)
-    return value
-
-
 @click.command(short_help='Warp a raster dataset.')
 @files_inout_arg
 @options.output_opt
@@ -48,10 +37,14 @@ def bounds_handler(ctx, param, value):
 @click.option(
     '--src-bounds',
     nargs=4, type=float, default=None,
-    help="Determine output extent from source bounds: left bottom right top ")
+    help="Determine output extent from source bounds: left bottom right top "
+         ". Cannot be used with destination --bounds")
+@click.option(
+    '--dst-bounds', nargs=4, type=float, default=None,
+    help="alias for --bounds")
 @click.option(
     '--bounds',
-    nargs=4, type=float, default=None, callback=bounds_handler,
+    nargs=4, type=float, default=None,
     help="Determine output extent from destination bounds: left bottom right top")
 @options.resolution_opt
 @click.option('--resampling', type=click.Choice([r.name for r in Resampling]),
@@ -69,7 +62,7 @@ def bounds_handler(ctx, param, value):
 @options.creation_options
 @click.pass_context
 def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
-         bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
+         bounds, dst_bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
          force_overwrite, creation_options):
     """
     Warp a raster dataset.
@@ -133,10 +126,10 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
             out_kwargs['driver'] = driver
 
             # Sort out the bounds options.
-            dst_bounds = bounds
+            dst_bounds = bounds or dst_bounds
             if src_bounds and dst_bounds:
                 raise click.BadParameter(
-                    "Source and destination bounds may not be specified "
+                    "--src-bounds and destination --bounds may not be specified "
                     "simultaneously.")
 
             if like:

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -199,6 +199,19 @@ def test_warp_no_reproject_bounds_res(runner, tmpdir):
             assert output.height == 67
 
 
+    # dst-bounds should be an alias to bounds
+    outputname = str(tmpdir.join('test2.tif'))
+    out_bounds = [-11850000, 4810000, -11849000, 4812000]
+    result = runner.invoke(warp.warp,[srcname, outputname,
+                                      '--res', 30,
+                                      '--dst-bounds', ] + out_bounds)
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert np.allclose(output.bounds, out_bounds)
+
+
 def test_warp_reproject_dst_crs(runner, tmpdir):
     srcname = 'tests/data/RGB.byte.tif'
     outputname = str(tmpdir.join('test.tif'))

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -276,13 +276,13 @@ def test_warp_reproject_bounds_no_res(runner, tmpdir):
 
 
 def test_warp_reproject_multi_bounds_fail(runner, tmpdir):
-    """Mixing --bounds and --x-dst-bounds fails."""
+    """Mixing --bounds and --src-bounds fails."""
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
     result = runner.invoke(warp.warp, [srcname, outputname,
                                        '--dst-crs', 'EPSG:4326',
-                                       '--x-dst-bounds'] + out_bounds +
+                                       '--src-bounds'] + out_bounds +
                                        ['--bounds'] + out_bounds)
     assert result.exit_code == 2
 
@@ -294,20 +294,9 @@ def test_warp_reproject_bounds_crossup_fail(runner, tmpdir):
     out_bounds = [-11850000, 4810000, -11849000, 4812000]
     result = runner.invoke(warp.warp, [srcname, outputname,
                                        '--dst-crs', 'EPSG:4326',
-                                       '--res', 0.001, '--x-dst-bounds', ]
+                                       '--res', 0.001, '--bounds', ]
                                        + out_bounds)
     assert result.exit_code == 2
-
-
-def test_warp_reproject_bounds_res_future_warning(runner, tmpdir):
-    """Use of --bounds results in a warning from the 1.0 future."""
-    srcname = 'tests/data/shade.tif'
-    outputname = str(tmpdir.join('test.tif'))
-    out_bounds = [-11850000, 4810000, -11849000, 4812000]
-    result = runner.invoke(
-                warp.warp, [srcname, outputname, '--dst-crs', 'EPSG:4326',
-                            '--res', 0.001, '--bounds'] + out_bounds)
-    assert "Future Warning" in result.output
 
 
 def test_warp_reproject_src_bounds_res(runner, tmpdir):
@@ -333,13 +322,13 @@ def test_warp_reproject_src_bounds_res(runner, tmpdir):
 
 
 def test_warp_reproject_dst_bounds(runner, tmpdir):
-    """--x-dst-bounds option works."""
+    """--bounds option works."""
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))
     out_bounds = [-106.45036, 39.6138, -106.44136, 39.6278]
     result = runner.invoke(
         warp.warp, [srcname, outputname, '--dst-crs', 'EPSG:4326',
-                    '--res', 0.001, '--x-dst-bounds'] + out_bounds)
+                    '--res', 0.001, '--bounds'] + out_bounds)
     assert result.exit_code == 0
     assert os.path.exists(outputname)
 


### PR DESCRIPTION
This PR resolves #549 with backwards-incompatible changes to rio warp

* removes `--x-dst-bounds` entirely
* new `--bounds` will behave like the old `x-dst-bounds`
* new `--src-bounds` stays the same

Open question: do we want to include a `--dst-bounds` alias to `--bounds`? I know that wasn't part of the original plan but every other option seems to specify `src-` or `dst-` when there could be ambiguity.