### PR TITLE
Avoid generating shapes w/ 0-dimension

### DIFF
--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -1,7 +1,10 @@
 """$ rio shapes"""
 
+from __future__ import division
+
 
 import logging
+import math
 import os
 
 import click
@@ -136,6 +139,8 @@ def shapes(
                         src.width % sampling, src.height % sampling)
                     # And follow by scaling.
                     transform *= Affine.scale(float(sampling))
+                    shape = (int(math.ceil(src.height / sampling)),
+                             int(math.ceil(src.width / sampling)))
 
                 # Most of the time, we'll use the valid data mask.
                 # We skip reading it if we're extracting every possible
@@ -144,8 +149,7 @@ def shapes(
                     if sampling == 1:
                         msk = src.read_masks(bidx)
                     else:
-                        msk_shape = (
-                            src.height // sampling, src.width // sampling)
+                        msk_shape = shape
                         if bidx is None:
                             msk = np.zeros(
                                 (src.count,) + msk_shape, 'uint8')
@@ -165,7 +169,7 @@ def shapes(
                         img = src.read(bidx, masked=False)
                     else:
                         img = np.zeros(
-                            (src.height // sampling, src.width // sampling),
+                            shape,
                             dtype=src.dtypes[src.indexes.index(bidx)])
                         img = src.read(bidx, img, masked=False)
 

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -147,8 +147,7 @@ def shapes(
                         src.width % x_sampling, src.height % y_sampling)
 
                     # And follow by scaling.
-                    transform *= Affine(
-                        shape[1] / src.width, shape[0] / src.height)
+                    transform *= Affine.scale(x_sampling, y_sampling)
 
                 # Most of the time, we'll use the valid data mask.
                 # We skip reading it if we're extracting every possible

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -133,14 +133,22 @@ def shapes(
                 # Adjust transforms.
                 transform = src.transform
                 if sampling > 1:
+                    # Determine the target shape (to decimate)
+                    shape = (int(math.ceil(src.height / sampling)),
+                             int(math.ceil(src.width / sampling)))
+
+                    # Calculate independent sampling factors
+                    x_sampling = src.width / shape[1]
+                    y_sampling = src.height / shape[0]
+
                     # Decimation of the raster produces a georeferencing
                     # shift that we correct with a translation.
                     transform *= Affine.translation(
-                        src.width % sampling, src.height % sampling)
+                        src.width % x_sampling, src.height % y_sampling)
+
                     # And follow by scaling.
-                    transform *= Affine.scale(float(sampling))
-                    shape = (int(math.ceil(src.height / sampling)),
-                             int(math.ceil(src.width / sampling)))
+                    transform *= Affine(
+                        shape[1] / src.width, shape[0] / src.height)
 
                 # Most of the time, we'll use the valid data mask.
                 # We skip reading it if we're extracting every possible


### PR DESCRIPTION
This could previously occur when one or more dimensions was smaller than the sampling factor (e.g. 4800, 1).

```
ERROR:rasterio._gdal:CPLE_AppDefined in Attempt to create 48x0 dataset is illegal,sizes must be larger than zero.
ERROR:rio:Exception caught during processing
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/rasterio/rio/shapes.py", line 229, in shapes
    **dump_kwds)
  File "/usr/local/lib/python2.7/dist-packages/rasterio/rio/helpers.py", line 55, in write_features
    features = list(collection())
  File "/usr/local/lib/python2.7/dist-packages/rasterio/rio/shapes.py", line 205, in __call__
    rasterio.features.shapes(img, **kwargs)):
  File "/usr/local/lib/python2.7/dist-packages/rasterio/features.py", line 100, in shapes
    for s, v in _shapes(image, mask, connectivity, transform.to_gdal()):
  File "rasterio/_features.pyx", line 77, in _shapes (rasterio/_features.c:3196)
  File "rasterio/_io.pyx", line 1586, in rasterio._io.InMemoryRaster.__cinit__ (rasterio/_io.c:27007)
  File "rasterio/_err.pyx", line 189, in rasterio._err.exc_wrap_pointer (rasterio/_err.c:2203)
CPLE_AppDefinedError: Attempt to create 48x0 dataset is illegal,sizes must be larger than zero.
```