### PR TITLE
Rely on @ensure_env for a GDAL environment

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Next Release
+------------
+
+Breaking changes:
+
+- Removed `**options` argument from `rasterio.warp.transform()`.  Transformer
+  options should be set explicitly inside the currently active
+  `rasterio.env.Env()`(#1010).  This argument was initially added in `1.0a1`.
+
 1.0a8 (2017-03-29)
 ------------------
 

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -266,8 +266,8 @@ class MemoryFile(MemoryFileBase):
                               height=height, count=count, crs=crs,
                               transform=transform, dtype=dtype,
                               nodata=nodata, **kwargs)
-            s.start()
-            return s
+        s.start()
+        return s
 
     def __enter__(self):
         return self

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -3,17 +3,17 @@
 Instances of these classes are called dataset objects.
 """
 
+
 import logging
 import math
-import uuid
 import warnings
 
 from rasterio._base import (
-    DatasetBase, get_dataset_driver, driver_can_create, driver_can_create_copy)
+    get_dataset_driver, driver_can_create, driver_can_create_copy)
 from rasterio._io import (
     DatasetReaderBase, DatasetWriterBase, BufferedDatasetWriterBase,
     MemoryFileBase)
-from rasterio import enums, windows
+from rasterio import windows
 from rasterio.env import Env
 from rasterio.transform import guard_transform, xy, rowcol
 

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -14,7 +14,7 @@ from rasterio._io import (
     DatasetReaderBase, DatasetWriterBase, BufferedDatasetWriterBase,
     MemoryFileBase)
 from rasterio import windows
-from rasterio.env import Env
+from rasterio.env import ensure_env
 from rasterio.transform import guard_transform, xy, rowcol
 
 
@@ -238,6 +238,7 @@ class MemoryFile(MemoryFileBase):
     def __init__(self, file_or_bytes=None, ext=''):
         super(MemoryFile, self).__init__(file_or_bytes=file_or_bytes, ext=ext)
 
+    @ensure_env
     def open(self, driver=None, width=None, height=None, count=None, crs=None,
              transform=None, dtype=None, nodata=None, **kwargs):
         """Open the file and return a Rasterio dataset object.
@@ -256,16 +257,15 @@ class MemoryFile(MemoryFileBase):
         """
         vsi_path = self.name
 
-        with Env():
-            if self.closed:
-                raise IOError("I/O operation on closed file.")
-            if self.exists():
-                s = DatasetReader(vsi_path, 'r+')
-            else:
-                s = DatasetWriter(vsi_path, 'w', driver=driver, width=width,
-                                  height=height, count=count, crs=crs,
-                                  transform=transform, dtype=dtype,
-                                  nodata=nodata, **kwargs)
+        if self.closed:
+            raise IOError("I/O operation on closed file.")
+        if self.exists():
+            s = DatasetReader(vsi_path, 'r+')
+        else:
+            s = DatasetWriter(vsi_path, 'w', driver=driver, width=width,
+                              height=height, count=count, crs=crs,
+                              transform=transform, dtype=dtype,
+                              nodata=nodata, **kwargs)
             s.start()
             return s
 
@@ -286,6 +286,7 @@ class ZipMemoryFile(MemoryFile):
     def __init__(self, file_or_bytes=None):
         super(ZipMemoryFile, self).__init__(file_or_bytes, ext='zip')
 
+    @ensure_env
     def open(self, path):
         """Open a dataset within the zipped stream.
 
@@ -301,12 +302,11 @@ class ZipMemoryFile(MemoryFile):
         """
         vsi_path = '/vsizip{0}/{1}'.format(self.name, path.lstrip('/'))
 
-        with Env():
-            if self.closed:
-                raise IOError("I/O operation on closed file.")
-            s = DatasetReader(vsi_path, 'r')
-            s.start()
-            return s
+        if self.closed:
+            raise IOError("I/O operation on closed file.")
+        s = DatasetReader(vsi_path, 'r')
+        s.start()
+        return s
 
 
 def get_writer_for_driver(driver):

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -1,5 +1,6 @@
 """Raster warping and reprojection."""
 
+
 from __future__ import absolute_import
 from __future__ import division
 
@@ -12,11 +13,13 @@ from rasterio._base import _transform
 from rasterio._warp import (
     _transform_geom, _reproject, _calculate_default_transform)
 from rasterio.enums import Resampling
-from rasterio.env import ensure_env, Env
+from rasterio.env import ensure_env
 from rasterio.transform import guard_transform
 
 
-def transform(src_crs, dst_crs, xs, ys, zs=None, **options):
+@ensure_env
+def transform(src_crs, dst_crs, xs, ys, zs=None):
+
     """Transform vectors from source to target coordinate reference system.
 
     Transform vectors of x, y and optionally z from source
@@ -39,11 +42,11 @@ def transform(src_crs, dst_crs, xs, ys, zs=None, **options):
     Returns
     ---------
     out: tuple of array_like, (xs, ys, [zs])
-    Tuple of x, y, and optionally z vectors, transformed into the target
-    coordinate reference system.
+        Tuple of x, y, and optionally z vectors, transformed into the target
+        coordinate reference system.
     """
-    with Env(**options):
-        return _transform(src_crs, dst_crs, xs, ys, zs)
+
+    return _transform(src_crs, dst_crs, xs, ys, zs)
 
 
 @ensure_env


### PR DESCRIPTION
Covers most of #1009

Eliminates most of the `Env()` creation within Rasterio, except for `rasterio.open()`, which will be more involved.