### PR TITLE
Set GDAL config options before driver registration

### DIFF
--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -39,7 +39,7 @@ code_map = {
     9: 'CPLE_UserInterrupt',
     10: 'ObjectNull',
 
-    # error numbers 11-16 are introduced in GDAL 2.1. See 
+    # error numbers 11-16 are introduced in GDAL 2.1. See
     # https://github.com/OSGeo/gdal/pull/98.
     11: 'CPLE_HttpResponse',
     12: 'CPLE_AWSBucketNotFound',
@@ -144,7 +144,7 @@ cdef class ConfigEnv(object):
     """Configuration option management"""
 
     def __init__(self, **options):
-        self.options = {}
+        self.options = options.copy()
         self.update_config_options(**self.options)
 
     def update_config_options(self, **kwargs):

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -188,12 +188,12 @@ class Env(object):
                     local._discovered_options[key] = val
                     log.debug("Discovered option: %s=%s", key, val)
 
-            defenv()
+            defenv(**self.options)
             self.context_options = {}
         else:
             self._has_parent_env = True
             self.context_options = getenv()
-        setenv(**self.options)
+            setenv(**self.options)
         log.debug("Entered env context: %r", self)
         return self
 
@@ -216,14 +216,19 @@ class Env(object):
         log.debug("Exited env context: %r", self)
 
 
-def defenv():
+def defenv(**options):
     """Create a default environment if necessary."""
     if local._env:
         log.debug("GDAL environment exists: %r", local._env)
     else:
         log.debug("No GDAL environment exists")
         local._env = GDALEnv()
-        local._env.update_config_options(**default_options)
+        # first set default options, then add user options
+        set_options = {}
+        for d in (default_options, options):
+            for (k, v) in d.items():
+                set_options[k] = v
+        local._env.update_config_options(**set_options)
         log.debug(
             "New GDAL environment %r created", local._env)
     local._env.start()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -12,7 +12,7 @@ import rasterio
 from rasterio._env import del_gdal_config, get_gdal_config, set_gdal_config
 from rasterio.env import defenv, delenv, getenv, setenv, ensure_env
 from rasterio.env import default_options
-from rasterio.errors import EnvError
+from rasterio.errors import EnvError, RasterioIOError
 from rasterio.rio.main import main_group
 
 
@@ -200,6 +200,13 @@ def test_open_with_env(gdalenv):
     with rasterio.Env():
         with rasterio.open('tests/data/RGB.byte.tif') as dataset:
             assert dataset.count == 3
+
+
+def test_skip_gtiff(gdalenv):
+    """De-register GTiff driver, verify that it will not be used."""
+    with rasterio.Env(GDAL_SKIP='GTiff'):
+        with pytest.raises(RasterioIOError):
+            rasterio.open('tests/data/RGB.byte.tif')
 
 
 @mingdalversion


### PR DESCRIPTION
When setting up an environment, pass in user provided options during the
original environment definition (and driver registration), rather than
defining the environment, and then defining potential driver related
configuration options too late to use them.

I think this addresses #1000 and #1001. At the very least, I was able to
override the default JP2 driver options in a rasterio environment on the
command line on my computer. There are certainly some subtleties
in this process with which I'm not familiar though. I also was not quite
sure what a test of this should look like. The most immediate hurdle was 
my uncertainty in whether there were particular drivers that would be
reasonable to test in a platform independent manner. I didn't see much 
in `test_env` that provided immediate guidance. 