### PR TITLE
add tests for OSR equivalence

### DIFF
--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -197,3 +197,17 @@ def test_repr():
 def test_epsg_code():
     assert CRS({'init': 'EPSG:4326'}).is_epsg_code
     assert not CRS({'proj': 'latlon'}).is_epsg_code
+
+
+def test_crs_OSR_equivalence():
+    crs1 = CRS.from_string('+proj=longlat +datum=WGS84 +no_defs')
+    crs2 = CRS.from_string('+proj=latlong +datum=WGS84 +no_defs')
+    crs3 = CRS({'init': 'EPSG:4326'})
+    assert crs1 == crs2
+    assert crs1 == crs3
+
+
+def test_crs_OSR_no_equivalence():
+    crs1 = CRS.from_string('+proj=longlat +datum=WGS84 +no_defs')
+    crs2 = CRS.from_string('+proj=longlat +datum=NAD27 +no_defs')
+    assert crs1 != crs2


### PR DESCRIPTION
These tests cover the case where the CRSs are not exactly equal but equivalent. This doesn't necessarily cover any new code paths in `_crs.pyx`, just tests the expected behavior explicitly.

per https://github.com/mapbox/rasterio/pull/1058#issuecomment-303762545