### PR TITLE
Switch OSRDestroySpatialReference to OSRRelease

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -241,7 +241,7 @@ cdef class DatasetBase(object):
                     crs[k] = v
 
             CPLFree(proj)
-            OSRDestroySpatialReference(osr)
+            OSRRelease(osr)
         else:
             log.debug("No projection detected.")
 
@@ -910,8 +910,8 @@ def _transform(src_crs, dst_crs, xs, ys, zs):
         CPLFree(x)
         CPLFree(y)
         CPLFree(z)
-        OSRDestroySpatialReference(src)
-        OSRDestroySpatialReference(dst)
+        OSRRelease(src)
+        OSRRelease(dst)
 
     return retval
 
@@ -936,7 +936,7 @@ cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL:
             auth, val = init.split(':')
 
             if not val:
-                OSRDestroySpatialReference(osr)
+                OSRRelease(osr)
                 raise CRSError("Invalid CRS: {!r}".format(crs))
 
             if auth.upper() == 'EPSG':
@@ -957,7 +957,7 @@ cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL:
     log.debug("OSRSetFromUserInput return value: %s", retval)
 
     if retval:
-        OSRDestroySpatialReference(osr)
+        OSRRelease(osr)
         raise CRSError("Invalid CRS: {!r}".format(crs))
 
     return osr
@@ -995,5 +995,5 @@ def _can_create_osr(crs):
         return False
 
     finally:
-        OSRDestroySpatialReference(osr)
+        OSRRelease(osr)
         CPLFree(wkt)

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -27,7 +27,7 @@ class _CRS(UserDict):
             retval = OSRIsGeographic(osr_crs)
             return bool(retval == 1)
         finally:
-            OSRDestroySpatialReference(osr_crs)
+            OSRRelease(osr_crs)
 
     @property
     def is_projected(self):
@@ -39,7 +39,7 @@ class _CRS(UserDict):
             retval = OSRIsProjected(osr_crs)
             return bool(retval == 1)
         finally:
-            OSRDestroySpatialReference(osr_crs)
+            OSRRelease(osr_crs)
 
     def __eq__(self, other):
         cdef OGRSpatialReferenceH osr_crs1 = NULL
@@ -55,8 +55,8 @@ class _CRS(UserDict):
             retval = OSRIsSame(osr_crs1, osr_crs2)
             return bool(retval == 1)
         finally:
-            OSRDestroySpatialReference(osr_crs1)
-            OSRDestroySpatialReference(osr_crs2)
+            OSRRelease(osr_crs1)
+            OSRRelease(osr_crs2)
 
     @property
     def wkt(self):
@@ -72,4 +72,4 @@ class _CRS(UserDict):
             return srcwkt.decode('utf-8')
         finally:
             CPLFree(srcwkt)
-            OSRDestroySpatialReference(osr)
+            OSRRelease(osr)

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1101,7 +1101,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         GDALSetProjection(self._hds, wkt)
 
         CPLFree(wkt)
-        OSRDestroySpatialReference(osr)
+        OSRRelease(osr)
         self._crs = crs
         log.debug("Self CRS: %r", self._crs)
 
@@ -1598,7 +1598,7 @@ cdef class InMemoryRaster:
                 GDALSetProjection(self._hds, srcwkt)
                 log.debug("Set CRS on temp source dataset: %s", srcwkt)
                 CPLFree(<void *>srcwkt)
-                OSRDestroySpatialReference(osr)
+                OSRRelease(osr)
 
         elif gcps and crs:
             gcplist = <GDAL_GCP *>CPLMalloc(len(gcps) * sizeof(GDAL_GCP))

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -55,8 +55,8 @@ def _transform_geom(
     try:
         transform = exc_wrap_pointer(OCTNewCoordinateTransformation(src, dst))
     except:
-        OSRDestroySpatialReference(src)
-        OSRDestroySpatialReference(dst)
+        OSRRelease(src)
+        OSRRelease(dst)
         raise
 
     # Transform options.
@@ -90,8 +90,8 @@ def _transform_geom(
         OCTDestroyCoordinateTransformation(transform)
         if options != NULL:
             CSLDestroy(options)
-        OSRDestroySpatialReference(src)
-        OSRDestroySpatialReference(dst)
+        OSRRelease(src)
+        OSRRelease(dst)
 
 
 def _reproject(
@@ -128,7 +128,7 @@ def _reproject(
         Source affine transformation.  Required if source and destination
         are ndarrays.  Will be derived from source if it is a rasterio Band.
     gcps: sequence of `GroundControlPoint` instances, optional
-        Ground control points for the source. May be used in place of 
+        Ground control points for the source. May be used in place of
         src_transform.
     src_crs: dict, optional
         Source coordinate reference system, in rasterio dict format.
@@ -240,7 +240,7 @@ def _reproject(
                 log.debug("Set CRS on temp source dataset: %s", srcwkt)
             finally:
                 CPLFree(srcwkt)
-                OSRDestroySpatialReference(osr)
+                OSRRelease(osr)
 
         elif gcps:
             gcplist = <GDAL_GCP *>CPLMalloc(len(gcps) * sizeof(GDAL_GCP))
@@ -323,7 +323,7 @@ def _reproject(
                     dst_dataset, dstwkt):
                 raise ("Failed to set projection on temp destination dataset.")
         finally:
-            OSRDestroySpatialReference(osr)
+            OSRRelease(osr)
             CPLFree(dstwkt)
 
         retval = io_auto(destination, dst_dataset, 1)
@@ -543,7 +543,7 @@ def _calculate_default_transform(src_crs, dst_crs, width, height,
 
     osr = osr_from_crs(dst_crs)
     OSRExportToWkt(osr, &wkt)
-    OSRDestroySpatialReference(osr)
+    OSRRelease(osr)
 
     with InMemoryRaster(width=width, height=height, transform=transform,
                         gcps=gcps, crs=src_crs) as temp:

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -83,7 +83,6 @@ cdef extern from "ogr_srs_api.h" nogil:
     int OSRAutoIdentifyEPSG(OGRSpatialReferenceH srs)
     void OSRCleanup()
     OGRSpatialReferenceH OSRClone(OGRSpatialReferenceH srs)
-    void OSRDestroySpatialReference(OGRSpatialReferenceH srs)
     int OSRExportToProj4(OGRSpatialReferenceH srs, char **params)
     int OSRExportToWkt(OGRSpatialReferenceH srs, char **params)
     int OSRFixup(OGRSpatialReferenceH srs)


### PR DESCRIPTION
Per issue #1021, `OSRRelease()` is safer.