### PR TITLE
Better context manager teardown

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -207,15 +207,17 @@ def open(fp, mode='r', driver=None, width=None, height=None,
             "driver '{0}' in '{1}' mode".format(driver, mode))
 
     # Special case for file object argument.
-    if mode =='r' and hasattr(fp, 'read'):
+    if mode == 'r' and hasattr(fp, 'read'):
 
         @contextmanager
         def fp_reader(fp):
             memfile = MemoryFile(fp.read())
             dataset = memfile.open()
-            yield dataset
-            dataset.close()
-            memfile.close()
+            try:
+                yield dataset
+            finally:
+                dataset.close()
+                memfile.close()
 
         return fp_reader(fp)
 
@@ -227,11 +229,13 @@ def open(fp, mode='r', driver=None, width=None, height=None,
             dataset = memfile.open(driver=driver, width=width, height=height,
                                    count=count, crs=crs, transform=transform,
                                    dtype=dtype, nodata=nodata, **kwargs)
-            yield dataset
-            dataset.close()
-            memfile.seek(0)
-            fp.write(memfile.read())
-            memfile.close()
+            try:
+                yield dataset
+            finally:
+                dataset.close()
+                memfile.seek(0)
+                fp.write(memfile.read())
+                memfile.close()
 
         return fp_writer(fp)
 


### PR DESCRIPTION
The context managers introduced in https://github.com/mapbox/rasterio/pull/966 will not tear down properly if an exception is raised.  This code snippet exhibits the problem:

```python
import os

import rasterio as rio

assert not os.path.exists('TEST.tif'), "Output 'TEST.tif' already exists."

with rio.open('tests/data/RGB.byte.tif') as src:
    profile = src.profile.copy()

    try:
        with open('TEST.tif', 'wb') as f:
            with rio.open(f, 'w', **profile) as dst:
                dst.write(src.read())
                # Raising an exception here breaks out of the context manager, but the code does not advance past the 'yield' in 'fp_writer()'.
                raise Exception
    except:
        # Since an exception was raised Rasterio never flushed the data to the output file, so this should be 0.
        print(os.path.getsize('TEST.tif'))
        # This should raise an exception like: rasterio.errors.RasterioIOError: 'TEST.tif' not recognized as a supported file format.
        with rio.open('TEST.tif') as src:
            print(src.count)
```

This is a common pattern for using `@contextmanager` on a function that needs to do some teardown:

```python
@contextmanager
def func():
    try:
        yield something
    finally:
        # teardown
```