### PR TITLE
Modify behavior of null CRS, WIP (#960).

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -937,11 +937,10 @@ def _transform(src_crs, dst_crs, xs, ys, zs):
 cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL:
     """Returns a reference to memory that must be deallocated
     by the caller."""
+    if not crs:
+        raise ValueError("A crs is required")  # CRSError("CRS cannot be None")
 
     cdef OGRSpatialReferenceH osr = OSRNewSpatialReference(NULL)
-
-    if not crs:
-        return osr
 
     if isinstance(crs, string_types):
         proj = crs.encode('utf-8')

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -937,10 +937,11 @@ def _transform(src_crs, dst_crs, xs, ys, zs):
 cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL:
     """Returns a reference to memory that must be deallocated
     by the caller."""
-    if not crs:
-        raise ValueError("A crs is required") # CRSError('CRS cannot be None')
 
     cdef OGRSpatialReferenceH osr = OSRNewSpatialReference(NULL)
+
+    if not crs:
+        return osr
 
     if isinstance(crs, string_types):
         proj = crs.encode('utf-8')

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -50,14 +50,13 @@ class _CRS(UserDict):
         cdef int retval
 
         try:
+            # return False immediately if either value is undefined
+            if not (self and other):
+                return False
             osr_crs1 = osr_from_crs(self)
             osr_crs2 = osr_from_crs(other)
-            osrs_valid = ((OSRIsGeographic(osr_crs1) == 1 or
-                           OSRIsProjected(osr_crs1) == 1) and
-                          (OSRIsGeographic(osr_crs2) == 1 or
-                           OSRIsProjected(osr_crs2) == 1))
-            osr_same = (OSRIsSame(osr_crs1, osr_crs2) == 1)
-            return (osr_same and osrs_valid)
+            retval = OSRIsSame(osr_crs1, osr_crs2)
+            return bool(retval == 1)
         finally:
             OSRDestroySpatialReference(osr_crs1)
             OSRDestroySpatialReference(osr_crs2)

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -52,8 +52,12 @@ class _CRS(UserDict):
         try:
             osr_crs1 = osr_from_crs(self)
             osr_crs2 = osr_from_crs(other)
-            retval = OSRIsSame(osr_crs1, osr_crs2)
-            return bool(retval == 1)
+            osrs_valid = ((OSRIsGeographic(osr_crs1) == 1 or
+                           OSRIsProjected(osr_crs1) == 1) and
+                          (OSRIsGeographic(osr_crs2) == 1 or
+                           OSRIsProjected(osr_crs2) == 1))
+            osr_same = (OSRIsSame(osr_crs1, osr_crs2) == 1)
+            return (osr_same and osrs_valid)
         finally:
             OSRDestroySpatialReference(osr_crs1)
             OSRDestroySpatialReference(osr_crs2)

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -132,6 +132,14 @@ def test_is_same_crs():
     assert lcc_crs1 != lcc_crs2
 
 
+def test_null_crs_equality():
+    assert (CRS() == CRS()) is False
+
+
+def test_null_and_valid_crs_equality():
+    assert (CRS() == CRS(init='EPSG:4326')) is False
+
+
 def test_to_string():
     assert CRS({'init': 'EPSG:4326'}).to_string() == "+init=EPSG:4326"
 
@@ -156,9 +164,7 @@ def test_empty_json():
 
 @pytest.mark.parametrize('arg', [None, {}, ''])
 def test_can_create_osr_none_err(arg):
-    """Passing None or empty fails"""
-    with pytest.raises(ValueError):
-        _can_create_osr(arg)
+    _can_create_osr(arg)
 
 
 def test_can_create_osr():

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -164,7 +164,9 @@ def test_empty_json():
 
 @pytest.mark.parametrize('arg', [None, {}, ''])
 def test_can_create_osr_none_err(arg):
-    _can_create_osr(arg)
+    """Passing None or empty fails"""
+    with pytest.raises(ValueError):
+        _can_create_osr(arg)
 
 
 def test_can_create_osr():


### PR DESCRIPTION
Allow comparison of null CRS with other CRS. I've reached the point where feedback would be useful. I've removed the ValueError raised from `_osr_from_crs`, and modified the behavior in checking equality of two CRS such that they must both be valid and equal to evaluate as True. I modified one group of tests (whose name I should have changed, I just realized), `test_crs.test_can_create_osr_none_err`, since that is the behavior I explicitly modified. I added a couple of simple tests of CRS comparison. On my system, I'm seeing one test failure, when warping a dataset with no CRS. It seems that a ValueError should now be raised in `reproject` when crs is None, but before I went too far, I thought I'd check in. 