### PR TITLE
rio warp: fix check-invert-proj option

### DIFF
--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -132,6 +132,8 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
                 "--dimensions cannot be used with --bounds or --res")
 
     with ctx.obj['env']:
+        print(check_invert_proj)
+        quit()
         setenv(CHECK_WITH_INVERT_PROJ=check_invert_proj)
 
         with rasterio.open(files[0]) as src:

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -55,7 +55,7 @@ MAX_OUTPUT_HEIGHT = 100000
               type=float, help="Manually override destination nodata")
 @click.option('--threads', type=int, default=1,
               help='Number of processing threads.')
-@click.option('--check-invert-proj', is_flag=True, default=True,
+@click.option('--check-invert-proj/--no-check-invert-proj', default=True,
               help='Constrain output to valid coordinate region in dst-crs')
 @options.force_overwrite_opt
 @options.creation_options

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -132,8 +132,6 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
                 "--dimensions cannot be used with --bounds or --res")
 
     with ctx.obj['env']:
-        print(check_invert_proj)
-        quit()
         setenv(CHECK_WITH_INVERT_PROJ=check_invert_proj)
 
         with rasterio.open(files[0]) as src:

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -484,31 +484,43 @@ def test_warp_badcrs_src_bounds(runner, tmpdir):
     assert "Invalid value for dst_crs" in result.output
 
 
-def test_warp_reproject_check_invert(runner, tmpdir):
+shape_check = (412, 397)
+shape_no_check = (291, 493)
+
+def test_warp_reproject_check_invert_default(runner, tmpdir):
+    outputname = str(tmpdir.join('test.tif'))
     srcname = 'tests/data/world.rgb.tif'
 
     # default True
-    outputname = str(tmpdir.join('test.tif'))
     runner.invoke(main_group, [
         'warp', srcname, outputname, '--dst-crs', 'EPSG:3759'])
 
-    # explicit True
-    output2name = str(tmpdir.join('test2.tif'))
-    runner.invoke(main_group, [
-        'warp', srcname, output2name, '--check-invert-proj',
-        '--dst-crs', 'EPSG:3759'])
+    with rasterio.open(outputname) as output:
+        assert output.shape == shape_check
 
-    # explicit False
-    output3name = str(tmpdir.join('test3.tif'))
+
+def test_warp_reproject_check_invert_true(runner, tmpdir):
+    outputname = str(tmpdir.join('test2.tif'))
+    srcname = 'tests/data/world.rgb.tif'
+
+    # explicit True
     runner.invoke(main_group, [
-        'warp', srcname, output3name, '--no-check-invert-proj',
+        'warp', srcname, outputname, '--check-invert-proj',
         '--dst-crs', 'EPSG:3759'])
 
     with rasterio.open(outputname) as output:
-        shape1 = output.shape
+        assert output.shape == shape_check
 
-    with rasterio.open(output2name) as output:
-        assert output.shape == shape1
 
-    with rasterio.open(output3name) as output:
-        assert output.shape != shape1
+def test_warp_reproject_check_invert_false(runner, tmpdir):
+    outputname = str(tmpdir.join('test2.tif'))
+    srcname = 'tests/data/world.rgb.tif'
+
+    # explicit False
+    runner.invoke(main_group, [
+        'warp', srcname, outputname, '--no-check-invert-proj',
+        '--dst-crs', 'EPSG:3759'])
+
+    with rasterio.open(outputname) as output:
+        assert output.shape != shape_check
+        assert output.shape == shape_no_check

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -484,43 +484,39 @@ def test_warp_badcrs_src_bounds(runner, tmpdir):
     assert "Invalid value for dst_crs" in result.output
 
 
-shape_check = (412, 397)
-shape_no_check = (291, 493)
-
-def test_warp_reproject_check_invert_default(runner, tmpdir):
+def test_warp_reproject_check_invert_true(runner, tmpdir):
     outputname = str(tmpdir.join('test.tif'))
