### PR TITLE
Faster warp

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -268,7 +268,7 @@ def band(ds, bidx):
     ----------
     ds: rasterio.RasterReader
         Open rasterio dataset
-    bidx: int
+    bidx: int or sequence of ints
         Band number, index starting at 1
 
     Returns

--- a/rasterio/_gdal.pxd
+++ b/rasterio/_gdal.pxd
@@ -237,6 +237,7 @@ cdef extern from "gdal_alg.h":
     void *GDALCreateApproxTransformer( GDALTransformerFunc pfnRawTransformer, void *pRawTransformerArg, double dfMaxError )
     int  GDALApproxTransform(void *pTransformArg, int bDstToSrc, int nPointCount, double *x, double *y, double *z, int *panSuccess )
     void GDALDestroyApproxTransformer( void * )
+    void GDALApproxTransformerOwnsSubtransformer(void *, int)
 
     int GDALFillNodata(void *dst_band, void *mask_band, double max_search_distance, int deprecated, int smoothing_iterations, char **options, void *progress_func, void *progress_data)
     int GDALChecksumImage(void *band, int xoff, int yoff, int width, int height)

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -22,42 +22,7 @@ MAX_OUTPUT_WIDTH = 100000
 MAX_OUTPUT_HEIGHT = 100000
 
 
