### PR TITLE
Release GIL when opening datasets

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -148,13 +148,16 @@ cdef class DatasetBase(object):
     def start(self):
         """Called to start reading a dataset."""
         cdef GDALDriverH driver
+        cdef char * cypath
 
         path = vsi_path(*parse_path(self.name))
         path = path.encode('utf-8')
+        cypath = path
 
         try:
             with CPLErrors() as cple:
-                self._hds = GDALOpen(<const char *>path, 0)
+                with nogil:
+                    self._hds = GDALOpen(cypath, 0)
                 cple.check()
         except CPLE_OpenFailedError as err:
             raise RasterioIOError(err.errmsg)


### PR DESCRIPTION
This releases the GIL around `GDALOpen`, allowing multiple/different datasets to be opened concurrently in multiple threads (convenient for loading remote datasets). Prior to this, opening would occur sequentially even when triggered by different threads.