### PR TITLE
Documentation of the changes to Band

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,8 @@ New features:
   tuples (#759).
 - Performance of `reproject()` has been increased by using an approximate
   transformer as with gdal_translate (#569).
+- `Band` objects may now represent one or more dataset bands and multiband 
+  reprojection of imagery kept in a GDAL dataset is now possible (#569).
 
 Bug fixes:
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -53,7 +53,7 @@ def window_index(*args, **kwargs):
 
 __all__ = [
     'band', 'open', 'copy', 'pad']
-__version__ = "1.0a1"
+__version__ = "1.0a2"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its
@@ -270,24 +270,20 @@ Band = namedtuple('Band', ['ds', 'bidx', 'dtype', 'shape'])
 
 
 def band(ds, bidx):
-    """Wraps a dataset and a band index up as a 'Band'
+    """A dataset and one or more of its bands
 
     Parameters
     ----------
-    ds: rasterio.RasterReader
-        Open rasterio dataset
+    ds: dataset object
+        An opened rasterio dataset object.
     bidx: int or sequence of ints
-        Band number, index starting at 1
+        Band number(s), index starting at 1.
 
     Returns
     -------
-    a rasterio.Band
+    rasterio.Band
     """
-    return Band(
-        ds,
-        bidx,
-        set(ds.dtypes).pop(),
-        ds.shape)
+    return Band(ds, bidx, set(ds.dtypes).pop(), ds.shape)
 
 
 def pad(array, transform, pad_width, mode=None, **kwargs):

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -184,10 +184,12 @@ def reproject(
 
     Parameters
     ------------
-    source: ndarray or rasterio Band
-        Source raster.
-    destination: ndarray or rasterio Band
-        Target raster.
+    source, destination: ndarray or Band
+        The source and destination are 2 or 3-D ndarrays, or a single
+        or multiple Rasterio Band object. The dimensionality of source
+        and destination must match, i.e., for multiband reprojection 
+        the lengths of the first axes of the source and destination 
+        must be the same.
     src_transform: affine.Affine(), optional
         Source affine transformation.  Required if source and destination
         are ndarrays.  Will be derived from source if it is a rasterio Band.


### PR DESCRIPTION
Made to support multiband warping to or from a GDAL dataset (rather than a ndarray).

The 1.0a2 version bump is tagging along for the ride.