### PR TITLE
Warp tests

### DIFF
--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -40,8 +40,8 @@ def supported_resampling(method):
 
 
 reproj_expected = (
-    ({'CHECK_WITH_INVERT_PROJ': False}, 6217),
-    ({'CHECK_WITH_INVERT_PROJ': True}, 4005))
+    ({'CHECK_WITH_INVERT_PROJ': False}, 7608),
+    ({'CHECK_WITH_INVERT_PROJ': True}, 2216))
 
 
 class ReprojectParams(object):
@@ -73,7 +73,19 @@ def default_reproject_params():
         width=80,
         height=80,
         src_crs={'init': 'EPSG:4326'},
-        dst_crs={'init': 'EPSG:32610'})
+        dst_crs={'init': 'EPSG:2163'})
+
+
+def uninvertable_reproject_params():
+    return ReprojectParams(
+        left=-120,
+        bottom=30,
+        right=-80,
+        top=70,
+        width=80,
+        height=80,
+        src_crs={'init': 'EPSG:4326'},
+        dst_crs={'init': 'EPSG:26836'})
 
 
 def test_transform():
@@ -321,10 +333,10 @@ def test_reproject_out_of_bounds():
 
 @pytest.mark.parametrize("options, expected", reproj_expected)
 def test_reproject_nodata(options, expected):
-    params = default_reproject_params()
     nodata = 215
 
     with rasterio.Env(**options):
+        params = uninvertable_reproject_params()
         source = np.ones((params.width, params.height), dtype=np.uint8)
         out = np.zeros((params.dst_width, params.dst_height),
                        dtype=source.dtype)
@@ -348,9 +360,9 @@ def test_reproject_nodata(options, expected):
 
 @pytest.mark.parametrize("options, expected", reproj_expected)
 def test_reproject_nodata_nan(options, expected):
-    params = default_reproject_params()
 
     with rasterio.Env(**options):
+        params = uninvertable_reproject_params()
         source = np.ones((params.width, params.height), dtype=np.float32)
         out = np.zeros((params.dst_width, params.dst_height),
                        dtype=source.dtype)
@@ -375,9 +387,9 @@ def test_reproject_nodata_nan(options, expected):
 @pytest.mark.parametrize("options, expected", reproj_expected)
 def test_reproject_dst_nodata_default(options, expected):
     """If nodata is not provided, destination will be filled with 0."""
-    params = default_reproject_params()
 
     with rasterio.Env(**options):
+        params = uninvertable_reproject_params()
         source = np.ones((params.width, params.height), dtype=np.uint8)
         out = np.zeros((params.dst_width, params.dst_height),
                        dtype=source.dtype)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -108,7 +108,7 @@ def test_transform_bounds_densify():
     # This transform is non-linear along the edges, so densification produces
     # a different result than otherwise
     src_crs = {'init': 'EPSG:4326'}
-    dst_crs = {'init': 'EPSG:32610'}
+    dst_crs = {'init': 'EPSG:2163'}
     assert np.allclose(
         transform_bounds(
             src_crs,
@@ -116,9 +116,8 @@ def test_transform_bounds_densify():
             -120, 40, -80, 64,
             densify_pts=0
         ),
-        (
-            646695.227266598, 4432069.056898901,
-            4201818.984205882, 7807592.187464975
+        ( -1684649.41338, -350356.81377,
+          1684649.41338, 2234551.18559
         )
     )
 
@@ -129,10 +128,8 @@ def test_transform_bounds_densify():
             -120, 40, -80, 64,
             densify_pts=100
         ),
-        (
-            646695.2272665979, 4432069.056898901,
-            4201818.984205882, 7807592.187464977
-        )
+        ( -1684649.41338, -555777.79210,
+          1684649.41338, 2234551.18559)
     )
 
 


### PR DESCRIPTION
Adjust warp tests for proj 4.9.3

For our tests parameterized by `CHECK_WITH_INVERT_PROJ`, we are expecting that the extent is far enough outside of the destination projection's valid bounds that it would hit uninvertable coordinatates. `proj` 4.9.3 introduced new transverse mercator calculations which give different results in the out-of-bounds regions. The trick was to find a projection that a) has uninvertable coords for this extent and b) behaves similarly across proj versions. I found that [epsg:26836](http://spatialreference.org/ref/epsg/26836/) fits the bill. There may be better ones to consider.

The densify bounds transformation and all other transforms which don't need to consider out-of-bounds cases, have been switched to [epsg:2163](http://spatialreference.org/ref/epsg/2163/) which easily covers the extent of our test case. 

Resolves #930 