### PR TITLE
use nanmin/max for histogram range

### DIFF
--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -223,7 +223,7 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
 
     # The histogram is computed individually for each 'band' in the array
     # so we need the overall min/max to constrain the plot
-    rng = arr.min(), arr.max()
+    rng = np.nanmin(arr), np.nanmax(arr)
 
     if len(arr.shape) is 2:
         arr = np.expand_dims(arr.flatten(), 0).T


### PR DESCRIPTION
Fixes #913 

I couldn't demonstrate any performance difference between the methods. There shouldn't be any impacts aside from fixing the nan case.

Leaves unresolved the question of how nan's should be treated in rio info stats or even more fundamentally if we should consider `nan` as a defacto nodata value when doing masked reads. Different questions for another time.