### PR TITLE
Fix setup.py exception when no gdal is available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ libraries = []
 extra_link_args = []
 gdal2plus = False
 gdal_output = [None] * 4
+gdalversion = None
 
 try:
     import numpy as np


### PR DESCRIPTION
When run without a gdal environment, `setup.py` is throwing an exception due to uninitialised variable `gdalversion` instead of printing [the error message below it](https://github.com/mapbox/rasterio/blob/994def271a14126e690a080ead816626a70fdeb0/setup.py#L135).

Full stack trace:

> 
> File "C:\Users\01\AppData\Local\Programs\Python\Python35\lib\site-packages\setuptools\sandbox.py", line 198, in setup_context
> yield
> File "C:\Users\01\AppData\Local\Programs\Python\Python35\lib\site-packages\setuptools\sandbox.py", line 255, in run_setup
> DirectorySandbox(setup_dir).run(runner)
> File "C:\Users\01\AppData\Local\Programs\Python\Python35\lib\site-packages\setuptools\sandbox.py", line 285, in run
> return func()
> File "C:\Users\01\AppData\Local\Programs\Python\Python35\lib\site-packages\setuptools\sandbox.py", line 253, in runner
> _execfile(setup_script, ns)
> File "C:\Users\01\AppData\Local\Programs\Python\Python35\lib\site-packages\setuptools\sandbox.py", line 47, in _execfile
> exec(code, globals, locals)
> File "C:\Users\01\AppData\Local\Temp\easy_install-ry9c1r3q\rasterio-1.0a8\setup.py", line 134, in
> NameError: name 'gdalversion' is not defined
