### PR TITLE
rio calc: pass snuggs eval kwargs as OrderedDict

### DIFF
--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -1,6 +1,6 @@
 """$ rio calc"""
 
-
+from collections import OrderedDict
 from distutils.version import LooseVersion
 
 import click
@@ -100,7 +100,7 @@ def calc(ctx, command, files, output, name, dtype, masked, force_overwrite,
                 dtype = dtype or first.meta['dtype']
                 kwargs['dtype'] = dtype
 
-            ctxkwds = {}
+            ctxkwds = OrderedDict()
             for i, (name, path) in enumerate(inputs):
                 with rasterio.open(path) as src:
                     # Using the class method instead of instance
@@ -120,7 +120,7 @@ def calc(ctx, command, files, output, name, dtype, masked, force_overwrite,
             snuggs.func_map['fillnodata'] = lambda *args: fillnodata(*args)
             snuggs.func_map['sieve'] = lambda *args: sieve(*args)
 
-            res = snuggs.eval(command, **ctxkwds)
+            res = snuggs.eval(command, ctxkwds)
 
             if (isinstance(res, np.ma.core.MaskedArray) and (
                     tuple(LooseVersion(np.__version__).version) < (1, 9) or

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ boto3>=1.2.4
 cligj
 enum34
 numpy>=1.8
-snuggs>=1.2
+snuggs>=1.4.1
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ with open('README.rst') as f:
     readme = f.read()
 
 # Runtime requirements.
-inst_reqs = ['affine', 'cligj', 'numpy', 'snuggs', 'click-plugins']
+inst_reqs = ['affine', 'cligj', 'numpy', 'snuggs>=1.4.1', 'click-plugins']
 
 if sys.version_info < (3, 4):
     inst_reqs.append('enum34')

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -182,4 +182,4 @@ def test_positional_calculation_byindex(tmpdir):
         answer = rgb.read(1, window=window) - rgb.read(1, window=window)
 
     with rasterio.open(outfile) as src:
-        assert src.read(1)[0, 0] == answer
+        assert src.read(1, window=window) == answer


### PR DESCRIPTION
Compliment to `snuggs=1.4.1` fix that should address #947

Storing in regular dict or passing via kwargs ignores the order of user input, making (read 1) and (read 2) sometimes act out of order (important for things like subtraction). These changes substitute an `OrderedDict` which should solve the issue. I was able to trigger a failure from the test case I added prior to applying the `OrderedDict` patch, and it passed with the code change. Finally, I specified the version of `snuggs` with the relevant fix as minimum version.

Let me know how it looks. Sorry for the wait!