### PR TITLE
Fix 'tranform' typo in doc & method

### DIFF
--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -16,7 +16,7 @@ from rasterio.transform import guard_transform, xy, rowcol
 
 class TransformMethodsMixin(object):
     """Mixin providing methods for calculations related
-    to tranforming between rows and columns of the raster
+    to transforming between rows and columns of the raster
     array and the coordinates.
 
     These methods are wrappers for the functionality in
@@ -46,7 +46,7 @@ class TransformMethodsMixin(object):
         tuple
             ``(x, y)``
         """
-        return xy(self.tranform, row, col, offset=offset)
+        return xy(self.transform, row, col, offset=offset)
 
     def ul(self, row, col):
         """Returns the coordinates (x, y) of the upper left corner of a


### PR DESCRIPTION
Caught a typo in `src.xy` method and in the corresponding docstring:

``` python
AttributeError                            Traceback (most recent call last)
<ipython-input-48-170b33479138> in <module>()
----> 1 src.xy(ys, xs, 'ul')

/home/ceholden/conda/envs/yatsm/lib/python2.7/site-packages/rasterio/io.pyc in xy(self, row, col, offset)
     47             ``(x, y)``
     48         """
---> 49         return xy(self.tranform, row, col, offset=offset)
     50 
     51     def ul(self, row, col):

AttributeError: 'DatasetReader' object has no attribute 'tranform'
```

Thanks for developing Rasterio -- it's been a joy to use in my work.