+    output2name = str(tmpdir.join('test2.tif'))
     srcname = 'tests/data/world.rgb.tif'
 
     # default True
     runner.invoke(main_group, [
         'warp', srcname, outputname, '--dst-crs', 'EPSG:3759'])
 
-    with rasterio.open(outputname) as output:
-        assert output.shape == shape_check
-
-
-def test_warp_reproject_check_invert_true(runner, tmpdir):
-    outputname = str(tmpdir.join('test2.tif'))
-    srcname = 'tests/data/world.rgb.tif'
-
     # explicit True
     runner.invoke(main_group, [
-        'warp', srcname, outputname, '--check-invert-proj',
+        'warp', srcname, output2name, '--check-invert-proj',
         '--dst-crs', 'EPSG:3759'])
 
-    with rasterio.open(outputname) as output:
-        assert output.shape == shape_check
+    with rasterio.open(outputname) as output, \
+         rasterio.open(output2name) as output2:
+        assert output.shape == output2.shape
 
 
 def test_warp_reproject_check_invert_false(runner, tmpdir):
-    outputname = str(tmpdir.join('test2.tif'))
+    outputname = str(tmpdir.join('test.tif'))
+    output2name = str(tmpdir.join('test2.tif'))
     srcname = 'tests/data/world.rgb.tif'
+
+    # default True
+    runner.invoke(main_group, [
+        'warp', srcname, outputname, '--dst-crs', 'EPSG:3759'])
 
     # explicit False
     runner.invoke(main_group, [
-        'warp', srcname, outputname, '--no-check-invert-proj',
+        'warp', srcname, output2name, '--no-check-invert-proj',
         '--dst-crs', 'EPSG:3759'])
 
-    with rasterio.open(outputname) as output:
-        assert output.shape != shape_check
-        assert output.shape == shape_no_check
+    with rasterio.open(outputname) as output, \
+         rasterio.open(output2name) as output2:
+        assert output.shape != output2.shape

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -486,23 +486,29 @@ def test_warp_badcrs_src_bounds(runner, tmpdir):
 
 def test_warp_reproject_check_invert(runner, tmpdir):
     srcname = 'tests/data/world.rgb.tif'
+
+    # default True
     outputname = str(tmpdir.join('test.tif'))
-    result = runner.invoke(main_group, [
-        'warp', srcname, outputname, '--check-invert-proj',
+    runner.invoke(main_group, [
+        'warp', srcname, outputname, '--dst-crs', 'EPSG:3759'])
+
+    # explicit True
+    output2name = str(tmpdir.join('test2.tif'))
+    runner.invoke(main_group, [
+        'warp', srcname, output2name, '--check-invert-proj',
         '--dst-crs', 'EPSG:3759'])
-    assert result.exit_code == 0
-    assert os.path.exists(outputname)
+
+    # explicit False
+    output3name = str(tmpdir.join('test3.tif'))
+    runner.invoke(main_group, [
+        'warp', srcname, output3name, '--no-check-invert-proj',
+        '--dst-crs', 'EPSG:3759'])
 
     with rasterio.open(outputname) as output:
-        assert output.crs == {'init': 'epsg:3759'}
         shape1 = output.shape
 
-    output2name = str(tmpdir.join('test2.tif'))
-    result = runner.invoke(main_group, [
-        'warp', srcname, output2name, '--dst-crs', 'EPSG:3759'])
-    assert result.exit_code == 0
-    assert os.path.exists(output2name)
-
     with rasterio.open(output2name) as output:
-        assert output.crs == {'init': 'epsg:3759'}
+        assert output.shape == shape1
+
+    with rasterio.open(output3name) as output:
         assert output.shape != shape1


### PR DESCRIPTION
The previous version had the `--check-invert-proj` option set with `is_flag=True, default=True` which effectively means there's no way to supply a `False`. This PR switches to the `--opt/--no-opt` syntax to make it more explicit