### PR TITLE
Raster data IO correctness

### DIFF
--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -49,7 +49,7 @@ cdef int io_band(
         int yoff,
         int width,
         int height,
-        object buffer)
+        object data)
 
 
 cdef int io_multi_band(
@@ -59,7 +59,7 @@ cdef int io_multi_band(
         int yoff,
         int width,
         int height,
-        object image,
+        object data,
         long[:] indexes)
 
 
@@ -70,7 +70,7 @@ cdef int io_multi_mask(
         int yoff,
         int width,
         int height,
-        object image,
+        object data,
         long[:] indexes)
 
 

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -42,206 +42,36 @@ ctypedef np.float64_t DTYPE_FLOAT64_t
 cdef bint in_dtype_range(value, dtype)
 
 
-cdef int io_ubyte(
+cdef int io_any(
         GDALRasterBandH band,
         int mode,
         int xoff,
         int yoff,
         int width,
         int height,
-        np.uint8_t[:, :] buffer)
+        object buffer)
 
 
-cdef int io_uint16(
-        GDALRasterBandH band,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.uint16_t[:, :] buffer)
-
-
-cdef int io_int16(
-        GDALRasterBandH band,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.int16_t[:, :] buffer)
-
-
-cdef int io_uint32(
-        GDALRasterBandH band,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.uint32_t[:, :] buffer)
-
-
-cdef int io_int32(
-        GDALRasterBandH band,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.int32_t[:, :] buffer)
-
-
-cdef int io_float32(
-        GDALRasterBandH band,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.float32_t[:, :] buffer)
-
-
-cdef int io_float64(
-        GDALRasterBandH band,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.float64_t[:, :] buffer)
-
-
-cdef int io_multi_ubyte(
+cdef int io_multi_any(
         GDALDatasetH hds,
         int mode,
         int xoff,
         int yoff,
         int width,
         int height,
-        np.uint8_t[:, :, :] buffer,
-        long[:] indexes,
-        int count)
+        object image,
+        long[:] indexes)
 
 
-cdef int io_multi_uint16(
+cdef int io_multi_mask(
         GDALDatasetH hds,
         int mode,
         int xoff,
         int yoff,
         int width,
         int height,
-        np.uint16_t[:, :, :] buffer,
-        long[:] indexes,
-        int count) nogil
-
-
-cdef int io_multi_int16(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.int16_t[:, :, :] buffer,
-        long[:] indexes,
-        int count) nogil
-
-
-cdef int io_multi_uint32(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.uint32_t[:, :, :] buffer,
-        long[:] indexes,
-        int count) nogil
-
-
-cdef int io_multi_int32(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.int32_t[:, :, :] buffer,
-        long[:] indexes,
-        int count) nogil
-
-
-cdef int io_multi_float32(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.float32_t[:, :, :] buffer,
-        long[:] indexes,
-        int count) nogil
-
-
-cdef int io_multi_float64(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.float64_t[:, :, :] buffer,
-        long[:] indexes,
-        int count) nogil
-
-
-cdef int io_multi_cint16(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.complex_t[:, :, :] out,
-        long[:] indexes,
-        int count)
-
-
-cdef int io_multi_cint32(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.complex_t[:, :, :] out,
-        long[:] indexes,
-        int count)
-
-
-cdef int io_multi_cfloat32(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.complex64_t[:, :, :] out,
-        long[:] indexes,
-        int count)
-
-
-cdef int io_multi_cfloat64(
-        GDALDatasetH hds,
-        int mode,
-        int xoff,
-        int yoff,
-        int width,
-        int height,
-        np.complex128_t[:, :, :] out,
-        long[:] indexes,
-        int count)
+        object image,
+        long[:] indexes)
 
 
 cdef int io_auto(image, GDALRasterBandH band, bint write)

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -42,7 +42,7 @@ ctypedef np.float64_t DTYPE_FLOAT64_t
 cdef bint in_dtype_range(value, dtype)
 
 
-cdef int io_any(
+cdef int io_band(
         GDALRasterBandH band,
         int mode,
         int xoff,
@@ -52,7 +52,7 @@ cdef int io_any(
         object buffer)
 
 
-cdef int io_multi_any(
+cdef int io_multi_band(
         GDALDatasetH hds,
         int mode,
         int xoff,

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -121,7 +121,7 @@ cdef int io_multi_ubyte(
         int height,
         np.uint8_t[:, :, :] buffer,
         long[:] indexes,
-        int count) nogil
+        int count)
 
 
 cdef int io_multi_uint16(

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -54,7 +54,7 @@ def get_data_window(arr, nodata=None):
 
     if nodata is None:
         if not hasattr(arr, 'mask'):
-            return ((0, arr.shape[-2]), (0, arr.shape[-1]))
+            return Window.from_ranges((0, arr.shape[-2]), (0, arr.shape[-1]))
     else:
         arr = np.ma.masked_array(arr, arr == nodata)
 

--- a/tests/test_complex_dtypes.py
+++ b/tests/test_complex_dtypes.py
@@ -1,0 +1,38 @@
+import logging
+import sys
+import uuid
+
+import numpy as np
+import pytest
+
+import rasterio
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+@pytest.fixture(scope='function')
+def tempfile():
+    """A temporary filename in the GDAL '/vsimem' filesystem"""
+    return '/vsimem/{}'.format(uuid.uuid4())
+
+
+def complex_image(height, width, dtype):
+    """An array with sequential elements"""
+    return np.array(
+        [complex(x, x) for x in range(height * width)],
+        dtype=dtype).reshape(height, width)
+
+dtypes = ['complex', 'complex64', 'complex128']
+
+
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("height,width", [(20, 20)])
+def test_read_array(tempfile, dtype, height, width):
+    """_io functions read and write arrays correctly"""
+    in_img = complex_image(height, width, dtype)
+    with rasterio.open(tempfile, 'w', driver='GTiff', dtype=dtype,
+                       height=height, width=width, count=1) as dataset:
+        dataset.write(in_img, 1)
+        out_img = dataset.read(1)
+    assert (in_img == out_img).all()

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -60,9 +60,6 @@ def test_validate_dtype():
     assert validate_dtype(np.array([1.4, 2.1, 3.65]), ('uint8',)) == False
 
 
-# Roundtrip to complex type failing for unknown reasons
-# see https://github.com/mapbox/rasterio/issues/714
-@pytest.mark.xfail
 def test_complex(tmpdir):
     name = str(tmpdir.join("complex.tif"))
     arr1 = np.ones((2, 2), dtype=complex_)

--- a/tests/test_gdal_raster_io.py
+++ b/tests/test_gdal_raster_io.py
@@ -1,0 +1,76 @@
+import logging
+import sys
+import uuid
+
+import numpy as np
+import pytest
+
+import rasterio
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+@pytest.fixture(scope='function')
+def tempfile():
+    """A temporary filename in the GDAL '/vsimem' filesystem"""
+    return '/vsimem/{}'.format(uuid.uuid4())
+
+
+def image(height, width, dtype):
+    """An array with sequential elements"""
+    return np.array(range(height * width), dtype=dtype).reshape(height, width)
+
+
+dtypes = ['uint8', 'uint16', 'int16', 'uint32', 'int32', 'float32', 'float64']
+
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("height,width", [(20, 30)])
+def test_read_array(tempfile, dtype, height, width):
+    """_io functions read and write arrays correctly"""
+    in_img = image(height, width, dtype)
+    with rasterio.open(tempfile, 'w', driver='GTiff', dtype=dtype,
+                       height=height, width=width, count=1) as dataset:
+        dataset.write(in_img, 1)
+        out_img = dataset.read(1)
+    assert (in_img == out_img).all()
+
+
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("height,width", [(20, 30)])
+def test_read_view_no_offset(tempfile, dtype, height, width):
+    """_io functions read views with no offset correctly"""
+    in_img = image(height, width, dtype)
+    with rasterio.open(tempfile, 'w', driver='GTiff', dtype=dtype,
+                       height=10, width=15, count=1) as dataset:
+        dataset.write(in_img[:10, :15], 1)
+        out_img = dataset.read(1)
+    assert (in_img[:10, :15] == out_img).all()
+
+
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("height,width", [(20, 30)])
+def test_read_view_offset(tempfile, dtype, height, width):
+    """_io functions read views with offsets correctly"""
+    in_img = image(height, width, dtype)
+    with rasterio.open(tempfile, 'w', driver='GTiff', dtype=dtype,
+                       height=10, width=15, count=1) as dataset:
+        dataset.write(in_img[5:15, 5:20], 1)
+        out_img = dataset.read(1)
+    assert (in_img[5:15, 5:20] == out_img).all()
+
+
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("height,width", [(20, 30)])
+def test_write_view_no_offset(tempfile, dtype, height, width):
+    """_io functions read views with offsets correctly"""
+    out_img = image(height, width, dtype)
+    in_img = np.zeros((10, 10), dtype=dtype)
+    with rasterio.open(tempfile, 'w', driver='GTiff', dtype=dtype,
+                       height=10, width=10, count=1) as dataset:
+        dataset.write(in_img, 1)
+    with rasterio.open(tempfile) as dataset:
+        result = dataset.read(1, out=out_img[:10, :10])
+
+    assert (result == in_img).all()
+    assert (out_img[:10, :10] == 0).all()

--- a/tests/test_gdal_raster_io.py
+++ b/tests/test_gdal_raster_io.py
@@ -63,7 +63,7 @@ def test_read_view_offset(tempfile, dtype, height, width):
 @pytest.mark.parametrize("dtype", dtypes)
 @pytest.mark.parametrize("height,width", [(20, 30)])
 def test_write_view_no_offset(tempfile, dtype, height, width):
-    """_io functions read views with offsets correctly"""
+    """_io functions read views without offsets correctly"""
     out_img = image(height, width, dtype)
     in_img = np.zeros((10, 10), dtype=dtype)
     with rasterio.open(tempfile, 'w', driver='GTiff', dtype=dtype,
@@ -72,5 +72,23 @@ def test_write_view_no_offset(tempfile, dtype, height, width):
     with rasterio.open(tempfile) as dataset:
         result = dataset.read(1, out=out_img[:10, :10])
 
-    assert (result == in_img).all()
+    assert (result == 0).all()
     assert (out_img[:10, :10] == 0).all()
+
+
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("height,width", [(20, 30)])
+def test_write_view_offset(tempfile, dtype, height, width):
+    """_io functions read views with offsets correctly"""
+    out_img = np.ones((height, width), dtype=dtype)
+    in_img = np.zeros((10, 10), dtype=dtype)
+    with rasterio.open(tempfile, 'w', driver='GTiff', dtype=dtype,
+                       height=10, width=10, count=1) as dataset:
+        dataset.write(in_img, 1)
+    with rasterio.open(tempfile) as dataset:
+        result = dataset.read(1, out=out_img[5:15, 5:15])
+
+    assert (result == 0).all()
+    assert (out_img[5:15, 5:15] == 0).all()
+    assert (out_img[:5, :5] == 1).all()
+    assert (out_img[15:, 15:] == 1).all()

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -245,6 +245,7 @@ def test_reproject_view():
             source = src.read(1)
 
         window = windows.Window(100, 100, 500, 500)
+        # window = windows.get_data_window(source)
         reduced_array = source[window.toslices()]
         reduced_transform = windows.transform(window, src.transform)
 
@@ -267,7 +268,6 @@ def test_reproject_view():
 
         out = np.empty(src.shape, dtype=np.uint8)
 
-
         reproject(
             reduced_array,
             out,
@@ -277,9 +277,7 @@ def test_reproject_view():
             dst_crs=dst_crs,
             resampling=Resampling.nearest)
 
-        show(out)
-
-        assert (out > 0).sum() == 438113
+        assert (out > 0).sum() == 299199
 
 
 def test_reproject_epsg():

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -11,7 +11,8 @@ from rasterio.enums import Resampling
 from rasterio.warp import (
     reproject, transform_geom, transform, transform_bounds,
     calculate_default_transform)
-
+from rasterio import windows
+from rasterio.plot import show
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
@@ -234,6 +235,50 @@ def test_reproject_ndarray():
             dst_transform=DST_TRANSFORM,
             dst_crs=dst_crs,
             resampling=Resampling.nearest)
+        assert (out > 0).sum() == 438113
+
+
+def test_reproject_view():
+    """Source views are reprojected properly"""
+    with rasterio.Env():
+        with rasterio.open('tests/data/RGB.byte.tif') as src:
+            source = src.read(1)
+
+        window = windows.Window(100, 100, 500, 500)
+        reduced_array = source[window.toslices()]
+        reduced_transform = windows.transform(window, src.transform)
+
+        # Assert that we're working with a view.
+        assert reduced_array.base is source
+
+        dst_crs = dict(
+            proj='merc',
+            a=6378137,
+            b=6378137,
+            lat_ts=0.0,
+            lon_0=0.0,
+            x_0=0.0,
+            y_0=0,
+            k=1.0,
+            units='m',
+            nadgrids='@null',
+            wktext=True,
+            no_defs=True)
+
+        out = np.empty(src.shape, dtype=np.uint8)
+
+
+        reproject(
+            reduced_array,
+            out,
+            src_transform=reduced_transform,
+            src_crs=src.crs,
+            dst_transform=DST_TRANSFORM,
+            dst_crs=dst_crs,
+            resampling=Resampling.nearest)
+
+        show(out)
+
         assert (out > 0).sum() == 438113
 
 


### PR DESCRIPTION
Towards resolving #900 

It turns out that the problem has nothing to do with warping. It is this: when a ndarray view is passed into dataset's `read()` or `write()` and thereby into the lower level `io` functions, the layout of the underlying buffer is miscommunicated to `GDALRasterIO()` and bytes were scrambled.

This is a show-stopping bug for 1.0a2. I'm doing some refactoring to make the bug easier to fix.