### PR TITLE
cast to avoid cython warnings re: discarding qualifiers

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -699,7 +699,7 @@ cdef class DatasetBase(object):
         retval = {}
 
         for i in range(GDALGetColorEntryCount(colortable)):
-            color = GDALGetColorEntry(colortable, i)
+            color = <GDALColorEntry*>GDALGetColorEntry(colortable, i)
             if color == NULL:
                 log.warn("NULL color at %d, skipping", i)
                 continue

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1484,7 +1484,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
 
         # Fixup, export to WKT, and set the GDAL dataset's projection.
         OSRFixup(osr)
-        OSRExportToWkt(osr, &wkt)
+        OSRExportToWkt(osr, <char**>&wkt)
         wkt_b = wkt
         log.debug("Exported WKT: %s", wkt_b.decode('utf-8'))
         GDALSetProjection(self._hds, wkt)
@@ -1934,10 +1934,10 @@ cdef class InMemoryRaster:
         # GDALSuggestedWarpOutput2()).
         if crs:
             osr = _osr_from_crs(crs)
-            OSRExportToWkt(osr, &srcwkt)
+            OSRExportToWkt(osr, <char**>&srcwkt)
             GDALSetProjection(self._hds, srcwkt)
             log.debug("Set CRS on temp source dataset: %s", srcwkt)
-            CPLFree(srcwkt)
+            CPLFree(<void *>srcwkt)
             OSRDestroySpatialReference(osr)
 
         self.write(image)


### PR DESCRIPTION
Resolves #514 . There are still several warnings but as noted https://github.com/mapbox/rasterio/issues/514#issuecomment-240137280, those are known issues related to the C code generated by Cython, not related to our pyx code.