### PR TITLE
WIP: Wrap ndarray, transform, and crs into a class

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -10,6 +10,7 @@ except ImportError:
     plt = None
 
 import rasterio
+from rasterio import GeoArray
 from rasterio.plot import show, show_hist, get_plt, plotting_extent
 from rasterio.enums import ColorInterp
 
@@ -145,7 +146,7 @@ def test_show_array():
     """
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
-            show(src.read(1))
+            show(GeoArray(src.read(1), src.transform))
             fig = plt.gcf()
             plt.close(fig)
         except ImportError:
@@ -159,7 +160,7 @@ def test_show_array3D():
     """
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
-            show(src.read((1, 2, 3)))
+            show(GeoArray(src.read((1, 2, 3)), src.transform))
             fig = plt.gcf()
             plt.close(fig)
         except ImportError:
@@ -254,18 +255,5 @@ def test_get_plt():
 @pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_plt_transform():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        show(src.read(), transform=src.transform)
-        show(src.read(1), transform=src.transform)
-
-def test_plotting_extent():
-    from rasterio.plot import reshape_as_image
-    expected = (101985.0, 339315.0, 2611485.0, 2826915.0)
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        assert plotting_extent(src) == expected
-        assert plotting_extent(
-            reshape_as_image(src.read()), transform=src.affine) == expected
-        assert plotting_extent(
-            src.read(1), transform=src.transform) == expected
-        # array requires a transform
-        with pytest.raises(ValueError):
-            plotting_extent(src.read(1))
+        show(GeoArray(src.read(), src.transform))
+        show(GeoArray(src.read(1), src.transform))

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -10,6 +10,7 @@ except ImportError:
     plt = None
 
 import rasterio
+from rasterio import GeoArray
 from rasterio.plot import show, show_hist
 from rasterio.rio.insp import stats
 
@@ -62,7 +63,7 @@ def test_show_array():
     """
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
-            show(src.read(1))
+            show(GeoArray(src.read(1), src.transform))
             fig = plt.gcf()
             plt.close(fig)
         except ImportError:


### PR DESCRIPTION
As described in #798 

This is a very early step toward roughing out a class that encapsulates a numpy array, transform, and optional crs.  Most methods and properties copied from `DatasetReader` (copy is temporary, due to changes coming in #793).  At this point, we should probably consider this proof of concept, throw-away code.

It includes a trivial demonstration of its application by undoing some of the good work by @perrygeo in #795.  (and most other places I thought of demoing this are wrapped up in #763).

No substantive tests yet, because I think we need to wrangle the API where we want it first.

I think we could possibly do this better by defining a base class shared by `DatasetReader` and `GeoArray` that provides some of these things; they rely on the same constructs. 

We could also provide a convenience method to make it easier to import from a raster dataset, except for the array.

This feels like it holds the promise of cleaning up many of our function calls; now we just need to pass around objects that provide the right interface.