### PR TITLE
Travis Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ addons:
     - gfortran
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 before_script: # configure a headless display to test matplotlib
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/rasterio/gdalextras.pxi
+++ b/rasterio/gdalextras.pxi
@@ -1,0 +1,3 @@
+cdef extern from "gdal.h" nogil:
+
+    CPLErr GDALDeleteRasterNoDataValue(GDALRasterBandH hBand)


### PR DESCRIPTION
Also adds `rasterio/gdalextras.pxi` to `.gitignore`.