### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pytest]
+[tool:pytest]
 testpaths = tests


### PR DESCRIPTION
Mute deprecation warning. Recent pytest versions suggest tool:pytest rather than pytest in setup.cfg.