### PR TITLE
Actually keep track of whether or not the drivers are registered

### DIFF
--- a/rasterio/_env.pxd
+++ b/rasterio/_env.pxd
@@ -3,4 +3,4 @@ cdef class ConfigEnv(object):
 
 
 cdef class GDALEnv(ConfigEnv):
-    cdef object _have_registered_drivers
+    cdef public object _have_registered_drivers

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -206,7 +206,11 @@ cdef class GDALEnv(ConfigEnv):
                         log.debug("Error handler popped")
                         raise ValueError("Drivers not registered.")
 
-                    self._have_registered_drivers
+                    # Flag the drivers as registered, otherwise every thread
+                    # will acquire a threadlock every time a new environment
+                    # is started rather than just whenever the first thread
+                    # actually makes it this far.
+                    self._have_registered_drivers = True
 
         log.debug("Started GDALEnv %r.", self)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -332,3 +332,10 @@ def test_env_discovery(key, val):
     # for other tests.
     finally:
         del_gdal_config(key)
+
+
+def test_have_registered_drivers():
+    """Ensure drivers are only registered once, otherwise each thread will
+    acquire a threadlock whenever an environment is started."""
+    with rasterio.Env():
+        assert rasterio.env.local._env._have_registered_drivers


### PR DESCRIPTION
Otherwise we pay penance to the thread lock gods every time an environment is started.  This slipped through https://github.com/mapbox/rasterio/pull/997.