### PR TITLE
Add --gcps to rio-info

### DIFF
--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -84,33 +84,21 @@ def _transform_geom(
 
         if precision >= 0:
             if result['type'] == 'Point':
-                x, y = result['coordinates']
-                x = round(x, precision)
-                y = round(y, precision)
-                new_coords = [x, y]
+                new_coords = [
+                    round(v, precision) for v in result['coordinates']]
             elif result['type'] in ['LineString', 'MultiPoint']:
-                xp, yp = zip(*result['coordinates'])
-                xp = [round(v, precision) for v in xp]
-                yp = [round(v, precision) for v in yp]
-                new_coords = list(zip(xp, yp))
+                new_coords = list(
+                    zip(*([round(v, precision) for v in r]
+                        for r in zip(*result['coordinates']))))
             elif result['type'] in ['Polygon', 'MultiLineString']:
-                new_coords = []
-                for piece in result['coordinates']:
-                    xp, yp = zip(*piece)
-                    xp = [round(v, precision) for v in xp]
-                    yp = [round(v, precision) for v in yp]
-                    new_coords.append(list(zip(xp, yp)))
+                new_coords = [list(zip(*([round(v, precision) for v in r]
+                              for r in zip(*piece))))
+                              for piece in result['coordinates']]
             elif result['type'] == 'MultiPolygon':
-                parts = result['coordinates']
-                new_coords = []
-                for part in parts:
-                    inner_coords = []
-                    for ring in part:
-                        xp, yp = zip(*ring)
-                        xp = [round(v, precision) for v in xp]
-                        yp = [round(v, precision) for v in yp]
-                        inner_coords.append(list(zip(xp, yp)))
-                    new_coords.append(inner_coords)
+                new_coords = [[list(zip(*([round(v, precision) for v in r]
+                              for r in zip(*piece))))
+                              for piece in part]
+                              for part in result['coordinates']]
             result['coordinates'] = new_coords
 
         return result

--- a/rasterio/control.py
+++ b/rasterio/control.py
@@ -56,5 +56,4 @@ class GroundControlPoint(object):
             coords.append(self.z)
         return {'id': self.id, 'type': 'Feature',
                 'geometry': {'type': 'Point', 'coordinates': tuple(coords)},
-                'properties': {'info': self.info, 'row': self.row,
-                               'col': self.col}}
+                'properties': self.asdict()}

--- a/rasterio/rio/gcps.py
+++ b/rasterio/rio/gcps.py
@@ -1,0 +1,110 @@
+"""Command access to dataset metadata, stats, and more."""
+
+
+import json
+
+import click
+from cligj import (
+    compact_opt, use_rs_opt, geojson_type_collection_opt,
+    geojson_type_feature_opt, projection_geographic_opt,
+    projection_projected_opt, precision_opt, indent_opt)
+
+import rasterio
+import rasterio.crs
+from rasterio.rio import options
+from rasterio.warp import transform_geom
+
+
+# Feature collection or feature sequence switch, defaulting to the
+# latter, the opposite of cligj's default.
+sequence_opt = click.option(
+    '--sequence/--no-sequence',
+    default=True,
+    help="Write a LF-delimited sequence of texts containing individual "
+         "objects or write a single JSON text containing a feature "
+         "collection object (the default).")
+
+
+@click.command(short_help="Print ground control points as GeoJSON.")
+@options.file_in_arg
+@geojson_type_collection_opt()
+@geojson_type_feature_opt(default=True)
+@projection_geographic_opt
+@projection_projected_opt
+@precision_opt
+@use_rs_opt
+@indent_opt
+@compact_opt
+@click.pass_context
+def gcps(ctx, input, geojson_type, projection, precision, use_rs, indent,
+         compact):
+    """Print GeoJSON representations of a dataset's control points.
+
+    Each ground control point is represented as a GeoJSON feature. The
+    'properties' member of each feature contains a JSON representation
+    of the control point with the following items:
+
+    \b
+        row, col:
+            row (or line) and col (or pixel) coordinates.
+        x, y, z:
+            x, y, and z spatial coordinates.
+        crs:
+            The coordinate reference system for x, y, and z.
+        id:
+            A unique (within the dataset) identifier for the control
+            point.
+        info:
+            A brief description of the control point.
+    """
+
+    # Handle the invalid combinations of args.
+    if geojson_type == 'feature' and indent and not use_rs:
+        raise click.BadParameter(
+            "Pretty-printing a sequence of Features requires the --rs option")
+
+    with ctx.obj['env'], rasterio.open(input) as src:
+
+        gcps, crs = src.gcps
+        proj = crs.to_string()
+        proj = proj.split('=')[1].upper() if proj.startswith('+init=epsg') else proj
+
+        def update_props(data, **kwds):
+            data['properties'].update(**kwds)
+            return data
+
+        def transform(feat):
+            dst_crs = 'epsg:4326' if projection == 'geographic' else crs
+            geom = transform_geom(crs, dst_crs, feat['geometry'],
+                                  precision=precision)
+            feat['geometry'] = geom
+            return feat
+
+        # Specifying --collection overrides --sequence.
+        if geojson_type == 'collection':
+
+            if projection == 'geographic' or precision >= 0:
+                features = [transform(update_props(p.__geo_interface__, crs=proj)) for p in gcps]
+            else:
+                features = [update_props(p.__geo_interface__, crs=proj) for p in gcps]
+
+            click.echo(json.dumps(
+                {'type': 'FeatureCollection', 'features': features},
+                separators=(',', ':') if compact else None,
+                indent=indent))
+
+        else:
+            for p in gcps:
+
+                if use_rs:
+                    click.echo(u'\x1e', nl=False)
+
+                if projection == 'geographic' or precision >= 0:
+                    feat = transform(update_props(p.__geo_interface__, crs=proj))
+                else:
+                    feat = update_props(p.__geo_interface__, crs=proj)
+
+                click.echo(json.dumps(
+                    feat,
+                    separators=(',', ':') if compact else None,
+                    indent=indent))

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -4,15 +4,10 @@
 import json
 
 import click
