### PR TITLE
Dont instantiate 'rasterio.Env()' in tests unless necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ venv/
 venv2/
 
 # rasterio
-test.tif
 gdal-config.txt
 VERSION.txt
 rasterio/_fill.cpp

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -207,9 +207,8 @@ def test_open_with_env(gdalenv):
 @pytest.mark.network
 def test_s3_open_with_session(gdalenv):
     """Read from S3 demonstrating lazy credentials."""
-    with rasterio.Env():
-        with rasterio.open(L8TIF) as dataset:
-            assert dataset.count == 1
+    with rasterio.open(L8TIF) as dataset:
+        assert dataset.count == 1
 
 
 @mingdalversion
@@ -225,9 +224,8 @@ def test_s3_open_with_default_session(gdalenv):
 @pytest.mark.network
 def test_open_https_vsicurl(gdalenv):
     """Read from HTTPS URL."""
-    with rasterio.Env():
-        with rasterio.open(httpstif) as dataset:
-            assert dataset.count == 1
+    with rasterio.open(httpstif) as dataset:
+        assert dataset.count == 1
 
 
 # CLI tests.

--- a/tests/test_err.py
+++ b/tests/test_err.py
@@ -1,9 +1,9 @@
-# Testing use of cpl_errs
+"""Testing use of ``cpl_errors``."""
+
 
 import pytest
 
 import rasterio
-from rasterio.env import Env
 from rasterio._err import CPLE_BaseError
 from rasterio.errors import RasterioIOError
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -58,94 +58,85 @@ def test_bounds_existing_bbox(basic_featurecollection):
 
 
 def test_geometry_mask(basic_geometry, basic_image_2x2):
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image_2x2 == 0,
-            geometry_mask(
-                [basic_geometry],
-                out_shape=DEFAULT_SHAPE,
-                transform=Affine.identity()
-            )
+    assert np.array_equal(
+        basic_image_2x2 == 0,
+        geometry_mask(
+            [basic_geometry],
+            out_shape=DEFAULT_SHAPE,
+            transform=Affine.identity()
         )
+    )
 
 
 def test_geometry_mask_invert(basic_geometry, basic_image_2x2):
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image_2x2,
-            geometry_mask(
-                [basic_geometry],
-                out_shape=DEFAULT_SHAPE,
-                transform=Affine.identity(),
-                invert=True
-            )
+    assert np.array_equal(
+        basic_image_2x2,
+        geometry_mask(
+            [basic_geometry],
+            out_shape=DEFAULT_SHAPE,
+            transform=Affine.identity(),
+            invert=True
         )
+    )
 
 
 def test_rasterize(basic_geometry, basic_image_2x2):
     """Rasterize operation should succeed for both an out_shape and out."""
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image_2x2,
-            rasterize([basic_geometry], out_shape=DEFAULT_SHAPE)
-        )
+    assert np.array_equal(
+        basic_image_2x2,
+        rasterize([basic_geometry], out_shape=DEFAULT_SHAPE)
+    )
 
-        out = np.zeros(DEFAULT_SHAPE)
-        rasterize([basic_geometry], out=out)
-        assert np.array_equal(basic_image_2x2, out)
+    out = np.zeros(DEFAULT_SHAPE)
+    rasterize([basic_geometry], out=out)
+    assert np.array_equal(basic_image_2x2, out)
 
 
 def test_rasterize_invalid_out_dtype(basic_geometry):
     """A non-supported data type for out should raise an exception."""
     out = np.zeros(DEFAULT_SHAPE, dtype=np.int64)
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            rasterize([basic_geometry], out=out)
+    with pytest.raises(ValueError):
+        rasterize([basic_geometry], out=out)
 
 
 def test_rasterize_shapes_out_dtype_mismatch(basic_geometry):
     """Shape values must be able to fit in data type for out."""
     out = np.zeros(DEFAULT_SHAPE, dtype=np.uint8)
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            rasterize([(basic_geometry, 10000000)], out=out)
+    with pytest.raises(ValueError):
+        rasterize([(basic_geometry, 10000000)], out=out)
 
 
 def test_rasterize_missing_out(basic_geometry):
     """If both out and out_shape are missing, should raise exception."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            rasterize([basic_geometry], out=None, out_shape=None)
+    with pytest.raises(ValueError):
+        rasterize([basic_geometry], out=None, out_shape=None)
 
 
 def test_rasterize_missing_shapes():
     """Shapes are required for this operation."""
-    with rasterio.Env():
-        with pytest.raises(ValueError) as ex:
-            rasterize([], out_shape=DEFAULT_SHAPE)
+    with pytest.raises(ValueError) as ex:
+        rasterize([], out_shape=DEFAULT_SHAPE)
 
-        assert 'No valid geometry objects' in str(ex.value)
+    assert 'No valid geometry objects' in str(ex.value)
 
 
 def test_rasterize_invalid_shapes():
     """Invalid shapes should raise an exception rather than be skipped."""
-    with rasterio.Env():
-        with pytest.raises(ValueError) as ex:
-            rasterize([{'foo': 'bar'}], out_shape=DEFAULT_SHAPE)
+    with pytest.raises(ValueError) as ex:
+        rasterize([{'foo': 'bar'}], out_shape=DEFAULT_SHAPE)
 
-        assert 'Invalid geometry object' in str(ex.value)
+    assert 'Invalid geometry object' in str(ex.value)
 
 
 def test_rasterize_invalid_out_shape(basic_geometry):
     """output array shape must be 2D."""
-    with rasterio.Env():
-        with pytest.raises(ValueError) as ex:
-            rasterize([basic_geometry], out_shape=(1, 10, 10))
-        assert 'Invalid out_shape' in str(ex.value)
+    with pytest.raises(ValueError) as ex:
+        rasterize([basic_geometry], out_shape=(1, 10, 10))
+    assert 'Invalid out_shape' in str(ex.value)
 
-        with pytest.raises(ValueError) as ex:
-            rasterize([basic_geometry], out_shape=(10,))
-        assert 'Invalid out_shape' in str(ex.value)
+    with pytest.raises(ValueError) as ex:
+        rasterize([basic_geometry], out_shape=(10,))
+    assert 'Invalid out_shape' in str(ex.value)
 
 
 def test_rasterize_default_value(basic_geometry, basic_image_2x2):
@@ -153,67 +144,61 @@ def test_rasterize_default_value(basic_geometry, basic_image_2x2):
     default_value = 2
     truth = basic_image_2x2 * default_value
 
-    with rasterio.Env():
-        assert np.array_equal(
-            truth,
-            rasterize(
-                [basic_geometry], out_shape=DEFAULT_SHAPE,
-                default_value=default_value
-            )
+    assert np.array_equal(
+        truth,
+        rasterize(
+            [basic_geometry], out_shape=DEFAULT_SHAPE,
+            default_value=default_value
         )
+    )
 
 
 def test_rasterize_invalid_default_value(basic_geometry):
     """A default value that requires an int64 should raise an exception."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            rasterize(
