### PR TITLE
Declare errorHandler() with gil

### DIFF
--- a/rasterio/_drivers.pyx
+++ b/rasterio/_drivers.pyx
@@ -48,7 +48,7 @@ code_map = {
 log = logging.getLogger(__name__)
 
 
-cdef void errorHandler(CPLErr err_class, int err_no, const char* msg):
+cdef void errorHandler(CPLErr err_class, int err_no, const char* msg) with gil:
     """Send GDAL errors and warnings to the Python logger."""
     if err_no in code_map:
         # 'rasterio._gdal' is the name in our logging hierarchy for


### PR DESCRIPTION
I've run recently into an incompatibility between rasterio and osgeo.gdal

Since recently in GDAL master, osgeo.gdal bindings are generated with an option
that cause the GIL to be released before going to GDAL native code :
https://trac.osgeo.org/gdal/ticket/6649

I now observe crashes when running the following

```
import rasterio
from osgeo import gdal
gdal.OpenEx('i_dont_exist', gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR)
```

The stack trace is

```
Program received signal SIGSEGV, Segmentation fault.
0x00007fffe1507401 in __Pyx_PyObject_Call (kw=0x0, arg=0x7fffe177f750, func=0x7ffff67b5cf8) at rasterio/_drivers.c:4620
4620        if (unlikely(Py_EnterRecursiveCall((char*)" while calling a Python object")))
(gdb) bt
#0  0x00007fffe1507401 in __Pyx_PyObject_Call (kw=0x0, arg=0x7fffe177f750, func=0x7ffff67b5cf8) at rasterio/_drivers.c:4620
#1  __pyx_f_8rasterio_8_drivers_errorHandler (__pyx_v_err_class=CE_Failure, __pyx_v_err_no=<optimized out>, 
    __pyx_v_msg=0xe6ea38 "i_dont_exist: No such file or directory") at rasterio/_drivers.c:1100
#2  0x00007ffff587eff3 in CPLErrorV (eErrClass=<optimized out>, err_no=<optimized out>, fmt=<optimized out>, args=<optimized out>) at cpl_error.cpp:358
#3  0x00007ffff587ed30 in CPLError (eErrClass=4159171344, err_no=-512231600, fmt=0x0) at cpl_error.cpp:204
#4  0x00007ffff589e570 in VSIToCPLError (eErrClass=CE_Failure, eDefaultErrorNo=4) at cpl_vsi_error.cpp:271
#5  0x00007ffff5808729 in GDALOpenEx (pszFilename=<optimized out>, nOpenFlags=<optimized out>, papszAllowedDrivers=<optimized out>, 
    papszOpenOptions=<optimized out>, papszSiblingFiles=<optimized out>) at gdaldataset.cpp:2886
#6  0x00007fffdf38c129 in OpenEx (utf8_path=utf8_path@entry=0x7ffff7e7b524 "i_dont_exist", nOpenFlags=nOpenFlags@entry=66, 
    allowed_drivers=allowed_drivers@entry=0x0, open_options=open_options@entry=0x0, sibling_files=sibling_files@entry=0x0) at extensions/gdal_wrap.cpp:5887
#7  0x00007fffdf38c79b in _wrap_OpenEx (args=<optimized out>, kwargs=<optimized out>) at extensions/gdal_wrap.cpp:27314
#8  0x000000000049968d in PyEval_EvalFrameEx ()
#9  0x00000000004a1634 in ?? ()
#10 0x000000000044e4a5 in PyRun_FileExFlags ()
#11 0x000000000044ec9f in PyRun_SimpleFileExFlags ()
#12 0x000000000044f904 in Py_Main ()
#13 0x00007ffff7818f45 in __libc_start_main (main=0x44f9c2 <main>, argc=2, argv=0x7fffffffe3a8, init=<optimized out>, fini=<optimized out>, 
    rtld_fini=<optimized out>, stack_end=0x7fffffffe398) at libc-start.c:287
#14 0x0000000000578c4e in _start ()

```

The issue is that the rasterio errorHandler callback is called with the
GIL released, but it does use Python stuff.
So the GIL should be re-acquired in the callback. (which is done in osgeo.gdal
too with Python error and progress callbacks)

http://docs.cython.org/en/latest/src/userguide/external_C_code.html#acquiring-and-releasing-the-gil