### PR TITLE
Fix dtype check in dataset write

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -960,13 +960,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             # Find the equivalent GDAL data type or raise an exception
             # We've mapped numpy scalar types to GDAL types so see
             # if we can crosswalk those.
-            if hasattr(self._init_dtype, 'type'):
-                tp = self._init_dtype.type
-                if tp not in dtypes.dtype_rev:
-                    raise ValueError(
-                        "Unsupported dtype: %s" % self._init_dtype)
-                else:
-                    gdal_dtype = dtypes.dtype_rev.get(tp)
+            if self._init_dtype not in dtypes.dtype_rev:
+                raise TypeError(
+                    "Unsupported dtype: %s" % self._init_dtype)
             else:
                 gdal_dtype = dtypes.dtype_rev.get(self._init_dtype)
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -33,6 +33,16 @@ def test_validate_dtype_str(tmpdir):
             dtype='Int16')
 
 
+def test_validate_dtype_int8(tmpdir, basic_image):
+    """Raise TypeError if dtype is unsupported by GDAL."""
+    name = str(tmpdir.join('int8.tif'))
+    basic_image_int8 = basic_image.astype('int8')
+    height, width = basic_image_int8.shape
+    with pytest.raises(TypeError):
+        rasterio.open(name, 'w', driver='GTiff', width=width, height=height,
+                      count=1, dtype=basic_image_int8.dtype)
+
+
 def test_validate_count_None(tmpdir):
     name = str(tmpdir.join("lol.tif"))
     with pytest.raises(TypeError):


### PR DESCRIPTION
It looks like the previously implemented data type check was not ever
being entered, due to checking for a 'type' attribute on a string. Since
the _init_dtype attribute is now always a string, remove this check and
related handling, so that now dtypes are checked for validity, providing
a more useful error message in case of an invalid dtype. Fixes #1008.