### PR TITLE
pytest warnings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ ghp-import
 numpy>=1.10
 snuggs>=1.2
 packaging
-pytest>=2.8.2
+pytest>=3.1.0
 pytest-cov>=2.2.0
 setuptools>=0.9.8
 wheel

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -7,6 +7,7 @@ import warnings
 
 from affine import Affine
 import numpy as np
+import pytest
 
 import rasterio
 from rasterio.crs import CRS
@@ -116,12 +117,13 @@ def test_mask_out_of_bounds(runner, tmpdir, basic_feature,
 
     output = str(tmpdir.join('test.tif'))
 
-    result = runner.invoke(
-        main_group,
-        ['mask', pixelated_image_file, output, '--geojson-mask', '-'],
-        input=json.dumps(basic_feature))
+    with pytest.warns(UserWarning) as warnings:
+        result = runner.invoke(
+            main_group,
+            ['mask', pixelated_image_file, output, '--geojson-mask', '-'],
+            input=json.dumps(basic_feature))
     assert result.exit_code == 0
-    assert 'outside bounds' in result.output
+    assert 'outside bounds' in warnings[1].message.args[0]
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -123,7 +123,7 @@ def test_mask_out_of_bounds(runner, tmpdir, basic_feature,
             ['mask', pixelated_image_file, output, '--geojson-mask', '-'],
             input=json.dumps(basic_feature))
     assert result.exit_code == 0
-    assert 'outside bounds' in warnings[1].message.args[0]
+    assert any(['outside bounds' in w.message.args[0] for w in warnings])
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -9,6 +9,7 @@ import affine
 from click.testing import CliRunner
 import numpy as np
 from pytest import fixture
+import pytest
 
 import rasterio
 from rasterio.merge import merge
@@ -116,11 +117,12 @@ def test_merge_warn(test_data_dir_1):
     inputs = [str(x) for x in test_data_dir_1.listdir()]
     inputs.sort()
     runner = CliRunner()
-    result = runner.invoke(
-        main_group, ['merge'] + inputs + [outputname] + ['--nodata', '-1'])
+    with pytest.warns(UserWarning) as warnings:
+        result = runner.invoke(
+            main_group, ['merge'] + inputs + [outputname] + ['--nodata', '-1'])
     assert result.exit_code == 0
+    assert '--nodata option for better results' in warnings[0].message.args[0]
     assert os.path.exists(outputname)
-    assert "using the --nodata option for better results" in result.output
 
 
 def test_merge_without_nodata(test_data_dir_2):


### PR DESCRIPTION
Pytest 3.1, released yesterday,  introduces some [new features and changes](https://docs.pytest.org/en/latest/changelog.html#changelog-history) in handling warnings.

For the purposes of rasterio tests, we assumed that some warnings are captured in the result output. This is no longer the case in pytest 3.1.

This PR upgrades pytest to >= 3.1.0 and asserts those warnings using the recommended [`pytest.warns`](https://docs.pytest.org/en/latest/warnings.html#warns)