### PR TITLE
Choose the correct DatasetWriter in MemoryFile

### DIFF
--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -262,10 +262,11 @@ class MemoryFile(MemoryFileBase):
         if self.exists():
             s = DatasetReader(vsi_path, 'r+')
         else:
-            s = DatasetWriter(vsi_path, 'w', driver=driver, width=width,
-                              height=height, count=count, crs=crs,
-                              transform=transform, dtype=dtype,
-                              nodata=nodata, **kwargs)
+            writer = get_writer_for_driver(driver)
+            s = writer(vsi_path, 'w', driver=driver, width=width,
+                       height=height, count=count, crs=crs,
+                       transform=transform, dtype=dtype,
+                       nodata=nodata, **kwargs)
         s.start()
         return s
 


### PR DESCRIPTION
Context: I was trying to create an HGT file using a `MemoryFile` and discovered that it wasn't using `BufferedDatasetWriter` (which it should have given that `Create` isn't supported by `SRTMHGT`).