-                [basic_geometry], out_shape=DEFAULT_SHAPE,
-                default_value=1000000000000
-            )
+    with pytest.raises(ValueError):
+        rasterize(
+            [basic_geometry], out_shape=DEFAULT_SHAPE,
+            default_value=1000000000000
+        )
 
 
 def test_rasterize_fill_value(basic_geometry, basic_image_2x2):
     """All pixels not covered by shapes should be given fill value."""
     default_value = 2
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image_2x2 + 1,
-            rasterize(
-                [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1,
-                default_value=default_value
-            )
+    assert np.array_equal(
+        basic_image_2x2 + 1,
+        rasterize(
+            [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1,
+            default_value=default_value
         )
+    )
 
 
 def test_rasterize_invalid_fill_value(basic_geometry):
     """A fill value that requires an int64 should raise an exception."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            rasterize(
-                [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1000000000000,
-                default_value=2
-            )
+    with pytest.raises(ValueError):
+        rasterize(
+            [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1000000000000,
+            default_value=2
+        )
 
 
 def test_rasterize_fill_value_dtype_mismatch(basic_geometry):
     """A fill value that doesn't match dtype should fail."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            rasterize(
-                [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1000000,
-                default_value=2, dtype=np.uint8
-            )
+    with pytest.raises(ValueError):
+        rasterize(
+            [basic_geometry], out_shape=DEFAULT_SHAPE, fill=1000000,
+            default_value=2, dtype=np.uint8
+        )
 
 
 def test_rasterize_all_touched(basic_geometry, basic_image):
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image,
-            rasterize(
-                [basic_geometry], out_shape=DEFAULT_SHAPE, all_touched=True
-            )
+    assert np.array_equal(
+        basic_image,
+        rasterize(
+            [basic_geometry], out_shape=DEFAULT_SHAPE, all_touched=True
         )
+    )
 
 
 def test_rasterize_value(basic_geometry, basic_image_2x2):
@@ -222,108 +207,103 @@ def test_rasterize_value(basic_geometry, basic_image_2x2):
     each shape
     """
     value = 5
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image_2x2 * value,
-            rasterize(
-                [(basic_geometry, value)], out_shape=DEFAULT_SHAPE
-            )
+    assert np.array_equal(
+        basic_image_2x2 * value,
+        rasterize(
+            [(basic_geometry, value)], out_shape=DEFAULT_SHAPE
         )
+    )
 
 
 def test_rasterize_invalid_value(basic_geometry):
     """A shape value that requires an int64 should raise an exception."""
-    with rasterio.Env():
-        with pytest.raises(ValueError) as ex:
-            rasterize(
-                [(basic_geometry, 1000000000000)], out_shape=DEFAULT_SHAPE
-            )
+    with pytest.raises(ValueError) as ex:
+        rasterize(
+            [(basic_geometry, 1000000000000)], out_shape=DEFAULT_SHAPE
+        )
 
-        assert 'dtype must be one of' in str(ex.value)
+    assert 'dtype must be one of' in str(ex.value)
 
 
 def test_rasterize_supported_dtype(basic_geometry):
     """Supported data types should return valid results."""
-    with rasterio.Env():
-        supported_types = (
-            ('int16', -32768),
-            ('int32', -2147483648),
-            ('uint8', 255),
-            ('uint16', 65535),
-            ('uint32', 4294967295),
-            ('float32', 1.434532),
-            ('float64', -98332.133422114)
+    supported_types = (
+        ('int16', -32768),
+        ('int32', -2147483648),
+        ('uint8', 255),
+        ('uint16', 65535),
+        ('uint32', 4294967295),
+        ('float32', 1.434532),
+        ('float64', -98332.133422114)
+    )
+
+    for dtype, default_value in supported_types:
+        truth = np.zeros(DEFAULT_SHAPE, dtype=dtype)
+        truth[2:4, 2:4] = default_value
+
+        result = rasterize(
+            [basic_geometry],
+            out_shape=DEFAULT_SHAPE,
+            default_value=default_value,
+            dtype=dtype
         )
+        assert np.array_equal(result, truth)
+        assert np.dtype(result.dtype) == np.dtype(truth.dtype)
 
-        for dtype, default_value in supported_types:
-            truth = np.zeros(DEFAULT_SHAPE, dtype=dtype)
-            truth[2:4, 2:4] = default_value
+        result = rasterize(
+            [(basic_geometry, default_value)],
+            out_shape=DEFAULT_SHAPE
+        )
+        if np.dtype(dtype).kind == 'f':
+            assert np.allclose(result, truth)
+        else:
+            assert np.array_equal(result, truth)
+        # Since dtype is auto-detected, it may not match due to upcasting
 
-            result = rasterize(
+
+def test_rasterize_unsupported_dtype(basic_geometry):
+    """Unsupported types should all raise exceptions."""
+    unsupported_types = (
+        ('int8', -127),
+        ('int64', 20439845334323),
+        ('float16', -9343.232)
+    )
+
+    for dtype, default_value in unsupported_types:
+        with pytest.raises(ValueError):
+            rasterize(
                 [basic_geometry],
                 out_shape=DEFAULT_SHAPE,
                 default_value=default_value,
                 dtype=dtype
             )
-            assert np.array_equal(result, truth)
-            assert np.dtype(result.dtype) == np.dtype(truth.dtype)
 
-            result = rasterize(
+        with pytest.raises(ValueError):
+            rasterize(
                 [(basic_geometry, default_value)],
-                out_shape=DEFAULT_SHAPE
+                out_shape=DEFAULT_SHAPE,
+                dtype=dtype
             )
-            if np.dtype(dtype).kind == 'f':
-                assert np.allclose(result, truth)
-            else:
-                assert np.array_equal(result, truth)
-            # Since dtype is auto-detected, it may not match due to upcasting
-
-
-def test_rasterize_unsupported_dtype(basic_geometry):
-    """Unsupported types should all raise exceptions."""
-    with rasterio.Env():
-        unsupported_types = (
-            ('int8', -127),
-            ('int64', 20439845334323),
-            ('float16', -9343.232)
-        )
-
-        for dtype, default_value in unsupported_types:
-            with pytest.raises(ValueError):
-                rasterize(
-                    [basic_geometry],
-                    out_shape=DEFAULT_SHAPE,
-                    default_value=default_value,
-                    dtype=dtype
-                )
-
-            with pytest.raises(ValueError):
-                rasterize(
-                    [(basic_geometry, default_value)],
-                    out_shape=DEFAULT_SHAPE,
-                    dtype=dtype
-                )
 
 
 def test_rasterize_mismatched_dtype(basic_geometry):
     """Mismatched values and dtypes should raise exceptions."""
-    with rasterio.Env():
-        mismatched_types = (('uint8', 3.2423), ('uint8', -2147483648))
-        for dtype, default_value in mismatched_types:
-            with pytest.raises(ValueError):
-                rasterize(
-                    [basic_geometry],
-                    out_shape=DEFAULT_SHAPE,
-                    default_value=default_value,
-                    dtype=dtype
-                )
+    mismatched_types = (('uint8', 3.2423), ('uint8', -2147483648))
+    for dtype, default_value in mismatched_types:
+        with pytest.raises(ValueError):
+            rasterize(
+                [basic_geometry],
+                out_shape=DEFAULT_SHAPE,
+                default_value=default_value,
+                dtype=dtype
+            )
 
-            with pytest.raises(ValueError):
-                rasterize(
-                    [(basic_geometry, default_value)],
-                    out_shape=DEFAULT_SHAPE,
-                    dtype=dtype
-                )
+        with pytest.raises(ValueError):
+            rasterize(
+                [(basic_geometry, default_value)],
+                out_shape=DEFAULT_SHAPE,
+                dtype=dtype
+            )
 
 
 def test_rasterize_geometries_symmetric():
@@ -331,10 +311,9 @@ def test_rasterize_geometries_symmetric():
     transform = (1.0, 0.0, 0.0, 0.0, -1.0, 0.0)
     truth = np.zeros(DEFAULT_SHAPE, dtype=rasterio.ubyte)
     truth[2:5, 2:5] = 1
-    with rasterio.Env():
-        s = shapes(truth, transform=transform)
-        result = rasterize(s, out_shape=DEFAULT_SHAPE, transform=transform)
-        assert np.array_equal(result, truth)
+    s = shapes(truth, transform=transform)
+    result = rasterize(s, out_shape=DEFAULT_SHAPE, transform=transform)
+    assert np.array_equal(result, truth)
 
 
 def test_rasterize_internal_driver_manager(basic_geometry):
@@ -344,42 +323,40 @@ def test_rasterize_internal_driver_manager(basic_geometry):
 
 def test_shapes(basic_image):
     """Test creation of shapes from pixel values."""
-    with rasterio.Env():
-        results = list(shapes(basic_image))
+    results = list(shapes(basic_image))
 
-        assert len(results) == 2
+    assert len(results) == 2
 
-        shape, value = results[0]
-        assert shape == {
-            'coordinates': [
-                [(2, 2), (2, 5), (5, 5), (5, 2), (2, 2)]
-            ],
-            'type': 'Polygon'
-        }
-        assert value == 1
+    shape, value = results[0]
+    assert shape == {
+        'coordinates': [
+            [(2, 2), (2, 5), (5, 5), (5, 2), (2, 2)]
+        ],
+        'type': 'Polygon'
+    }
+    assert value == 1
 
-        shape, value = results[1]
-        assert shape == {
-            'coordinates': [
-                [(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)],
-                [(2, 2), (5, 2), (5, 5), (2, 5), (2, 2)]
-            ],
-            'type': 'Polygon'
-        }
-        assert value == 0
+    shape, value = results[1]
+    assert shape == {
+        'coordinates': [
+            [(0, 0), (0, 10), (10, 10), (10, 0), (0, 0)],
+            [(2, 2), (5, 2), (5, 5), (2, 5), (2, 2)]
+        ],
+        'type': 'Polygon'
+    }
+    assert value == 0
 
 
 def test_shapes_band(pixelated_image, pixelated_image_file):
     """Shapes from a band should match shapes from an array."""
-    with rasterio.Env():
-        truth = list(shapes(pixelated_image))
+    truth = list(shapes(pixelated_image))
 
-        with rasterio.open(pixelated_image_file) as src:
-            band = rasterio.band(src, 1)
-            assert truth == list(shapes(band))
+    with rasterio.open(pixelated_image_file) as src:
+        band = rasterio.band(src, 1)
+        assert truth == list(shapes(band))
 
-            # Mask band should function, but will mask out some results
-            assert truth[0] == list(shapes(band, mask=band))[0]
+        # Mask band should function, but will mask out some results
+        assert truth[0] == list(shapes(band, mask=band))[0]
 
 
 def test_shapes_connectivity_rook(diagonal_image):
@@ -387,8 +364,7 @@ def test_shapes_connectivity_rook(diagonal_image):
     Diagonals are not connected, so there will be 1 feature per pixel plus
     background.
     """
-    with rasterio.Env():
-        assert len(list(shapes(diagonal_image, connectivity=4))) == 12
+    assert len(list(shapes(diagonal_image, connectivity=4))) == 12
 
 
 def test_shapes_connectivity_queen(diagonal_image):
@@ -396,15 +372,13 @@ def test_shapes_connectivity_queen(diagonal_image):
     Diagonals are connected, so there will be 1 feature for all pixels plus
     background.
     """
-    with rasterio.Env():
-        assert len(list(shapes(diagonal_image, connectivity=8))) == 2
+    assert len(list(shapes(diagonal_image, connectivity=8))) == 2
 
 
 def test_shapes_connectivity_invalid(diagonal_image):
     """Invalid connectivity should raise exception."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            assert next(shapes(diagonal_image, connectivity=12))
+    with pytest.raises(ValueError):
+        assert next(shapes(diagonal_image, connectivity=12))
 
 
 def test_shapes_mask(basic_image):
@@ -412,55 +386,51 @@ def test_shapes_mask(basic_image):
     mask = np.ones(basic_image.shape, dtype=rasterio.bool_)
     mask[4:5, 4:5] = False
 
-    with rasterio.Env():
-        results = list(shapes(basic_image, mask=mask))
+    results = list(shapes(basic_image, mask=mask))
 
-        assert len(results) == 2
+    assert len(results) == 2
 
-        shape, value = results[0]
-        assert shape == {
-            'coordinates': [
-                [(2, 2), (2, 5), (4, 5), (4, 4), (5, 4), (5, 2), (2, 2)]
-            ],
-            'type': 'Polygon'
-        }
-        assert value == 1
+    shape, value = results[0]
+    assert shape == {
+        'coordinates': [
+            [(2, 2), (2, 5), (4, 5), (4, 4), (5, 4), (5, 2), (2, 2)]
+        ],
+        'type': 'Polygon'
+    }
+    assert value == 1
 
 
 def test_shapes_blank_mask(basic_image):
     """Mask is blank so results should mask shapes without mask."""
-    with rasterio.Env():
-        assert np.array_equal(
-            list(shapes(
-                basic_image,
-                mask=np.ones(basic_image.shape, dtype=rasterio.bool_))
-            ),
-            list(shapes(basic_image))
-        )
+    assert np.array_equal(
+        list(shapes(
+            basic_image,
+            mask=np.ones(basic_image.shape, dtype=rasterio.bool_))
+        ),
+        list(shapes(basic_image))
+    )
 
 
 def test_shapes_invalid_mask_shape(basic_image):
     """A mask that is the wrong shape should fail."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            next(shapes(
-                basic_image,
-                mask=np.ones(
-                    (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
-                    dtype=rasterio.bool_
-                )
-            ))
+    with pytest.raises(ValueError):
+        next(shapes(
+            basic_image,
+            mask=np.ones(
+                (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
+                dtype=rasterio.bool_
+            )
+        ))
 
 
 def test_shapes_invalid_mask_dtype(basic_image):
     """A mask that is the wrong dtype should fail."""
-    with rasterio.Env():
-        for dtype in ('int8', 'int16', 'int32'):
-            with pytest.raises(ValueError):
-                next(shapes(
-                    basic_image,
-                    mask=np.ones(basic_image.shape, dtype=dtype)
-                ))
+    for dtype in ('int8', 'int16', 'int32'):
+        with pytest.raises(ValueError):
+            next(shapes(
+                basic_image,
+                mask=np.ones(basic_image.shape, dtype=dtype)
+            ))
 
 
 def test_shapes_supported_dtypes(basic_image):
@@ -473,10 +443,9 @@ def test_shapes_supported_dtypes(basic_image):
         ('float32', 1.434532)
     )
 
-    with rasterio.Env():
-        for dtype, test_value in supported_types:
-            shape, value = next(shapes(basic_image.astype(dtype) * test_value))
-            assert np.allclose(value, test_value)
+    for dtype, test_value in supported_types:
+        shape, value = next(shapes(basic_image.astype(dtype) * test_value))
+        assert np.allclose(value, test_value)
 
 
 def test_shapes_unsupported_dtypes(basic_image):
@@ -489,10 +458,9 @@ def test_shapes_unsupported_dtypes(basic_image):
         ('float64', -98332.133422114)
     )
 
-    with rasterio.Env():
-        for dtype, test_value in unsupported_types:
-            with pytest.raises(ValueError):
-                next(shapes(basic_image.astype(dtype) * test_value))
+    for dtype, test_value in unsupported_types:
+        with pytest.raises(ValueError):
+            next(shapes(basic_image.astype(dtype) * test_value))
 
 
 def test_shapes_internal_driver_manager(basic_image):
@@ -505,26 +473,23 @@ def test_sieve_small(basic_image, pixelated_image):
     Setting the size smaller than or equal to the size of the feature in the
     image should not change the image.
     """
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image,
-            sieve(pixelated_image, basic_image.sum())
-        )
+    assert np.array_equal(
+        basic_image,
+        sieve(pixelated_image, basic_image.sum())
+    )
 
 
 def test_sieve_large(basic_image):
     """
     Setting the size larger than size of feature should leave us an empty image.
     """
-    with rasterio.Env():
-        assert not np.any(sieve(basic_image, basic_image.sum() + 1))
+    assert not np.any(sieve(basic_image, basic_image.sum() + 1))
 
 
 def test_sieve_invalid_size(basic_image):
-    with rasterio.Env():
-        for invalid_size in (0, 45.1234, basic_image.size + 1):
-            with pytest.raises(ValueError):
-                sieve(basic_image, invalid_size)
+    for invalid_size in (0, 45.1234, basic_image.size + 1):
+        with pytest.raises(ValueError):
+            sieve(basic_image, invalid_size)
 
 
 def test_sieve_connectivity_rook(diagonal_image):
@@ -549,31 +514,29 @@ def test_sieve_connectivity_invalid(basic_image):
 
 def test_sieve_out(basic_image):
     """Output array passed in should match the returned array."""
-    with rasterio.Env():
-        output = np.zeros_like(basic_image)
-        output[1:3, 1:3] = 5
-        sieved_image = sieve(basic_image, basic_image.sum(), out=output)
-        assert np.array_equal(basic_image, sieved_image)
-        assert np.array_equal(output, sieved_image)
+    output = np.zeros_like(basic_image)
+    output[1:3, 1:3] = 5
+    sieved_image = sieve(basic_image, basic_image.sum(), out=output)
+    assert np.array_equal(basic_image, sieved_image)
+    assert np.array_equal(output, sieved_image)
 
 
 def test_sieve_invalid_out(basic_image):
     """Output with different dtype or shape should fail."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            sieve(
-                basic_image, basic_image.sum(),
-                out=np.zeros(basic_image.shape, dtype=rasterio.int32)
-            )
+    with pytest.raises(ValueError):
+        sieve(
+            basic_image, basic_image.sum(),
+            out=np.zeros(basic_image.shape, dtype=rasterio.int32)
+        )
 
-        with pytest.raises(ValueError):
-            sieve(
-                basic_image, basic_image.sum(),
-                out=np.zeros(
-                    (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
-                    dtype=rasterio.ubyte
-                )
+    with pytest.raises(ValueError):
+        sieve(
+            basic_image, basic_image.sum(),
+            out=np.zeros(
+                (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
+                dtype=rasterio.ubyte
             )
+        )
 
 
 def test_sieve_mask(basic_image):
@@ -585,53 +548,49 @@ def test_sieve_mask(basic_image):
     mask[4:5, 4:5] = False
     truth = basic_image * np.invert(mask)
 
-    with rasterio.Env():
-        sieved_image = sieve(basic_image, basic_image.sum(), mask=mask)
-        assert sieved_image.sum() > 0
+    sieved_image = sieve(basic_image, basic_image.sum(), mask=mask)
+    assert sieved_image.sum() > 0
 
-        assert np.array_equal(
-            truth,
-            sieved_image
-        )
+    assert np.array_equal(
+        truth,
+        sieved_image
+    )
 
-        assert np.array_equal(
-            truth.astype(rasterio.uint8),
-            sieved_image
-        )
+    assert np.array_equal(
+        truth.astype(rasterio.uint8),
+        sieved_image
+    )
 
 
 def test_sieve_blank_mask(basic_image):
     """A blank mask should have no effect."""
     mask = np.ones(basic_image.shape, dtype=rasterio.bool_)
-    with rasterio.Env():
-        assert np.array_equal(
-            basic_image,
-            sieve(basic_image, basic_image.sum(), mask=mask)
-        )
+    assert np.array_equal(
+        basic_image,
+        sieve(basic_image, basic_image.sum(), mask=mask)
+    )
 
 
 def test_sieve_invalid_mask_shape(basic_image):
     """A mask that is the wrong shape should fail."""
-    with rasterio.Env():
-        with pytest.raises(ValueError):
-            sieve(
-                basic_image, basic_image.sum(),
-                mask=np.ones(
-                    (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
-                    dtype=rasterio.bool_
-                )
+    with pytest.raises(ValueError):
+        sieve(
+            basic_image, basic_image.sum(),
+            mask=np.ones(
+                (basic_image.shape[0] + 10, basic_image.shape[1] + 10),
+                dtype=rasterio.bool_
             )
+        )
 
 
 def test_sieve_invalid_mask_dtype(basic_image):
     """A mask that is the wrong dtype should fail."""
-    with rasterio.Env():
-        for dtype in ('int8', 'int16', 'int32'):
-            with pytest.raises(ValueError):
-                sieve(
-                    basic_image, basic_image.sum(),
-                    mask=np.ones(basic_image.shape, dtype=dtype)
-                )
+    for dtype in ('int8', 'int16', 'int32'):
+        with pytest.raises(ValueError):
+            sieve(
+                basic_image, basic_image.sum(),
+                mask=np.ones(basic_image.shape, dtype=dtype)
+            )
 
 
 def test_sieve_supported_dtypes(basic_image):
@@ -643,12 +602,11 @@ def test_sieve_supported_dtypes(basic_image):
         ('uint16', 65535)
     )
 
-    with rasterio.Env():
-        for dtype, test_value in supported_types:
-            truth = (basic_image).astype(dtype) * test_value
-            sieved_image = sieve(truth, basic_image.sum())
-            assert np.array_equal(truth, sieved_image)
-            assert np.dtype(sieved_image.dtype) == np.dtype(dtype)
+    for dtype, test_value in supported_types:
+        truth = (basic_image).astype(dtype) * test_value
+        sieved_image = sieve(truth, basic_image.sum())
+        assert np.array_equal(truth, sieved_image)
+        assert np.dtype(sieved_image.dtype) == np.dtype(dtype)
 
 
 def test_sieve_unsupported_dtypes(basic_image):
@@ -662,29 +620,28 @@ def test_sieve_unsupported_dtypes(basic_image):
         ('float64', -98332.133422114)
     )
 
-    with rasterio.Env():
-        for dtype, test_value in unsupported_types:
-            with pytest.raises(ValueError):
-                sieve(
-                    (basic_image).astype(dtype) * test_value,
-                    basic_image.sum()
-                )
+    for dtype, test_value in unsupported_types:
+        with pytest.raises(ValueError):
+            sieve(
+                (basic_image).astype(dtype) * test_value,
+                basic_image.sum()
+            )
 
 
 def test_sieve_band(pixelated_image, pixelated_image_file):
     """Sieving a band from a raster file should match sieve of array."""
-    with rasterio.Env():
-        truth = sieve(pixelated_image, 9)
 
-        with rasterio.open(pixelated_image_file) as src:
-            band = rasterio.band(src, 1)
-            assert np.array_equal(truth, sieve(band, 9))
+    truth = sieve(pixelated_image, 9)
 
-            # Mask band should also work but will be a no-op
-            assert np.array_equal(
-                pixelated_image,
-                sieve(band, 9, mask=band)
-            )
+    with rasterio.open(pixelated_image_file) as src:
+        band = rasterio.band(src, 1)
+        assert np.array_equal(truth, sieve(band, 9))
+
+        # Mask band should also work but will be a no-op
+        assert np.array_equal(
+            pixelated_image,
+            sieve(band, 9, mask=band)
+        )
 
 
 def test_sieve_internal_driver_manager(basic_image, pixelated_image):

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -391,10 +391,9 @@ def test_warp_reproject_like(runner, tmpdir):
         "nodata": 0
     }
 
-    with rasterio.Env():
-        with rasterio.open(likename, 'w', **kwargs) as dst:
-            data = np.zeros((10, 10), dtype=rasterio.uint8)
-            dst.write(data, indexes=1)
+    with rasterio.open(likename, 'w', **kwargs) as dst:
+        data = np.zeros((10, 10), dtype=rasterio.uint8)
+        dst.write(data, indexes=1)
 
     srcname = 'tests/data/shade.tif'
     outputname = str(tmpdir.join('test.tif'))

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -46,9 +46,11 @@ def test_tags_update(tmpdir):
         assert src.tags(1) == {'c': '3'}
         assert src.tags(ns='rasterio_testing') == {'rus': u'другая строка'}
 
-def test_tags_update_twice():
+
+def test_tags_update_twice(tmpdir):
+    path = str(tmpdir.join('test.tif'))
     with rasterio.open(
-            'test.tif', 'w', 
+            path, 'w',
             'GTiff', 3, 4, 1, dtype=rasterio.ubyte) as dst:
         dst.update_tags(a=1, b=2)
         assert dst.tags() == {'a': '1', 'b': '2'}
@@ -56,9 +58,10 @@ def test_tags_update_twice():
         assert dst.tags() == {'a': '1', 'b': '2', 'c': '3'}
 
 
-def test_tags_eq():
+def test_tags_eq(tmpdir):
+    path = str(tmpdir.join('test.tif'))
     with rasterio.open(
-            'test.tif', 'w', 
+            path, 'w',
             'GTiff', 3, 4, 1, dtype=rasterio.ubyte) as dst:
         dst.update_tags(a="foo=bar")
         assert dst.tags() == {'a': "foo=bar"}

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -57,12 +57,11 @@ class ReprojectParams(object):
         self.src_crs = src_crs
         self.dst_crs = dst_crs
 
-        with rasterio.Env():
-            dt, dw, dh = calculate_default_transform(
-                src_crs, dst_crs, width, height, left, bottom, right, top)
-            self.dst_transform = dt
-            self.dst_width = dw
-            self.dst_height = dh
+        dt, dw, dh = calculate_default_transform(
+            src_crs, dst_crs, width, height, left, bottom, right, top)
+        self.dst_transform = dt
+        self.dst_width = dw
+        self.dst_height = dh
 
 
 def default_reproject_params():
@@ -105,16 +104,15 @@ def test_transform():
 
 
 def test_transform_bounds():
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            l, b, r, t = src.bounds
-            assert np.allclose(
-                transform_bounds(src.crs, {'init': 'EPSG:4326'}, l, b, r, t),
-                (
-                    -78.95864996545055, 23.564991210854686,
-                    -76.57492370013823, 25.550873767433984
-                )
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        l, b, r, t = src.bounds
+        assert np.allclose(
+            transform_bounds(src.crs, {'init': 'EPSG:4326'}, l, b, r, t),
+            (
+                -78.95864996545055, 23.564991210854686,
+                -76.57492370013823, 25.550873767433984
             )
+        )
 
 
 def test_transform_bounds_densify():
@@ -141,13 +139,12 @@ def test_transform_bounds_densify():
 
 def test_transform_bounds_no_change():
     """Make sure that going from and to the same crs causes no change."""
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            l, b, r, t = src.bounds
-            assert np.allclose(
-                transform_bounds(src.crs, src.crs, l, b, r, t),
-                src.bounds
-            )
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        l, b, r, t = src.bounds
+        assert np.allclose(
+            transform_bounds(src.crs, src.crs, l, b, r, t),
+            src.bounds
+        )
 
 
 def test_transform_bounds_densify_out_of_bounds():
@@ -165,142 +162,136 @@ def test_calculate_default_transform():
         0.0028535715391804096, 0.0, -78.95864996545055,
         0.0, -0.0028535715391804096, 25.550873767433984)
 
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            wgs84_crs = {'init': 'EPSG:4326'}
-            dst_transform, width, height = calculate_default_transform(
-                src.crs, wgs84_crs, src.width, src.height, *src.bounds)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        wgs84_crs = {'init': 'EPSG:4326'}
+        dst_transform, width, height = calculate_default_transform(
+            src.crs, wgs84_crs, src.width, src.height, *src.bounds)
 
-            assert dst_transform.almost_equals(target_transform)
-            assert width == 835
-            assert height == 696
+        assert dst_transform.almost_equals(target_transform)
+        assert width == 835
+        assert height == 696
 
 
 def test_calculate_default_transform_single_resolution():
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            target_resolution = 0.1
-            target_transform = Affine(
-                target_resolution, 0.0, -78.95864996545055,
-                0.0, -target_resolution, 25.550873767433984
-            )
-            dst_transform, width, height = calculate_default_transform(
-                src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
-                *src.bounds, resolution=target_resolution
-            )
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        target_resolution = 0.1
+        target_transform = Affine(
+            target_resolution, 0.0, -78.95864996545055,
+            0.0, -target_resolution, 25.550873767433984
+        )
+        dst_transform, width, height = calculate_default_transform(
+            src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
+            *src.bounds, resolution=target_resolution
+        )
 
-            assert dst_transform.almost_equals(target_transform)
-            assert width == 24
-            assert height == 20
+        assert dst_transform.almost_equals(target_transform)
+        assert width == 24
+        assert height == 20
 
 
 def test_calculate_default_transform_multiple_resolutions():
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            target_resolution = (0.2, 0.1)
-            target_transform = Affine(
-                target_resolution[0], 0.0, -78.95864996545055,
-                0.0, -target_resolution[1], 25.550873767433984
-            )
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        target_resolution = (0.2, 0.1)
+        target_transform = Affine(
+            target_resolution[0], 0.0, -78.95864996545055,
+            0.0, -target_resolution[1], 25.550873767433984
+        )
 
-            dst_transform, width, height = calculate_default_transform(
-                src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
-                *src.bounds, resolution=target_resolution
-            )
+        dst_transform, width, height = calculate_default_transform(
+            src.crs, {'init': 'EPSG:4326'}, src.width, src.height,
+            *src.bounds, resolution=target_resolution
+        )
 
-            assert dst_transform.almost_equals(target_transform)
-            assert width == 12
-            assert height == 20
+        assert dst_transform.almost_equals(target_transform)
+        assert width == 12
+        assert height == 20
 
 
 def test_reproject_ndarray():
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read(1)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        source = src.read(1)
 
-        dst_crs = dict(
-            proj='merc',
-            a=6378137,
-            b=6378137,
-            lat_ts=0.0,
-            lon_0=0.0,
-            x_0=0.0,
-            y_0=0,
-            k=1.0,
-            units='m',
-            nadgrids='@null',
-            wktext=True,
-            no_defs=True)
-        out = np.empty(src.shape, dtype=np.uint8)
-        reproject(
-            source,
-            out,
-            src_transform=src.transform,
-            src_crs=src.crs,
-            dst_transform=DST_TRANSFORM,
-            dst_crs=dst_crs,
-            resampling=Resampling.nearest)
-        assert (out > 0).sum() == 438113
+    dst_crs = dict(
+        proj='merc',
+        a=6378137,
+        b=6378137,
+        lat_ts=0.0,
+        lon_0=0.0,
+        x_0=0.0,
+        y_0=0,
+        k=1.0,
+        units='m',
+        nadgrids='@null',
+        wktext=True,
+        no_defs=True)
+    out = np.empty(src.shape, dtype=np.uint8)
+    reproject(
+        source,
+        out,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_transform=DST_TRANSFORM,
+        dst_crs=dst_crs,
+        resampling=Resampling.nearest)
+    assert (out > 0).sum() == 438113
 
 
 def test_reproject_view():
     """Source views are reprojected properly"""
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read(1)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        source = src.read(1)
 
-        window = windows.Window(100, 100, 500, 500)
-        # window = windows.get_data_window(source)
-        reduced_array = source[window.toslices()]
-        reduced_transform = windows.transform(window, src.transform)
+    window = windows.Window(100, 100, 500, 500)
+    # window = windows.get_data_window(source)
+    reduced_array = source[window.toslices()]
+    reduced_transform = windows.transform(window, src.transform)
 
-        # Assert that we're working with a view.
-        assert reduced_array.base is source
+    # Assert that we're working with a view.
+    assert reduced_array.base is source
 
-        dst_crs = dict(
-            proj='merc',
-            a=6378137,
-            b=6378137,
-            lat_ts=0.0,
-            lon_0=0.0,
-            x_0=0.0,
-            y_0=0,
-            k=1.0,
-            units='m',
-            nadgrids='@null',
-            wktext=True,
-            no_defs=True)
+    dst_crs = dict(
+        proj='merc',
+        a=6378137,
+        b=6378137,
+        lat_ts=0.0,
+        lon_0=0.0,
+        x_0=0.0,
+        y_0=0,
+        k=1.0,
+        units='m',
+        nadgrids='@null',
+        wktext=True,
+        no_defs=True)
 
-        out = np.empty(src.shape, dtype=np.uint8)
+    out = np.empty(src.shape, dtype=np.uint8)
 
-        reproject(
-            reduced_array,
-            out,
-            src_transform=reduced_transform,
-            src_crs=src.crs,
-            dst_transform=DST_TRANSFORM,
-            dst_crs=dst_crs,
-            resampling=Resampling.nearest)
+    reproject(
+        reduced_array,
+        out,
+        src_transform=reduced_transform,
+        src_crs=src.crs,
+        dst_transform=DST_TRANSFORM,
+        dst_crs=dst_crs,
+        resampling=Resampling.nearest)
 
-        assert (out > 0).sum() == 299199
+    assert (out > 0).sum() == 299199
 
 
 def test_reproject_epsg():
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read(1)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        source = src.read(1)
 
-        dst_crs = {'init': 'EPSG:3857'}
-        out = np.empty(src.shape, dtype=np.uint8)
-        reproject(
-            source,
-            out,
-            src_transform=src.transform,
-            src_crs=src.crs,
-            dst_transform=DST_TRANSFORM,
-            dst_crs=dst_crs,
-            resampling=Resampling.nearest)
-        assert (out > 0).sum() == 438113
+    dst_crs = {'init': 'EPSG:3857'}
+    out = np.empty(src.shape, dtype=np.uint8)
+    reproject(
+        source,
+        out,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_transform=DST_TRANSFORM,
+        dst_crs=dst_crs,
+        resampling=Resampling.nearest)
+    assert (out > 0).sum() == 438113
 
 
 def test_reproject_out_of_bounds():
@@ -308,21 +299,20 @@ def test_reproject_out_of_bounds():
 
     Should return blank image.
     """
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read(1)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        source = src.read(1)
 
-        dst_crs = {'init': 'EPSG:32619'}
-        out = np.zeros(src.shape, dtype=np.uint8)
-        reproject(
-            source,
-            out,
-            src_transform=src.transform,
-            src_crs=src.crs,
-            dst_transform=DST_TRANSFORM,
-            dst_crs=dst_crs,
-            resampling=Resampling.nearest)
-        assert not out.any()
+    dst_crs = {'init': 'EPSG:32619'}
+    out = np.zeros(src.shape, dtype=np.uint8)
+    reproject(
+        source,
+        out,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_transform=DST_TRANSFORM,
+        dst_crs=dst_crs,
+        resampling=Resampling.nearest)
+    assert not out.any()
 
 
 @pytest.mark.parametrize("options, expected", reproj_expected)
@@ -407,62 +397,59 @@ def test_reproject_invalid_dst_nodata():
     """dst_nodata must be in value range of data type."""
     params = default_reproject_params()
 
-    with rasterio.Env():
-        source = np.ones((params.width, params.height), dtype=np.uint8)
-        out = source.copy()
+    source = np.ones((params.width, params.height), dtype=np.uint8)
+    out = source.copy()
 
-        with pytest.raises(ValueError):
-            reproject(
-                source,
-                out,
-                src_transform=params.src_transform,
-                src_crs=params.src_crs,
-                src_nodata=0,
-                dst_transform=params.dst_transform,
-                dst_crs=params.dst_crs,
-                dst_nodata=999999999
-            )
+    with pytest.raises(ValueError):
+        reproject(
+            source,
+            out,
+            src_transform=params.src_transform,
+            src_crs=params.src_crs,
+            src_nodata=0,
+            dst_transform=params.dst_transform,
+            dst_crs=params.dst_crs,
+            dst_nodata=999999999
+        )
 
 
 def test_reproject_missing_src_nodata():
     """src_nodata is required if dst_nodata is not None."""
     params = default_reproject_params()
 
-    with rasterio.Env():
-        source = np.ones((params.width, params.height), dtype=np.uint8)
-        out = source.copy()
+    source = np.ones((params.width, params.height), dtype=np.uint8)
+    out = source.copy()
 
-        with pytest.raises(ValueError):
-            reproject(
-                source,
-                out,
-                src_transform=params.src_transform,
-                src_crs=params.src_crs,
-                dst_transform=params.dst_transform,
-                dst_crs=params.dst_crs,
-                dst_nodata=215
-            )
+    with pytest.raises(ValueError):
+        reproject(
+            source,
+            out,
+            src_transform=params.src_transform,
+            src_crs=params.src_crs,
+            dst_transform=params.dst_transform,
+            dst_crs=params.dst_crs,
+            dst_nodata=215
+        )
 
 
 def test_reproject_invalid_src_nodata():
     """src_nodata must be in range for data type."""
     params = default_reproject_params()
 
-    with rasterio.Env():
-        source = np.ones((params.width, params.height), dtype=np.uint8)
-        out = source.copy()
+    source = np.ones((params.width, params.height), dtype=np.uint8)
+    out = source.copy()
 
-        with pytest.raises(ValueError):
-            reproject(
-                source,
-                out,
-                src_transform=params.src_transform,
-                src_crs=params.src_crs,
-                src_nodata=999999999,
-                dst_transform=params.dst_transform,
-                dst_crs=params.dst_crs,
-                dst_nodata=215
-            )
+    with pytest.raises(ValueError):
+        reproject(
+            source,
+            out,
+            src_transform=params.src_transform,
+            src_crs=params.src_crs,
+            src_nodata=999999999,
+            dst_transform=params.dst_transform,
+            dst_crs=params.dst_crs,
+            dst_nodata=215
+        )
 
 
 def test_reproject_init_nodata_tofile(tmpdir):
@@ -583,65 +570,63 @@ def test_reproject_no_init_nodata_toarray():
     source1[:rows // 2, :cols // 2] = 200
     source2[rows // 2:, cols // 2:] = 100
 
-    with rasterio.Env():
-        reproject(
-            source1,
-            out,
-            src_transform=params.src_transform,
-            src_crs=params.src_crs,
-            src_nodata=0.0,
-            dst_transform=params.dst_transform,
-            dst_crs=params.dst_crs,
-            dst_nodata=0.0
-        )
+    reproject(
+        source1,
+        out,
+        src_transform=params.src_transform,
+        src_crs=params.src_crs,
+        src_nodata=0.0,
+        dst_transform=params.dst_transform,
+        dst_crs=params.dst_crs,
+        dst_nodata=0.0
+    )
 
-        assert out.max() == 200
-        assert out.min() == 0
+    assert out.max() == 200
+    assert out.min() == 0
 
-        reproject(
-            source2,
-            out,
-            src_transform=params.src_transform,
-            src_crs=params.src_crs,
-            src_nodata=0.0,
-            dst_transform=params.dst_transform,
-            dst_crs=params.dst_crs,
-            dst_nodata=0.0,
-            init_dest_nodata=False
-        )
+    reproject(
+        source2,
+        out,
+        src_transform=params.src_transform,
+        src_crs=params.src_crs,
+        src_nodata=0.0,
+        dst_transform=params.dst_transform,
+        dst_crs=params.dst_crs,
+        dst_nodata=0.0,
+        init_dest_nodata=False
+    )
 
-        # 200s should NOT be overwritten by 100s
-        assert out.max() == 200
-        assert out.min() == 0
+    # 200s should NOT be overwritten by 100s
+    assert out.max() == 200
+    assert out.min() == 0
 
 
 def test_reproject_multi():
     """Ndarry to ndarray."""
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read()
-        dst_crs = dict(
-            proj='merc',
-            a=6378137,
-            b=6378137,
-            lat_ts=0.0,
-            lon_0=0.0,
-            x_0=0.0,
-            y_0=0,
-            k=1.0,
-            units='m',
-            nadgrids='@null',
-            wktext=True,
-            no_defs=True)
-        destin = np.empty(source.shape, dtype=np.uint8)
-        reproject(
-            source,
-            destin,
-            src_transform=src.transform,
-            src_crs=src.crs,
-            dst_transform=DST_TRANSFORM,
-            dst_crs=dst_crs,
-            resampling=Resampling.nearest)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        source = src.read()
+    dst_crs = dict(
+        proj='merc',
+        a=6378137,
+        b=6378137,
+        lat_ts=0.0,
+        lon_0=0.0,
+        x_0=0.0,
+        y_0=0,
+        k=1.0,
+        units='m',
+        nadgrids='@null',
+        wktext=True,
+        no_defs=True)
+    destin = np.empty(source.shape, dtype=np.uint8)
+    reproject(
+        source,
+        destin,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_transform=DST_TRANSFORM,
+        dst_crs=dst_crs,
+        resampling=Resampling.nearest)
     assert destin.any()
 
 
@@ -830,40 +815,38 @@ def test_transform_geom_multipolygon(polygon_3373):
 
 def test_reproject_unsupported_resampling():
     """Values not in enums. Resampling are not supported."""
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read(1)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        source = src.read(1)
 
-        dst_crs = {'init': 'EPSG:32619'}
-        out = np.empty(src.shape, dtype=np.uint8)
-        with pytest.raises(ValueError):
-            reproject(
-                source,
-                out,
-                src_transform=src.transform,
-                src_crs=src.crs,
-                dst_transform=DST_TRANSFORM,
-                dst_crs=dst_crs,
-                resampling=99)
+    dst_crs = {'init': 'EPSG:32619'}
+    out = np.empty(src.shape, dtype=np.uint8)
+    with pytest.raises(ValueError):
+        reproject(
+            source,
+            out,
+            src_transform=src.transform,
+            src_crs=src.crs,
+            dst_transform=DST_TRANSFORM,
+            dst_crs=dst_crs,
+            resampling=99)
 
 
 def test_reproject_unsupported_resampling_guass():
     """Resampling.gauss is unsupported."""
-    with rasterio.Env():
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            source = src.read(1)
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        source = src.read(1)
 
-        dst_crs = {'init': 'EPSG:32619'}
-        out = np.empty(src.shape, dtype=np.uint8)
-        with pytest.raises(ValueError):
-            reproject(
-                source,
-                out,
-                src_transform=src.transform,
-                src_crs=src.crs,
-                dst_transform=DST_TRANSFORM,
-                dst_crs=dst_crs,
-                resampling=Resampling.gauss)
+    dst_crs = {'init': 'EPSG:32619'}
+    out = np.empty(src.shape, dtype=np.uint8)
+    with pytest.raises(ValueError):
+        reproject(
+            source,
+            out,
+            src_transform=src.transform,
+            src_crs=src.crs,
+            dst_transform=DST_TRANSFORM,
+            dst_crs=dst_crs,
+            resampling=Resampling.gauss)
 
 
 @pytest.mark.parametrize("method", Resampling)
@@ -874,33 +857,32 @@ def test_resample_default_invert_proj(method):
     if not supported_resampling(method):
         pytest.skip()
 
-    with rasterio.Env():
-        with rasterio.open('tests/data/world.rgb.tif') as src:
-            source = src.read(1)
-            profile = src.profile.copy()
+    with rasterio.open('tests/data/world.rgb.tif') as src:
+        source = src.read(1)
+        profile = src.profile.copy()
 
-        dst_crs = {'init': 'EPSG:32619'}
+    dst_crs = {'init': 'EPSG:32619'}
 
-        # Calculate the ideal dimensions and transformation in the new crs
-        dst_affine, dst_width, dst_height = calculate_default_transform(
-            src.crs, dst_crs, src.width, src.height, *src.bounds)
+    # Calculate the ideal dimensions and transformation in the new crs
+    dst_affine, dst_width, dst_height = calculate_default_transform(
+        src.crs, dst_crs, src.width, src.height, *src.bounds)
 
-        profile['height'] = dst_height
-        profile['width'] = dst_width
+    profile['height'] = dst_height
+    profile['width'] = dst_width
 
-        out = np.empty(shape=(dst_height, dst_width), dtype=np.uint8)
+    out = np.empty(shape=(dst_height, dst_width), dtype=np.uint8)
 
-        out = np.empty(src.shape, dtype=np.uint8)
-        reproject(
-            source,
-            out,
-            src_transform=src.transform,
-            src_crs=src.crs,
-            dst_transform=dst_affine,
-            dst_crs=dst_crs,
-            resampling=method)
+    out = np.empty(src.shape, dtype=np.uint8)
+    reproject(
+        source,
+        out,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_transform=dst_affine,
+        dst_crs=dst_crs,
+        resampling=method)
 
-        assert out.mean() > 0
+    assert out.mean() > 0
 
 
 @pytest.mark.xfail()
@@ -972,14 +954,13 @@ def test_reproject_identity():
     dstaff = Affine(0.5, 0.0, 0.0, 0.0, 0.5, 0.0)
     dstcrs = {'init': 'epsg:3857'}
 
-    with rasterio.Env():
-        reproject(
-            src, dst,
-            src_transform=srcaff,
-            src_crs=srccrs,
-            dst_transform=dstaff,
-            dst_crs=dstcrs,
-            resampling=Resampling.nearest)
+    reproject(
+        src, dst,
+        src_transform=srcaff,
+        src_crs=srccrs,
+        dst_transform=dstaff,
+        dst_crs=dstcrs,
+        resampling=Resampling.nearest)
 
     # note the affines are both positive e, dst is identity
     src = np.random.random(100).reshape((1, 10, 10))
@@ -990,14 +971,13 @@ def test_reproject_identity():
     dstaff = Affine(1.0, 0.0, 0.0, 0.0, 1.0, 0.0)  # Identity
     dstcrs = {'init': 'epsg:3857'}
 
-    with rasterio.Env():
-        reproject(
-            src, dst,
-            src_transform=srcaff,
-            src_crs=srccrs,
-            dst_transform=dstaff,
-            dst_crs=dstcrs,
-            resampling=Resampling.nearest)
+    reproject(
+        src, dst,
+        src_transform=srcaff,
+        src_crs=srccrs,
+        dst_transform=dstaff,
+        dst_crs=dstcrs,
+        resampling=Resampling.nearest)
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 
-import rasterio
 from rasterio._warp import _calculate_default_transform
 from rasterio.control import GroundControlPoint
 from rasterio.errors import CRSError
@@ -34,9 +33,8 @@ def test_identity():
         5009377.085697309)
     transform = from_bounds(left, bottom, right, top, width, height)
 
-    with rasterio.Env():
-        res_transform, res_width, res_height = _calculate_default_transform(
-            src_crs, dst_crs, width, height, left, bottom, right, top)
+    res_transform, res_width, res_height = _calculate_default_transform(
+        src_crs, dst_crs, width, height, left, bottom, right, top)
 
     assert res_width == width
     assert res_height == height
@@ -84,16 +82,15 @@ def test_transform_bounds():
 
 
 def test_gdal_transform_notnull():
-    with rasterio.Env():
-        dt, dw, dh = _calculate_default_transform(
-            src_crs={'init': 'EPSG:4326'},
-            dst_crs={'init': 'EPSG:32610'},
-            width=80,
-            height=80,
-            left=-120,
-            bottom=30,
-            right=-80,
-            top=70)
+    dt, dw, dh = _calculate_default_transform(
+        src_crs={'init': 'EPSG:4326'},
+        dst_crs={'init': 'EPSG:32610'},
+        width=80,
+        height=80,
+        left=-120,
+        bottom=30,
+        right=-80,
+        top=70)
     assert True
 
 
@@ -127,17 +124,16 @@ def test_gdal_transform_fail_src_crs():
     os.environ.get('GDALVERSION', 'a.b.c').startswith('1.9'),
     reason="GDAL 1.9 doesn't catch this error")
 def test_gdal_transform_fail_dst_crs_xfail():
-    with rasterio.Env():
-        with pytest.raises(CRSError):
-            dt, dw, dh = _calculate_default_transform(
-                {'init': 'EPSG:4326'},
-                {'proj': 'foobar'},
-                width=80,
-                height=80,
-                left=-120,
-                bottom=30,
-                right=-80,
-                top=70)
+    with pytest.raises(CRSError):
+        dt, dw, dh = _calculate_default_transform(
+            {'init': 'EPSG:4326'},
+            {'proj': 'foobar'},
+            width=80,
+            height=80,
+            left=-120,
+            bottom=30,
+            right=-80,
+            top=70)
 
 
 def test_gcps_calculate_transform():


### PR DESCRIPTION
For https://github.com/mapbox/rasterio/issues/1009

As referenced in https://github.com/mapbox/rasterio/issues/1009#issuecomment-293443234.

I also switched the test responsible for writing `test.tif` to the current directory to pytest's `tmpdir` fixture.