### PR TITLE
Fixed bug in dtypes.get_minimum_dtype()

### DIFF
--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -108,7 +108,7 @@ def get_minimum_dtype(values):
     min_value = values.min()
     max_value = values.max()
 
-    if values.dtype.kind == 'i':
+    if values.dtype.kind in ('i', 'u'):
         if min_value >= 0:
             if max_value <= 255:
                 return uint8

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -43,6 +43,13 @@ def test_get_minimum_dtype():
     assert get_minimum_dtype([-1.5, 0, 1.5]) == float32
     assert get_minimum_dtype([-1.5e+100, 0, 1.5e+100]) == float64
 
+    assert get_minimum_dtype(np.array([0, 1], dtype=np.uint)) == uint8
+    assert get_minimum_dtype(np.array([0, 1000], dtype=np.uint)) == uint16
+    assert get_minimum_dtype(np.array([0, 100000], dtype=np.uint)) == uint32
+    assert get_minimum_dtype(np.array([-1, 0, 1], dtype=np.int)) == int16
+    assert get_minimum_dtype(np.array([-1, 0, 100000], dtype=np.int)) == int32
+    assert get_minimum_dtype(np.array([-1.5, 0, 1.5], dtype=np.float64)) == float32
+
 
 def test_can_cast_dtype():
     assert can_cast_dtype((1, 2, 3), np.uint8) == True


### PR DESCRIPTION
`get_minimum_dtype()` was not returning working properly when numpy arrays with `uint`* dtypes were passed in.

Added tests to prove it and prevent regressions.