-from cligj import (
-    sequence_opt, use_rs_opt, geojson_type_collection_opt,
-    geojson_type_feature_opt, projection_geographic_opt,
-    projection_projected_opt, precision_opt)
 
 import rasterio
 import rasterio.crs
 from rasterio.rio import options
-from rasterio.warp import transform_geom
 
 
 @click.command(short_help="Print information about a data file.")
@@ -55,22 +50,13 @@ from rasterio.warp import transform_geom
 @click.option('--checksum', 'meta_member', flag_value='checksum',
               help="Print integer checksum of a single band "
                    "(use --bidx).")
-@click.option('--gcps', 'meta_member', flag_value='gcps',
-              help="Print JSON representation of ground control points.")
-@sequence_opt
-@use_rs_opt
-@geojson_type_collection_opt()
-@geojson_type_feature_opt()
-@projection_geographic_opt
-@projection_projected_opt
-@precision_opt
 @click.option('-v', '--tell-me-more', '--verbose', is_flag=True,
               help="Output extra information.")
 @options.bidx_opt
 @options.masked_opt
 @click.pass_context
-def info(ctx, input, aspect, indent, namespace, meta_member, sequence, use_rs,
-         geojson_type, projection, precision, verbose, bidx, masked):
+def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
+         masked):
     """Print metadata about the dataset as JSON.
 
     Optionally print a single metadata item as a string.
@@ -110,8 +96,9 @@ def info(ctx, input, aspect, indent, namespace, meta_member, sequence, use_rs,
                 proj4 = crs.to_string()
                 if proj4.startswith('+init=epsg'):
                     proj4 = proj4.split('=')[1].upper()
-                info['gcps'] = {
-                    'crs': proj4, 'points': [p.asdict() for p in gcps]}
+                if gcps:
+                    info['gcps'] = {
+                        'crs': proj4, 'points': [p.asdict() for p in gcps]}
 
             if aspect == 'meta':
                 if meta_member == 'stats':
@@ -122,48 +109,6 @@ def info(ctx, input, aspect, indent, namespace, meta_member, sequence, use_rs,
                         float(band.mean())))
                 elif meta_member == 'checksum':
                     click.echo(str(src.checksum(bidx)))
-
-                elif meta_member == 'gcps':
-                    gcps, crs = src.gcps
-
-                    if geojson_type == 'collection':
-                        features = [p.__geo_interface__ for p in gcps]
-                        if projection == 'geographic' or precision >= 0:
-                            prec = 7 if precision == -1 else precision
-                            dst_crs = 'epsg:4326' if projection == 'geographic' else crs
-                            for i, feat in enumerate(features):
-                                geom = transform_geom(crs, dst_crs,
-                                                      feat['geometry'],
-                                                      precision=prec)
-                                feat['geometry'] = geom
-                                features[i] = feat
-
-                        click.echo(json.dumps(
-                            {'type': 'FeatureCollection',
-                             'features': features}))
-
-                    elif sequence:
-                        for p in gcps:
-                            if use_rs:
-                                click.echo(u'\x1e', nl=False)
-
-                            if geojson_type == 'feature':
-                                feat = p.__geo_interface__
-                                if projection == 'geographic' or precision >= 0:
-                                    prec = 7 if precision == -1 else precision
-                                    dst_crs = 'epsg:4326' if projection == 'geographic' else crs
-                                    geom = transform_geom(crs, dst_crs,
-                                                          feat['geometry'],
-                                                          precision=prec)
-                                    feat['geometry'] = geom
-                                click.echo(json.dumps(feat))
-
-                            else:
-                                click.echo(json.dumps(p.asdict()))
-
-                    else:
-                        click.echo(json.dumps([p.asdict() for p in gcps]))
-
                 elif meta_member:
                     if isinstance(info[meta_member], (list, tuple)):
                         click.echo(" ".join(map(str, info[meta_member])))

--- a/setup.py
+++ b/setup.py
@@ -277,6 +277,7 @@ setup_args = dict(
         convert=rasterio.rio.convert:convert
         edit-info=rasterio.rio.edit_info:edit
         env=rasterio.rio.env:env
+        gcps=rasterio.rio.gcps:gcps
         info=rasterio.rio.info:info
         insp=rasterio.rio.insp:insp
         mask=rasterio.rio.mask:mask

--- a/tests/test_rio_gcp.py
+++ b/tests/test_rio_gcp.py
@@ -1,0 +1,85 @@
+import json
+import logging
+import sys
+
+from click.testing import CliRunner
+import pytest
+
+from rasterio.rio.main import main_group
+
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+def test_feature_seq():
+    """GeoJSON sequence w/out RS is the default"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['gcps', 'tests/data/white-gemini-iv.vrt'])
+    assert result.exit_code == 0
+    assert result.output.count('"Feature"') == 3
+    assert '-78' in result.output
+
+def test_collection():
+    """GeoJSON collections can be had, optionally"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--collection'])
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert '-78' in result.output
+
+
+def test_feature_seq_indent_rs():
+    """Indentation of a feature sequence succeeds with ascii RS option"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        ['gcps', 'tests/data/white-gemini-iv.vrt', '--indent', '2', '--rs'])
+    assert result.exit_code == 0
+
+
+def test_feature_seq_indent_no_rs():
+    """Indentation of a feature sequence fails without ascii RS option"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--indent', '2'])
+    assert result.exit_code == 2
+
+
+def test_projected():
+    """Projected GeoJSON is an option"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--projected'])
+    assert result.exit_code == 0
+    assert '-78' not in result.output
+
+
+def test_feature_precision():
+    """Coordinate rounding is an option"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--projected', '--precision', '1'])
+    assert result.exit_code == 0
+    assert '116792.0,' in result.output
+
+
+def test_collection_precision():
+    """Coordinate rounding is an option"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--collection', '--projected', '--precision', '1'])
+    assert result.exit_code == 0
+    assert '"FeatureCollection"' in result.output
+    assert '116792.0,' in result.output
+
+
+def test_collection_geographic_precision():
+    """Unrounded coordinates are an option"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--collection', '--projected'])
+    assert result.exit_code == 0
+    assert '"FeatureCollection"' in result.output
+    assert '116792.0,' in result.output

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -694,3 +694,19 @@ def test_info_checksums_only():
         ['info', 'tests/data/RGB.byte.tif', '--checksum', '--bidx', '2'])
     assert result.exit_code == 0
     assert result.output.strip() == '29131'
+
+
+def test_info_gcp_dump():
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['info', 'tests/data/white-gemini-iv.vrt', '--gcps'])
+    assert result.exit_code == 0
+    assert '"info": "c"' in result.output
+
+
+def test_info_gcp_collection():
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['info', 'tests/data/white-gemini-iv.vrt', '--gcps', '--collection'])
+    assert result.exit_code == 0
+    assert '"info": "c"' in result.output

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -694,19 +694,3 @@ def test_info_checksums_only():
         ['info', 'tests/data/RGB.byte.tif', '--checksum', '--bidx', '2'])
     assert result.exit_code == 0
     assert result.output.strip() == '29131'
-
-
-def test_info_gcp_dump():
-    runner = CliRunner()
-    result = runner.invoke(
-        main_group, ['info', 'tests/data/white-gemini-iv.vrt', '--gcps'])
-    assert result.exit_code == 0
-    assert '"info": "c"' in result.output
-
-
-def test_info_gcp_collection():
-    runner = CliRunner()
-    result = runner.invoke(
-        main_group, ['info', 'tests/data/white-gemini-iv.vrt', '--gcps', '--collection'])
-    assert result.exit_code == 0
-    assert '"info": "c"' in result.output


### PR DESCRIPTION
Either simple JSON representation or GeoJSON, one object or seq. With option to round, as in rio-shapes.

This work also caught a bug in transform_geom(), see #922.