### PR TITLE
Test for single int indexes

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -19,6 +19,11 @@ def test_sampling_indexes():
         assert list(data) == [25]
 
 
+def test_sampling_single_index():
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        data = next(src.sample([(220650.0, 2719200.0)], indexes=2))
+        assert list(data) == [25]
+
 def test_sampling_type():
     """See https://github.com/mapbox/rasterio/issues/378."""
     with rasterio.open('tests/data/RGB.byte.tif') as src:


### PR DESCRIPTION
Test for single int indexes argument to `sample` method.

Test currently fails as noted in #862 