### PR TITLE
Special handling for GDAL_CACHEMAX

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Changes
 Next Release
 ------------
 
+New features:
+
+- Enable setting and getting `GDAL_CACHEMAX` (#1042).
+- Integer config option values are now properly encoded and decoded (#1042).
+
 Breaking changes:
 
 - Removed `**options` argument from `rasterio.warp.transform()`.  Transformer

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -80,7 +80,8 @@ def driver_count():
 
 
 cpdef get_gdal_config(key, normalize=True):
-    """Get the value of a GDAL configuration option
+    """Get the value of a GDAL configuration option.  When requesting
+    ``GDAL_CACHEMAX`` the value is returned unaltered. 
 
     Parameters
     ----------

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -236,8 +236,10 @@ cdef extern from "gdal.h" nogil:
     const GDAL_GCP *GDALGetGCPs(GDALDatasetH hDS)
     int GDALGetGCPCount(GDALDatasetH hDS)
     const char *GDALGetGCPProjection(GDALDatasetH hDS)
+    int GDALGetCacheMax()
+    void GDALSetCacheMax(int nBytes)
     GIntBig GDALGetCacheMax64()
-    void GDALSetCacheMax64(int nBytes)
+    void GDALSetCacheMax64(GIntBig nBytes)
 
 
 cdef extern from "ogr_api.h" nogil:

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -235,8 +235,8 @@ cdef extern from "gdal.h" nogil:
     const GDAL_GCP *GDALGetGCPs(GDALDatasetH hDS)
     int GDALGetGCPCount(GDALDatasetH hDS)
     const char *GDALGetGCPProjection(GDALDatasetH hDS)
-
-
+    int GDALGetCacheMax64()
+    void GDALSetCacheMax64(int nBytes)
 
 
 cdef extern from "ogr_api.h" nogil:

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -109,6 +109,7 @@ cdef extern from "gdal.h" nogil:
     ctypedef void * GDALAsyncReaderH
 
     ctypedef long long GSpacing
+    ctypedef unsigned long long GIntBig
 
     ctypedef enum GDALDataType:
         GDT_Unknown
@@ -235,7 +236,7 @@ cdef extern from "gdal.h" nogil:
     const GDAL_GCP *GDALGetGCPs(GDALDatasetH hDS)
     int GDALGetGCPCount(GDALDatasetH hDS)
     const char *GDALGetGCPProjection(GDALDatasetH hDS)
-    int GDALGetCacheMax64()
+    GIntBig GDALGetCacheMax64()
     void GDALSetCacheMax64(int nBytes)
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -87,8 +87,8 @@ def test_env_accessors(gdalenv):
     expected.update({'foo': '1', 'bar': '2'})
     assert getenv() == rasterio.env.local._env.options
     assert getenv() == expected
-    assert get_gdal_config('foo') == '1'
-    assert get_gdal_config('bar') == '2'
+    assert get_gdal_config('foo') == 1
+    assert get_gdal_config('bar') == 2
     delenv()
     with pytest.raises(EnvError):
         getenv()
@@ -339,3 +339,20 @@ def test_have_registered_drivers():
     acquire a threadlock whenever an environment is started."""
     with rasterio.Env():
         assert rasterio.env.local._env._have_registered_drivers
+
+
+def test_gdal_cachemax():
+    """``GDAL_CACHEMAX`` is a special case."""
+    original_cachemax = get_gdal_config('GDAL_CACHEMAX')
+    assert original_cachemax != 4321
+    # GDALSetCacheMax() has a limit of somewhere between 2 and 3 GB.
+    # We use GDALSetCacheMax64(), so use a value that is outside the 32 bit
+    # range to verify it is not being truncated.
+    set_gdal_config('GDAL_CACHEMAX', 4321)
+    assert get_gdal_config('GDAL_CACHEMAX', 4321) == 4321
+
+    # On first read the number will be in bytes.  Drop to MB if necessary.
+    try:
+        set_gdal_config('GDAL_CACHEMAX', original_cachemax)
+    except OverflowError:
+        set_gdal_config('GDAL_CACHEMAX', int(original_cachemax / 1000000))


### PR DESCRIPTION
Closes #875 

Looking at the [`osgeo` Python bindings](https://github.com/OSGeo/gdal/blob/trunk/gdal/swig/python/osgeo/gdal.py#L2934) it appears as though they use [`GDALGetCacheMax64()`](http://www.gdal.org/gdal_8h.html#ac06786652e940f0694cf214dfa08b74d).

A couple things:

1. When GDAL is compiled as 32 bit I don't know if `GDAL*CacheMax64()` is defined, but I'm also not sure how to check if an external object exists in a `pxi` file.  There's a check to see if Python is 64 bit, which the config option handlers use to determine with function to call.
2. The `GDALSetCacheMax*()` functions claim to support setting `GDAL_CACHEMAX` with a string like `4%`, but I couldn't get it to work in Rasterio or `osgeo`.  This suggests it is possible though: `GDAL_CACHEMAX=1% CPL_DEBUG=ON gdal_translate tests/data/RGB.byte.tif HUH.tif`
3. I also added normalization support for integer value encoding and decoding, and fixed a bug where integers would be cast to `ON`.