### PR TITLE
Wrap OSRRelease in check for NULL (#1035)

### DIFF
--- a/rasterio/_base.pxd
+++ b/rasterio/_base.pxd
@@ -32,3 +32,4 @@ cdef class DatasetBase:
 
 cdef const char *get_driver_name(GDALDriverH driver)
 cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL
+cdef _safe_osr_release(OGRSpatialReferenceH srs)

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -237,7 +237,7 @@ cdef class DatasetBase(object):
                     crs[k] = v
 
             CPLFree(proj)
-            OSRRelease(osr)
+            _safe_osr_release(osr)
         else:
             log.debug("No projection detected.")
 
@@ -905,8 +905,8 @@ def _transform(src_crs, dst_crs, xs, ys, zs):
         CPLFree(x)
         CPLFree(y)
         CPLFree(z)
-        OSRRelease(src)
-        OSRRelease(dst)
+        _safe_osr_release(src)
+        _safe_osr_release(dst)
 
     return retval
 
@@ -931,7 +931,7 @@ cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL:
             auth, val = init.split(':')
 
             if not val:
-                OSRRelease(osr)
+                _safe_osr_release(osr)
                 raise CRSError("Invalid CRS: {!r}".format(crs))
 
             if auth.upper() == 'EPSG':
@@ -952,10 +952,18 @@ cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL:
     log.debug("OSRSetFromUserInput return value: %s", retval)
 
     if retval:
-        OSRRelease(osr)
+        _safe_osr_release(osr)
         raise CRSError("Invalid CRS: {!r}".format(crs))
 
     return osr
+
+
+cdef _safe_osr_release(OGRSpatialReferenceH srs):
+    """Wrapper to handle OSR release when NULL."""
+
+    if srs != NULL:
+        OSRRelease(srs)
+    srs = NULL
 
 
 def _can_create_osr(crs):
@@ -990,5 +998,5 @@ def _can_create_osr(crs):
         return False
 
     finally:
-        OSRRelease(osr)
+        _safe_osr_release(osr)
         CPLFree(wkt)

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -106,4 +106,4 @@ class _CRS(UserDict):
             return cls.from_string(proj4.decode('utf-8'))
         finally:
             CPLFree(proj4)
-            _safe_osr_relase(osr)
+            _safe_osr_release(osr)

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -9,6 +9,7 @@ from rasterio.compat import UserDict
 from rasterio.compat import string_types
 
 from rasterio._base cimport _osr_from_crs as osr_from_crs
+from rasterio._base cimport _safe_osr_release
 
 
 log = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ class _CRS(UserDict):
             retval = OSRIsGeographic(osr_crs)
             return bool(retval == 1)
         finally:
-            OSRRelease(osr_crs)
+            _safe_osr_release(osr_crs)
 
     @property
     def is_projected(self):
@@ -39,7 +40,7 @@ class _CRS(UserDict):
             retval = OSRIsProjected(osr_crs)
             return bool(retval == 1)
         finally:
-            OSRRelease(osr_crs)
+            _safe_osr_release(osr_crs)
 
     def __eq__(self, other):
         cdef OGRSpatialReferenceH osr_crs1 = NULL
@@ -55,8 +56,8 @@ class _CRS(UserDict):
             retval = OSRIsSame(osr_crs1, osr_crs2)
             return bool(retval == 1)
         finally:
-            OSRRelease(osr_crs1)
-            OSRRelease(osr_crs2)
+            _safe_osr_release(osr_crs1)
+            _safe_osr_release(osr_crs2)
 
     @property
     def wkt(self):
@@ -72,4 +73,4 @@ class _CRS(UserDict):
             return srcwkt.decode('utf-8')
         finally:
             CPLFree(srcwkt)
-            OSRRelease(osr)
+            _safe_osr_release(osr)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -314,15 +314,15 @@ def _reproject(
             log.debug("Set transform on temp source dataset: %d", retval)
 
             try:
-                osr = _osr_from_crs(src_crs)
-                OSRExportToWkt(osr, &srcwkt)
+                src_osr = _osr_from_crs(src_crs)
+                OSRExportToWkt(src_osr, &srcwkt)
                 GDALSetProjection(src_dataset, srcwkt)
 
                 log.debug("Set CRS on temp source dataset: %s", srcwkt)
 
             finally:
                 CPLFree(srcwkt)
-                _safe_osr_release(osr)
+                _safe_osr_release(src_osr)
 
         elif gcps:
             gcplist = <GDAL_GCP *>CPLMalloc(len(gcps) * sizeof(GDAL_GCP))
@@ -403,8 +403,8 @@ def _reproject(
                 "Failed to set transform on temp destination dataset.")
 
         try:
-            osr = _osr_from_crs(dst_crs)
-            OSRExportToWkt(osr, &dstwkt)
+            dst_osr = _osr_from_crs(dst_crs)
+            OSRExportToWkt(dst_osr, &dstwkt)
 
             log.debug("CRS for temp destination dataset: %s.", dstwkt)
 
@@ -413,7 +413,7 @@ def _reproject(
                 raise ("Failed to set projection on temp destination dataset.")
         finally:
             CPLFree(dstwkt)
-            _safe_osr_release(osr)
+            _safe_osr_release(dst_osr)
 
         retval = io_auto(destination, dst_dataset, 1)
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -211,3 +211,18 @@ def test_crs_OSR_no_equivalence():
     crs1 = CRS.from_string('+proj=longlat +datum=WGS84 +no_defs')
     crs2 = CRS.from_string('+proj=longlat +datum=NAD27 +no_defs')
     assert crs1 != crs2
+
+
+def test_safe_osr_release(tmpdir):
+    log = logging.getLogger('rasterio._gdal')
+    log.setLevel(logging.DEBUG)
+    logfile = str(tmpdir.join('test.log'))
+    fh = logging.FileHandler(logfile)
+    log.addHandler(fh)
+
+    with rasterio.Env():
+        CRS({}) == CRS({})
+
+    print(log)
+    log = open(logfile).read()
+    assert "Pointer 'hSRS' is NULL in 'OSRRelease'" not in log

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -223,6 +223,5 @@ def test_safe_osr_release(tmpdir):
     with rasterio.Env():
         CRS({}) == CRS({})
 
-    print(log)
     log = open(logfile).read()
     assert "Pointer 'hSRS' is NULL in 'OSRRelease'" not in log


### PR DESCRIPTION
I replaced all OSRRelease calls with a call to a wrapper that first checks for NULL, and only passes to OSRRelease if not. I added a test to verify that the previous test of empty CRS does not produce an entry in the log (I'm not that familiar with the details of logging, and basically copied another test of whether values are logged or not, so the purpose of a couple of the lines in the test were not totally clear to me).