### PR TITLE
clarify bounds vs gcps in calculate_default_transform

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -295,11 +295,11 @@ def calculate_default_transform(src_crs, dst_crs, width, height,
         Example: CRS({'init': 'EPSG:4326'})
     dst_crs: CRS or dict
         Target coordinate reference system.
-    width, height: int, optional
-        Source raster width and height. Not needed if gcps are used.
+    width, height: int
+        Source raster width and height.
     left, bottom, right, top: float, optional
         Bounding coordinates in src_crs, from the bounds property of a
-        raster.
+        raster. Required unless using gcps.
     gcps: sequence of GroundControlPoint, optional
         Instead of a bounding box for the source, a sequence of ground
         control points may be provided.
@@ -326,6 +326,10 @@ def calculate_default_transform(src_crs, dst_crs, width, height,
     if any(x is not None for x in (left, bottom, right, top)) and gcps:
         raise ValueError("Bounding values and ground control points may not"
                          "be used together.")
+
+    if any(x is None for x in (left, bottom, right, top)) and not gcps:
+        raise ValueError("Either four bounding values or ground control points"
+                         "must be specified")
 
     dst_affine, dst_width, dst_height = _calculate_default_transform(
         src_crs, dst_crs, width, height, left, bottom, right, top, gcps)

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -17,6 +17,13 @@ def test_gcps_bounds_exclusivity():
             'epsg:4326', 'epsg:3857', width=1, height=1, left=1.0, gcps=[1])
 
 
+def test_one_of_gcps_bounds():
+    """at least one of gcps or bounds parameters must be provided"""
+    with pytest.raises(ValueError):
+        calculate_default_transform(
+            'epsg:4326', 'epsg:3857', width=1, height=1)
+
+
 def test_identity():
     """Get the same transform and dimensions back for same crs."""
     # Tile: [53, 96, 8]
@@ -132,3 +139,15 @@ def test_gdal_transform_fail_dst_crs_xfail():
                 bottom=30,
                 right=-80,
                 top=70)
+
+
+def test_gcps_calculate_transform():
+    src_gcps = [
+        GroundControlPoint(row=0, col=0, x=156113, y=2818720, z=0),
+        GroundControlPoint(row=0, col=800, x=338353, y=2785790, z=0),
+        GroundControlPoint(row=800, col=800, x=297939, y=2618518, z=0),
+        GroundControlPoint(row=800, col=0, x=115698, y=2651448, z=0)]
+    _, width, height = calculate_default_transform(
+        'epsg:3857', 'epsg:4326', width=800, height=800, gcps=src_gcps)
+    assert width == 1087
+    assert height == 895


### PR DESCRIPTION
* Width and height are required.
* Either bounding values *or* ground control points (but not both) must be provided
* Explicit test for gcps with `calculate_default_transform`

Resolves #943