### PR TITLE
Adds function that rounds window to full expanse of intersecting tiles

### DIFF
--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -350,7 +350,7 @@ def window_index(window):
     return tuple(slice(*w) for w in window)
 
 
-def round_window_to_full_tiles(window=None, block_shapes=None):
+def round_window_to_full_tiles(window, block_shapes):
     """
     Round window to include full expanse of intersecting tiles.
 

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -350,7 +350,7 @@ def window_index(window):
     return tuple(slice(*w) for w in window)
 
 
-def round_window_to_full_tiles(window, block_shapes):
+def round_window_to_full_blocks(window, block_shapes):
     """
     Round window to include full expanse of intersecting tiles.
 

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -5,7 +5,7 @@ of a tuple:
 
     ((row_start, row_stop), (col_start, col_stop))
 """
-
+from __future__ import division
 import collections
 import functools
 import math
@@ -375,12 +375,12 @@ def round_window_to_full_tiles(window, block_shapes):
     row_range = window[0]
     col_range = window[1]
 
-    row_min = int(row_range[0] / height_shape) * height_shape
-    row_max = int(row_range[1] / height_shape) * height_shape + \
+    row_min = int(row_range[0] // height_shape) * height_shape
+    row_max = int(row_range[1] // height_shape) * height_shape + \
         (height_shape if row_range[1] % height_shape != 0 else 0)
 
-    col_min = int(col_range[0] / width_shape) * width_shape
-    col_max = int(col_range[1] / width_shape) * width_shape + \
+    col_min = int(col_range[0] // width_shape) * width_shape
+    col_max = int(col_range[1] // width_shape) * width_shape + \
         (width_shape if col_range[1] % width_shape != 0 else 0)
 
     return Window.from_ranges((row_min, row_max), (col_min, col_max))

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -367,7 +367,7 @@ def round_window_to_full_tiles(window=None, block_shapes=None):
     Window
     """
     if len(set(block_shapes)) != 1:
-            raise ValueError('All bands must have the same block/stripe structure')
+        raise ValueError('All bands must have the same block/stripe structure')
 
     height_shape = block_shapes[0][0]
     width_shape = block_shapes[0][1]

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -350,6 +350,42 @@ def window_index(window):
     return tuple(slice(*w) for w in window)
 
 
