### PR TITLE
Use np.zeros instead of np.empty in read()

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1,8 +1,8 @@
-# cython: boundscheck=False
 """Rasterio input/output."""
 
 from __future__ import absolute_import
 
+include "directives.pxi"
 include "gdal.pxi"
 
 import logging
@@ -90,7 +90,8 @@ cdef int io_auto(data, GDALRasterBandH band, bint write, int resampling=0):
 cdef class DatasetReaderBase(DatasetBase):
 
     def read(self, indexes=None, out=None, window=None, masked=False,
-            out_shape=None, boundless=False, resampling=Resampling.nearest):
+            out_shape=None, boundless=False, resampling=Resampling.nearest,
+            fill_value=None):
         """Read raster bands as a multidimensional array
 
         Parameters
@@ -135,6 +136,9 @@ cdef class DatasetReaderBase(DatasetBase):
             are permitted and partially or completely filled arrays will
             be returned as appropriate.
 
+        fill_value : scalar
+            Fill value applied in the `boundless=True` case only.
+
         Returns
         -------
         Numpy ndarray or a view on a Numpy ndarray
@@ -169,10 +173,17 @@ cdef class DatasetReaderBase(DatasetBase):
             check_dtypes.add(dtype)
 
             ndv = self._nodatavals[idx]
+
+            log.debug("Output nodata value read from file: %r", ndv)
+
             # Change given nodatavals to the closest value that
             # can be represented by this band's data type to
             # match GDAL's strategy.
-            if ndv is not None:
+            if fill_value:
+                ndv = fill_value
+                log.debug("Output nodata value set from fill value")
+
+            elif ndv is not None:
                 if np.dtype(dtype).kind in ('i', 'u'):
                     info = np.iinfo(dtype)
                     dt_min, dt_max = info.min, info.max
@@ -187,6 +198,8 @@ cdef class DatasetReaderBase(DatasetBase):
                     ndv = dt_max
 
             nodatavals.append(ndv)
+
+        log.debug("Output nodata values: %r", nodatavals)
 
         # Mixed dtype reads are not supported at this time.
         if len(check_dtypes) > 1:
@@ -214,12 +227,9 @@ cdef class DatasetReaderBase(DatasetBase):
 
         if out is not None and out_shape is not None:
             raise ValueError("out and out_shape are exclusive")
-        elif out_shape is not None:
-            if len(out_shape) == 2:
-                out_shape = (1,) + out_shape
-            out = np.empty(out_shape, dtype=dtype)
 
-        if out is not None:
+        # `out` takes precedence over `out_shape`.
+        elif out is not None:
             if out.dtype != dtype:
                 raise ValueError(
                     "the array's dtype '%s' does not match "
@@ -228,6 +238,23 @@ cdef class DatasetReaderBase(DatasetBase):
                 raise ValueError(
                     "'out' shape %s does not match window shape %s" %
                     (out.shape, win_shape))
+
+        else:
+            if out_shape is not None:
+                if len(out_shape) == 2:
+                    out_shape = (1,) + out_shape
+            else:
+                out_shape = win_shape
+
+            # We're filling in both the bounded and boundless cases.
+            # TODO: profile and see if we should avoid this in the
+            # bounded case.
+            out = np.zeros(out_shape, dtype=dtype)
+            for i, (ndv, arr) in enumerate(zip(
+                    nodatavals, out if len(out.shape) == 3 else [out])):
+
+                if ndv is not None:
+                    arr.fill(ndv)
 
         # Masking
         # -------
@@ -245,13 +272,6 @@ cdef class DatasetReaderBase(DatasetBase):
             log.debug("all_valid: %s", all_valid)
             log.debug("mask_flags: %r", enums)
 
-        if out is None:
-            out = np.zeros(win_shape, dtype)
-            for ndv, arr in zip(
-                    nodatavals, out if len(out.shape) == 3 else [out]):
-                if ndv is not None:
-                    arr.fill(ndv)
-
         # We can jump straight to _read() in some cases. We can ignore
         # the boundless flag if there's no given window.
         if not boundless or not window:
@@ -262,7 +282,7 @@ cdef class DatasetReaderBase(DatasetBase):
                 if all_valid:
                     mask = np.ma.nomask
                 else:
-                    mask = np.empty(out.shape, 'uint8')
+                    mask = np.zeros(out.shape, 'uint8')
                     mask = ~self._read(
                         indexes, mask, window, 'uint8', masks=True,
                         resampling=resampling).astype('bool')
@@ -293,12 +313,12 @@ cdef class DatasetReaderBase(DatasetBase):
                 buffer_shape = (
                         int(round(overlap_h*scaling_h)),
                         int(round(overlap_w*scaling_w)))
-                data = np.empty(win_shape[:-2] + buffer_shape, dtype)
+                data = np.zeros(win_shape[:-2] + buffer_shape, dtype)
                 data = self._read(indexes, data, overlap, dtype,
                                   resampling=resampling)
 
                 if masked:
-                    mask = np.empty(win_shape[:-2] + buffer_shape, 'uint8')
+                    mask = np.zeros(win_shape[:-2] + buffer_shape, 'uint8')
                     mask = ~self._read(
                         indexes, mask, overlap, 'uint8', masks=True,
                         resampling=resampling).astype('bool')
@@ -472,7 +492,7 @@ cdef class DatasetReaderBase(DatasetBase):
                 scaling_h = float(out.shape[-2:][0])/window_h
                 scaling_w = float(out.shape[-2:][1])/window_w
                 buffer_shape = (int(overlap_h*scaling_h), int(overlap_w*scaling_w))
-                data = np.empty(win_shape[:-2] + buffer_shape, 'uint8')
+                data = np.zeros(win_shape[:-2] + buffer_shape, 'uint8')
                 data = self._read(indexes, data, overlap, dtype, masks=True,
                                   resampling=resampling)
             else:
@@ -645,7 +665,7 @@ cdef class DatasetReaderBase(DatasetBase):
                 window
                 and windows.shape(window, self.height, self.width)
                 or self.shape)
-            out = np.empty(out_shape, np.uint8)
+            out = np.zeros(out_shape, np.uint8)
         if window:
             window = windows.evaluate(window, self.height, self.width)
             yoff = window[0][0]

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -102,18 +102,22 @@ cdef class DatasetReaderBase(DatasetBase):
 
         out : numpy ndarray, optional
             As with Numpy ufuncs, this is an optional reference to an
-            output array with the same dimensions and shape into which
-            data will be placed.
+            output array into which data will be placed. If the height
+            and width of `out` differ from that of the specified 
+            window (see below), the raster image will be decimated or
+            replicated using the specified resampling method (also see
+            below).
 
             *Note*: the method's return value may be a view on this
             array. In other words, `out` is likely to be an
             incomplete representation of the method's results.
 
-            Cannot combined with `out_shape`.
+            This parameter cannot be combined with `out_shape`.
 
         out_shape : tuple, optional
-            A tuple describing the output array's shape.  Allows for decimated
-            reads without constructing an output Numpy array.
+            A tuple describing the shape of a new output array. See
+            `out` (above) for notes on image decimation and
+            replication.
 
             Cannot combined with `out`.
 
@@ -249,7 +253,12 @@ cdef class DatasetReaderBase(DatasetBase):
             # We're filling in both the bounded and boundless cases.
             # TODO: profile and see if we should avoid this in the
             # bounded case.
-            out = np.zeros(out_shape, dtype=dtype)
+
+            if boundless:
+                out = np.zeros(out_shape, dtype=dtype)
+            else:
+                out = np.empty(out_shape, dtype=dtype)
+
             for i, (ndv, arr) in enumerate(zip(
                     nodatavals, out if len(out.shape) == 3 else [out])):
 

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -1,4 +1,4 @@
-# cython: boundscheck=False
+include "directives.pxi"
 
 # The baseline GDAL API.
 include "gdal.pxi"

--- a/rasterio/_shim21.pyx
+++ b/rasterio/_shim21.pyx
@@ -1,4 +1,4 @@
-# cython: boundscheck=False
+include "directives.pxi"
 
 # The baseline GDAL API.
 include "gdal.pxi"

--- a/rasterio/directives.pxi
+++ b/rasterio/directives.pxi
@@ -1,0 +1,1 @@
+# cython: boundscheck=False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ import pytest
 import numpy as np
 
 from rasterio.crs import CRS
+import rasterio
+
 
 DEFAULT_SHAPE = (10, 10)
 

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -19,10 +19,21 @@ def test_read_boundless_natural_extent():
 
 
 def test_read_boundless_beyond():
+    """Reading entirely outside the dataset returns no data"""
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         data = src.read(window=((-200, -100), (-200, -100)), boundless=True)
         assert data.shape == (3, 100, 100)
         assert not data.any()
+        assert (data == 0).all()
+
+
+def test_read_boundless_beyond_fill_value():
+    """Reading entirely outside the dataset returns the fill value"""
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        data = src.read(window=((-200, -100), (-200, -100)), boundless=True,
+                        fill_value=1)
+        assert data.shape == (3, 100, 100)
+        assert (data == 1).all()
 
 
 def test_read_boundless_beyond2():
@@ -85,6 +96,7 @@ def test_read_boundless_masks_zero_stop():
         data = src.read_masks(window=((-200, 0), (-200, 0)), boundless=True)
         assert data.shape == (3, 200, 200)
         assert data.min() == data.max() == src.nodata
+
 
 def test_read_boundless_noshift():
     with rasterio.open('tests/data/rgb4.tif') as src:

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -10,49 +10,68 @@ import rasterio
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def test_read_boundless_natural_extent():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+@pytest.fixture(scope='session')
+def rgb_array(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as src:
+        return src.read()
+
+
+@pytest.fixture(scope='function')
+def rgb_byte_tif_reader(path_rgb_byte_tif):
+    return rasterio.open(path_rgb_byte_tif)
+
+
+def test_read_boundless_false(rgb_byte_tif_reader, rgb_array):
+    """Reading natural window with boundless=False works"""
+    with rgb_byte_tif_reader as src:
+        data = src.read(boundless=False)
+        assert data.shape == rgb_array.shape
+        assert data.sum() == rgb_array.sum()
+
+
+def test_read_boundless_natural_extent(rgb_byte_tif_reader, rgb_array):
+    """Reading natural window with boundless=True works"""
+    with rgb_byte_tif_reader as src:
         data = src.read(boundless=True)
-        assert data.shape == (3, src.height, src.width)
-        assert abs(data[0].mean() - src.read(1).mean()) < 0.0001
-        assert data.any()
+        assert data.shape == rgb_array.shape
+        assert data.sum() == rgb_array.sum()
 
 
-def test_read_boundless_beyond():
+def test_read_boundless_beyond(rgb_byte_tif_reader):
     """Reading entirely outside the dataset returns no data"""
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+    with rgb_byte_tif_reader as src:
         data = src.read(window=((-200, -100), (-200, -100)), boundless=True)
         assert data.shape == (3, 100, 100)
         assert not data.any()
         assert (data == 0).all()
 
 
-def test_read_boundless_beyond_fill_value():
+def test_read_boundless_beyond_fill_value(rgb_byte_tif_reader):
     """Reading entirely outside the dataset returns the fill value"""
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+    with rgb_byte_tif_reader as src:
         data = src.read(window=((-200, -100), (-200, -100)), boundless=True,
                         fill_value=1)
         assert data.shape == (3, 100, 100)
         assert (data == 1).all()
 
 
-def test_read_boundless_beyond2():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_read_boundless_beyond2(rgb_byte_tif_reader):
+    with rgb_byte_tif_reader as src:
         data = src.read(window=((1000, 1100), (1000, 1100)), boundless=True)
         assert data.shape == (3, 100, 100)
         assert not data.any()
 
 
-def test_read_boundless_overlap():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_read_boundless_overlap(rgb_byte_tif_reader):
+    with rgb_byte_tif_reader as src:
         data = src.read(window=((-200, 200), (-200, 200)), boundless=True)
         assert data.shape == (3, 400, 400)
         assert data.any()
         assert data[0,399,399] == 13
 
 
-def test_read_boundless_resample():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_read_boundless_resample(rgb_byte_tif_reader):
+    with rgb_byte_tif_reader as src:
         out = np.zeros((3, 800, 800), dtype=np.uint8)
         data = src.read(
                 out=out,
@@ -64,16 +83,16 @@ def test_read_boundless_resample():
         assert data[0,798,798] == 13
 
 
-def test_read_boundless_masked_no_overlap():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_read_boundless_masked_no_overlap(rgb_byte_tif_reader):
+    with rgb_byte_tif_reader as src:
         data = src.read(
             window=((-200, -100), (-200, -100)), boundless=True, masked=True)
         assert data.shape == (3, 100, 100)
         assert data.mask.all()
 
 
-def test_read_boundless_masked_overlap():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_read_boundless_masked_overlap(rgb_byte_tif_reader):
+    with rgb_byte_tif_reader as src:
         data = src.read(
             window=((-200, 200), (-200, 200)), boundless=True, masked=True)
         assert data.shape == (3, 400, 400)
@@ -83,16 +102,16 @@ def test_read_boundless_masked_overlap():
         assert data.mask[0,0,0] == True
 
 
-def test_read_boundless_zero_stop():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_read_boundless_zero_stop(rgb_byte_tif_reader):
+    with rgb_byte_tif_reader as src:
         data = src.read(
             window=((-200, 0), (-200, 0)), boundless=True, masked=True)
         assert data.shape == (3, 200, 200)
         assert data.mask.all()
 
 
-def test_read_boundless_masks_zero_stop():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_read_boundless_masks_zero_stop(rgb_byte_tif_reader):
+    with rgb_byte_tif_reader as src:
         data = src.read_masks(window=((-200, 0), (-200, 0)), boundless=True)
         assert data.shape == (3, 200, 200)
         assert data.min() == data.max() == src.nodata
@@ -116,7 +135,7 @@ def test_read_boundless_noshift():
         assert np.array_equal(r1, r2)
 
 
-def test_np_warning(recwarn):
+def test_np_warning(recwarn, rgb_byte_tif_reader):
     """Ensure no deprecation warnings
     On np 1.11 and previous versions of rasterio you might see:
         VisibleDeprecationWarning: using a non-integer number
@@ -124,7 +143,7 @@ def test_np_warning(recwarn):
     """
     import warnings
     warnings.simplefilter('always')
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+    with rgb_byte_tif_reader as src:
         window = ((-10, 100), (-10, 100))
         src.read(1, window=window, boundless=True)
     assert len(recwarn) == 0


### PR DESCRIPTION
Resolves #1030.

Tests are forthcoming. As is a check that we can revert to `np.empty()` for bounded reads.