### PR TITLE
enforce consistent key order in rio info output

### DIFF
--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -105,7 +105,7 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
                     else:
                         click.echo(info[meta_member])
                 else:
-                    click.echo(json.dumps(info, indent=indent))
+                    click.echo(json.dumps(info, sort_keys=True, indent=indent))
 
             elif aspect == 'tags':
                 click.echo(


### PR DESCRIPTION
Tiny tweak to make `rio info` output more readable by sorting the keys for consistent order. Was thinking of making this an option but I don't see any downside to hardcoding it.

related to #904 