+def round_window_to_full_tiles(window=None, block_shapes=None):
+    """
+    Round window to include full expanse of intersecting tiles.
+
+    Parameters
+    ----------
+    window : a Window or window tuple
+        The input window.
+
+    block_shapes : tuple of block shapes
+        The input raster's block shape. All bands must have the same block/stripe structure
+
+    Returns
+    -------
+    Window
+    """
+    if len(set(block_shapes)) != 1:
+            raise ValueError('All bands must have the same block/stripe structure')
+
+    height_shape = block_shapes[0][0]
+    width_shape = block_shapes[0][1]
+
+    row_range = window[0]
+    col_range = window[1]
+
+    row_min = int(row_range[0] / height_shape) * height_shape
+    row_max = int(row_range[1] / height_shape) * height_shape + \
+        (height_shape if row_range[1] % height_shape != 0 else 0)
+
+    col_min = int(col_range[0] / width_shape) * width_shape
+    col_max = int(col_range[1] / width_shape) * width_shape + \
+        (width_shape if col_range[1] % width_shape != 0 else 0)
+
+    return Window.from_ranges((row_min, row_max), (col_min, col_max))
+
+
 class Window(tuple):
     """Windows are rectangular subsets of rasters.
     

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -9,7 +9,7 @@ import pytest
 import rasterio
 from rasterio.windows import (
     from_bounds, bounds, transform, evaluate, window_index, shape, Window,
-    intersect, intersection, get_data_window, union, round_window_to_full_tiles)
+    intersect, intersection, get_data_window, union, round_window_to_full_blocks)
 
 
 EPS = 1.0e-8
@@ -294,11 +294,11 @@ def test_intersection():
     assert window == ((8, 10), (8, 10))
 
 
-def test_round_window_to_full_tiles():
+def test_round_window_to_full_blocks():
     with rasterio.open('tests/data/alpha.tif') as src:
         block_shapes = src.block_shapes
         test_window = ((321, 548), (432, 765))
-        rounded_window = round_window_to_full_tiles(test_window, block_shapes)
+        rounded_window = round_window_to_full_blocks(test_window, block_shapes)
         block_shape = block_shapes[0]
         height_shape = block_shape[0]
         width_shape = block_shape[1]
@@ -311,14 +311,14 @@ def test_round_window_already_at_edge():
     with rasterio.open('tests/data/alpha.tif') as src:
         block_shapes = src.block_shapes
         test_window = ((256, 512), (512, 768))
-        rounded_window = round_window_to_full_tiles(test_window, block_shapes)
+        rounded_window = round_window_to_full_blocks(test_window, block_shapes)
         assert rounded_window == test_window
 
 def test_round_window_boundless():
     with rasterio.open('tests/data/alpha.tif') as src:
         block_shapes = src.block_shapes
         test_window = ((256, 512), (1000, 1500))
-        rounded_window = round_window_to_full_tiles(test_window, block_shapes)
+        rounded_window = round_window_to_full_blocks(test_window, block_shapes)
         block_shape = block_shapes[0]
         height_shape = block_shape[0]
         width_shape = block_shape[1]

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -306,3 +306,23 @@ def test_round_window_to_full_tiles():
         assert rounded_window[0][1] % height_shape == 0
         assert rounded_window[1][0] % width_shape == 0
         assert rounded_window[1][1] % width_shape == 0
+
+def test_round_window_already_at_edge():
+    with rasterio.open('tests/data/alpha.tif') as src:
+        block_shapes = src.block_shapes
+        test_window = ((256, 512), (512, 768))
+        rounded_window = round_window_to_full_tiles(test_window, block_shapes)
+        assert rounded_window == test_window
+
+def test_round_window_boundless():
+    with rasterio.open('tests/data/alpha.tif') as src:
+        block_shapes = src.block_shapes
+        test_window = ((256, 512), (1000, 1500))
+        rounded_window = round_window_to_full_tiles(test_window, block_shapes)
+        block_shape = block_shapes[0]
+        height_shape = block_shape[0]
+        width_shape = block_shape[1]
+        assert rounded_window[0][0] % height_shape == 0
+        assert rounded_window[0][1] % height_shape == 0
+        assert rounded_window[1][0] % width_shape == 0
+        assert rounded_window[1][1] % width_shape == 0

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -9,7 +9,7 @@ import pytest
 import rasterio
 from rasterio.windows import (
     from_bounds, bounds, transform, evaluate, window_index, shape, Window,
-    intersect, intersection, get_data_window, union)
+    intersect, intersection, get_data_window, union, round_window_to_full_tiles)
 
 
 EPS = 1.0e-8
@@ -292,3 +292,17 @@ def test_intersection():
     """Window intersection works."""
     window = intersection(Window(0, 0, 10, 10), Window(8, 8, 12, 12))
     assert window == ((8, 10), (8, 10))
+
+
+def test_round_window_to_full_tiles():
+    with rasterio.open('tests/data/alpha.tif') as src:
+        block_shapes = src.block_shapes
+        test_window = ((321, 548), (432, 765))
+        rounded_window = round_window_to_full_tiles(test_window, block_shapes)
+        block_shape = block_shapes[0]
+        height_shape = block_shape[0]
+        width_shape = block_shape[1]
+        assert rounded_window[0][0] % height_shape == 0
+        assert rounded_window[0][1] % height_shape == 0
+        assert rounded_window[1][0] % width_shape == 0
+        assert rounded_window[1][1] % width_shape == 0


### PR DESCRIPTION
When finding a window for clipping a subset of a raster, it is sometimes useful for the window to evenly split on the borders of the raster's tiles. For example, if a subset is clipped out of a larger raster, if that subset raster will end up being multiplied against or otherwise compared to the larger raster, having the tiles line up makes for a cleaner operation. In addition, if running some kind of block statistics of a larger raster and a subset, having tiles that are equal makes it easier to compare differently shaped, but identically tiled rasters.