-@click.command(short_help='Warp a raster dataset.')
-@files_inout_arg
-@options.output_opt
-@format_opt
-@click.option(
-    '--like',
-    type=click.Path(exists=True),
-    help='Raster dataset to use as a template for obtaining affine '
-         'transform (bounds and resolution), and crs.')
-@click.option('--dst-crs', default=None,
-              help='Target coordinate reference system.')
-@options.dimensions_opt
-@click.option(
-    '--src-bounds',
-    nargs=4, type=float, default=None,
-    help="Determine output extent from source bounds: left bottom right top "
-         ". Cannot be used with destination --bounds")
-@click.option(
-    '--bounds', '--dst-bounds', nargs=4, type=float, default=None,
-    help="Determine output extent from destination bounds: left bottom right top")
-@options.resolution_opt
-@click.option('--resampling', type=click.Choice([r.name for r in Resampling]),
-              default='nearest', help="Resampling method.",
-              show_default=True)
-@click.option('--src-nodata', default=None, show_default=True,
-              type=float, help="Manually override source nodata")
-@click.option('--dst-nodata', default=None, show_default=True,
-              type=float, help="Manually override destination nodata")
-@click.option('--threads', type=int, default=1,
-              help='Number of processing threads.')
-@click.option('--check-invert-proj', type=bool, default=True,
-              help='Constrain output to valid coordinate region in dst-crs')
-@options.force_overwrite_opt
-@options.creation_options
-@click.pass_context
-def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
+def warp_main(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
          dst_bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
          force_overwrite, creation_options):
     """
@@ -276,3 +241,49 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
                         dst_nodata=dst_nodata,
                         resampling=resampling,
                         num_threads=threads)
+
+
+@click.command(short_help='Warp a raster dataset.')
+@files_inout_arg
+@options.output_opt
+@format_opt
+@click.option(
+    '--like',
+    type=click.Path(exists=True),
+    help='Raster dataset to use as a template for obtaining affine '
+         'transform (bounds and resolution), and crs.')
+@click.option('--dst-crs', default=None,
+              help='Target coordinate reference system.')
+@options.dimensions_opt
+@click.option(
+    '--src-bounds',
+    nargs=4, type=float, default=None,
+    help="Determine output extent from source bounds: left bottom right top "
+         ". Cannot be used with destination --bounds")
+@click.option(
+    '--bounds', '--dst-bounds', nargs=4, type=float, default=None,
+    help="Determine output extent from destination bounds: left bottom right top")
+@options.resolution_opt
+@click.option('--resampling', type=click.Choice([r.name for r in Resampling]),
+              default='nearest', help="Resampling method.",
+              show_default=True)
+@click.option('--src-nodata', default=None, show_default=True,
+              type=float, help="Manually override source nodata")
+@click.option('--dst-nodata', default=None, show_default=True,
+              type=float, help="Manually override destination nodata")
+@click.option('--threads', type=int, default=1,
+              help='Number of processing threads.')
+@click.option('--check-invert-proj', is_flag=True, default=True,
+              help='Constrain output to valid coordinate region in dst-crs')
+@options.force_overwrite_opt
+@options.creation_options
+@click.option('--profile', is_flag=True, default=False)
+@click.pass_context
+def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
+         dst_bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj,
+         force_overwrite, creation_options, profile):
+    if profile:
+        from cProfile import runctx
+        runctx('warp_main(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds, dst_bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj, force_overwrite, creation_options)', globals(), locals(), sort='time')
+    else:
+        warp_main(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds, dst_bounds, res, resampling, src_nodata, dst_nodata, threads, check_invert_proj, force_overwrite, creation_options)

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -454,7 +454,7 @@ def test_warp_reproject_check_invert(runner, tmpdir):
     srcname = 'tests/data/world.rgb.tif'
     outputname = str(tmpdir.join('test.tif'))
     result = runner.invoke(warp.warp, [srcname, outputname,
-                                       '--check-invert-proj', 'yes',
+                                       '--check-invert-proj',
                                        '--dst-crs', 'EPSG:3759'])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
@@ -465,7 +465,6 @@ def test_warp_reproject_check_invert(runner, tmpdir):
 
     output2name = str(tmpdir.join('test2.tif'))
     result = runner.invoke(warp.warp, [srcname, output2name,
-                                       '--check-invert-proj', 'no',
                                        '--dst-crs', 'EPSG:3759'])
     assert result.exit_code == 0
     assert os.path.exists(output2name)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -36,7 +36,7 @@ def supported_resampling(method):
 
 
 reproj_expected = (
-    ({'CHECK_WITH_INVERT_PROJ': False}, 6215),
+    ({'CHECK_WITH_INVERT_PROJ': False}, 6217),
     ({'CHECK_WITH_INVERT_PROJ': True}, 4005))
 
 
@@ -233,7 +233,7 @@ def test_reproject_ndarray():
             dst_transform=DST_TRANSFORM,
             dst_crs=dst_crs,
             resampling=Resampling.nearest)
-        assert (out > 0).sum() == 438146
+        assert (out > 0).sum() == 438113
 
 
 def test_reproject_epsg():
@@ -251,7 +251,7 @@ def test_reproject_epsg():
             dst_transform=DST_TRANSFORM,
             dst_crs=dst_crs,
             resampling=Resampling.nearest)
-        assert (out > 0).sum() == 438146
+        assert (out > 0).sum() == 438113
 
 
 def test_reproject_out_of_bounds():


### PR DESCRIPTION
Significant speedups by 1) warping multiple bands in one pass, 2) using the approximate transformer as suggested in #569.

#### rio-warp

```
(pydotorg35)MapBox-FC:rasterio sean$ time rio warp --threads 4 --dst-crs epsg:3857 ~/work/data/NE2_50M_SR_W/NE2_50M_SR_W.tif -o /tmp/warped.tif

real	0m4.148s
user	0m4.473s
sys	0m1.521s
```

#### gdalwarp

```
(pydotorg35)MapBox-FC:rasterio sean$ time gdalwarp -t_srs epsg:3857 ~/work/data/NE2_50M_SR_W/NE2_50M_SR_W.tif /tmp/gdalwarped.tif -overwrite
Creating output file that is 7284P x 9630L.
Processing input file /Users/sean/work/data/NE2_50M_SR_W/NE2_50M_SR_W.tif.
0...10...20...30...40...50...60...70...80...90...100 - done.

real	0m2.540s
user	0m1.569s
sys	0m0.692s
```