### PR TITLE
Fixed broken image URLs 

### DIFF
--- a/docs/topics/masking-by-shapefile.rst
+++ b/docs/topics/masking-by-shapefile.rst
@@ -22,7 +22,7 @@ This shapefile contains a single polygon, a box near the center of the raster, s
 
 Using ``plot`` and ``imshow`` from ``matplotlib``, we can see the region defined by the shapefile in red overlaid on the original raster.
 
-.. image:: img/box_rgb.png
+.. image:: ../img/box_rgb.png
 
 Applying the features in the shapefile as a mask on the raster sets all pixels outside of the features to be zero. Since ``crop=True`` in this example, the extent of the raster is also set to be the extent of the features in the shapefile. We can then use the updated spatial transform and raster height and width to write the masked raster to a new file.
 
@@ -35,4 +35,4 @@ Applying the features in the shapefile as a mask on the raster sets all pixels o
         with rasterio.open("RGB.byte.masked.tif", "w", **out_meta) as dest:
             dest.write(out_image) 
 
-.. image:: img/box_masked_rgb.png
+.. image:: ../img/box_masked_rgb.png

--- a/docs/topics/masks.rst
+++ b/docs/topics/masks.rst
@@ -80,7 +80,7 @@ array shows the ``255`` values that indicate *valid data* regions.
 
 Displayed using Matplotlib's `imshow()`, the mask looks like this:
 
-.. image:: img/mask_band.png
+.. image:: ../img/mask_band.png
 
 Wait, what are these 0 values in the mask interior? This is an example of
 a problem inherent in 8-bit raster data: lack of dynamic range. The dataset
@@ -147,7 +147,7 @@ as an RGB image (with the help of `numpy.dstack()`):
     >>> msk = src.read_masks()
     >>> show(np.dstack(msk))  # doctest: +SKIP
 
-.. image:: img/mask_bands_rgb.png
+.. image:: ../img/mask_bands_rgb.png
 
 Colored regions appear where valid data pixels don't quite coincide. This is,
 again, an artifact of scaling data down to 8 bits per band. We'll begin by
@@ -159,7 +159,7 @@ masks we've read.
     >>> new_msk = (msk[0] & msk[1] & msk[2])
     >>> show(new_msk)  # doctest: +SKIP
 
-.. image:: img/mask_conj.png
+.. image:: ../img/mask_conj.png
 
 Now we'll use `sieve()` to shake out the small buggy regions of the mask. I've
 found the right value for the ``size`` argument empirically.
@@ -170,7 +170,7 @@ found the right value for the ``size`` argument empirically.
     >>> sieved_msk = sieve(new_msk, size=800)
     >>> show(sieved_msk)  # doctest: +SKIP
 
-.. image:: img/mask_sieved.png
+.. image:: ../img/mask_sieved.png
 
 Last thing to do is write that sieved mask back to the dataset.
 

--- a/docs/topics/plotting.rst
+++ b/docs/topics/plotting.rst
@@ -40,7 +40,7 @@ you can pass in a transform in order to get extent labels.
     <matplotlib.axes._subplots.AxesSubplot object at 0x...>
 
 
-.. image:: img/rgb.jpg
+.. image:: ../img/rgb.jpg
 
 and similarly for single band plots. Note that you can pass in ``cmap`` to
 specify a matplotlib color ramp. Any kwargs passed to ``show`` will passed
@@ -54,7 +54,7 @@ through to the underlying pyplot functions.
     <matplotlib.axes._subplots.AxesSubplot object at 0x...>
 
 
-.. image:: img/singleband.jpg
+.. image:: ../img/singleband.jpg
 
 You can create a figure with multiple subplots by passing the ``show(..., ax=ax1)``
 argument. Also note that this example demonstrates setting the overall figure size
@@ -73,7 +73,7 @@ and sets a title for each subplot.
     >>> pyplot.show()
 
 
-.. image:: img/subplots.jpg
+.. image:: ../img/subplots.jpg
 
 For single-band rasters, there is also an option to generate contours.
 
@@ -86,7 +86,7 @@ For single-band rasters, there is also an option to generate contours.
     <matplotlib.axes._subplots.AxesSubplot object at 0x...>
     >>> pyplot.show()
 
-.. image:: img/contours.jpg
+.. image:: ../img/contours.jpg
 
 Rasterio also provides a ``plot.show_hist`` function for generating histograms of
 single or multiband rasters:
@@ -99,7 +99,7 @@ single or multiband rasters:
     ...     histtype='stepfilled', title="Histogram")
 
 
-.. image:: img/hist.jpg
+.. image:: ../img/hist.jpg
 
 The ``show_hist`` function also takes an ``ax`` argument to allow subplot configurations
 
@@ -112,4 +112,4 @@ The ``show_hist`` function also takes an ``ax`` argument to allow subplot config
     ...           lw=0.0, stacked=False, alpha=0.3, ax=axhist)
     >>> pyplot.show()
 
-.. image:: img/rgb_hist.jpg
+.. image:: ../img/rgb_hist.jpg


### PR DESCRIPTION

Ref. Issue #1017 

Fixed images in the following files:
- masks.rst
- masking-by-shapefile.rst
- plotting.rst