### PR TITLE
WarpedVRT with target dimensions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -161,7 +161,7 @@ Installing Rasterio
 
 Rasterio, its Cython extensions, normal dependencies, and dev dependencies can
 be installed with ``$ pip``.  Installing Rasterio in editable mode while
-developing is very but only affects the Python files.  Specifying the
+developing is very convenient but only affects the Python files.  Specifying the
 ``[test]`` extra in the command below tells ``$ pip`` to also install
 Rasterio's dev dependencies.
 

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -575,7 +575,7 @@ def _calculate_default_transform(src_crs, dst_crs, width, height,
 
     if all(x is not None for x in (left, bottom, right, top)):
         transform = from_bounds(left, bottom, right, top, width, height)
-        transform=transform.to_gdal()
+        transform = transform.to_gdal()
     elif any(x is not None for x in (left, bottom, right, top)):
         raise ValueError(
             "Some, but not all, bounding box parameters were provided.")

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -717,6 +717,7 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
                 psWOptions.hSrcDS = hds
                 psWOptions.pfnTransformer = pfnTransformer
+                psWOptions.pTransformerArg = hTransformArg
 
                 with nogil:
                     hds_warped = GDALCreateWarpedVRT(

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -154,6 +154,17 @@ cdef GDALWarpOptions * create_warp_options(
     # This is because CSLSetNameValue returns a new list each time
     psWOptions.papszWarpOptions = warp_extras
 
+    # Set up band info
+    if psWOptions.nBandCount == 0:
+        psWOptions.nBandCount = src_count
+
+        psWOptions.panSrcBands = <int*>CPLMalloc(src_count * sizeof(int))
+        psWOptions.panDstBands = <int*>CPLMalloc(src_count * sizeof(int))
+
+        for i in range(src_count):
+            psWOptions.panSrcBands[i] = i + 1
+            psWOptions.panDstBands[i] = i + 1
+
     return psWOptions
 
 

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -631,6 +631,7 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
     def __init__(self, src_dataset, dst_crs=None, resampling=Resampling.nearest,
                  tolerance=0.125, src_nodata=None, dst_nodata=None,
+                 dst_width=None, dst_height=None, dst_transform=None,
                  init_dest_nodata=True, **warp_extras):
         # kwargs become warp options.
         super(WarpedVRTReaderBase, self).__init__(self)
@@ -641,6 +642,9 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self.tolerance = tolerance
         self.src_nodata = src_nodata
         self.dst_nodata = dst_nodata
+        self.dst_width = dst_width
+        self.dst_height = dst_height
+        self.dst_transform = dst_transform
         self.warp_extras = warp_extras.copy()
         if init_dest_nodata is True and 'init_dest' not in warp_extras:
             self.warp_extras['init_dest'] = 'NO_DATA'
@@ -655,6 +659,11 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         cdef GDALWarpOptions *psWOptions = NULL
         cdef float c_tolerance = tolerance
         cdef GDALResampleAlg c_resampling = resampling
+        cdef int c_width = dst_width or 0
+        cdef int c_height = dst_height or 0
+        cdef double gt[6]
+        cdef void *hTransformArg = NULL
+        cdef GDALTransformerFunc pfnTransformer = NULL
 
         # Convert destination CRS to a C WKT string.
         try:
@@ -669,6 +678,11 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         hds = (<DatasetReaderBase?>self.src_dataset).handle()
         hds = exc_wrap_pointer(hds)
 
+        if dst_transform:
+            t = dst_transform.to_gdal()
+            for i in range(6):
+                gt[i] = t[i]
+
         log.debug("Warp_extras: %r", self.warp_extras)
 
         for key, val in self.warp_extras.items():
@@ -682,11 +696,38 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
             self.dst_nodata, GDALGetRasterCount(hds), <const char **>c_warp_extras)
 
         try:
-            with nogil:
-                hds_warped = GDALAutoCreateWarpedVRT(
-                    hds, NULL, dst_crs_wkt, c_resampling,
-                    c_tolerance, psWOptions)
-            self._hds = exc_wrap_pointer(hds_warped)
+            if dst_width and dst_height and dst_transform:
+                # set up transform args (otherwise handled in GDALAutoCreateWarpedVRT)
+                try:
+                    hTransformArg = exc_wrap_pointer(
+                        GDALCreateGenImgProjTransformer(
+                            hds, NULL, NULL, dst_crs_wkt, True, 1.0, 0))
+                    if c_tolerance > 0.0:
+                        hTransformArg = exc_wrap_pointer(
+                            GDALCreateApproxTransformer(
+                                GDALGenImgProjTransform, hTransformArg, c_tolerance))
+                        pfnTransformer = GDALApproxTransform
+                        GDALApproxTransformerOwnsSubtransformer(hTransformArg, 1)
+
+                    log.debug("Created transformer and options.")
+
+                except:
+                    GDALDestroyApproxTransformer(hTransformArg)
+                    raise
+
+                psWOptions.hSrcDS = hds
+                psWOptions.pfnTransformer = pfnTransformer
+
+                with nogil:
+                    hds_warped = GDALCreateWarpedVRT(
+                        hds, c_width, c_height, gt, psWOptions)
+                self._hds = exc_wrap_pointer(hds_warped)
+            else:
+                with nogil:
+                    hds_warped = GDALAutoCreateWarpedVRT(
+                        hds, NULL, dst_crs_wkt, c_resampling,
+                        c_tolerance, psWOptions)
+                self._hds = exc_wrap_pointer(hds_warped)
         except CPLE_OpenFailedError as err:
             raise RasterioIOError(err.errmsg)
         finally:

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -473,6 +473,7 @@ cdef extern from "gdal_alg.h" nogil:
     void *GDALCreateGenImgProjTransformer3(
             const char *pszSrcWKT, const double *padfSrcGeoTransform,
             const char *pszDstWKT, const double *padfDstGeoTransform)
+    void GDALSetGenImgProjTransformerDstGeoTransform(void *hTransformArg, double *padfGeoTransform)
     int GDALGenImgProjTransform(void *pTransformArg, int bDstToSrc,
                                 int nPointCount, double *x, double *y,
                                 double *z, int *panSuccess)

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -440,6 +440,10 @@ cdef extern from "gdalwarper.h" nogil:
         GDALResampleAlg eResampleAlg, double dfMaxError,
         const GDALWarpOptions *psOptionsIn)
 
+    GDALDatasetH GDALCreateWarpedVRT(
+        GDALDatasetH hSrcDS, int nPixels, int nLines,
+         double *padfGeoTransform, const GDALWarpOptions *psOptionsIn)
+
 
 cdef extern from "gdal_alg.h" nogil:
 

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -33,6 +33,13 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
         than the nodata value of src_dataset.
     dst_nodata : float, int
         The nodata value for the virtually warped dataset.
+    dst_width : int, optional
+        Target width. dst_height and dst_transform must also be provided.
+    dst_height : int, optional
+        Target height. dst_width and dst_transform must also be provided.
+    dst_transform: affine.Affine(), optional
+        Target affine transformation.  Required if width and height are
+        provided.
     warp_extras : dict
         GDAL extra warp options. See
         http://www.gdal.org/structGDALWarpOptions.html.


### PR DESCRIPTION
When working with DEMs, I've discovered that it's necessary to (create and) read from warped VRTs where the pixel dimensions match the world at particular web Mercator zooms, else GDAL interpolation (regardless of resampling method) introduces artifacts that only show up when calculating gradients (generating hillshades), e.g.:

![image](https://cloud.githubusercontent.com/assets/45/26615506/2f4c6c9a-457c-11e7-92f6-f44b2083effb.png)

I'm attempting to wrap `GDALCreateWarpedVRT` to achieve this. However, it doesn't include all of the data source / warp option preparation that `GDALAutoCreateWarpedVRT` does, so additional work needs to be done in `create_warp_options`, etc.

This PR looks right, but when I try to use it (`read`ing windows from the VRT), it segfaults within `io_multi_band` (in `shim_rasterioex.pxi`).

I _think_ I may be creating `hTransformArg` incorrectly (in `_warp.pyx`; equivalent to `GenImgProjTransformer` below), but it may also be related to the size of the virtual image.

Here's a warped VRT that I'm trying to create the dynamic equivalent of:

```xml
<VRTDataset rasterXSize="16777216" rasterYSize="16777216" subClass="VRTWarpedDataset">
  <SRS>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</SRS>
  <GeoTransform> -2.0037508340000000e+07,  2.3886571335792541e+00,  0.0000000000000000e+00,  2.0037508340000000e+07,  0.0000000000000000e+00, -2.3886571335792541e+00</GeoTransform>
  <Metadata>
    <MDI key="AREA_OR_POINT">Area</MDI>
  </Metadata>
  <VRTRasterBand band="1" dataType="Float32" subClass="VRTWarpedRasterBand">
    <Metadata>
      <MDI key="LAYER_TYPE">athematic</MDI>
    </Metadata>
    <Description>Layer_1</Description>
    <NoDataValue>-3.402823466385289e+38</NoDataValue>
    <ColorInterp>Alpha</ColorInterp>
  </VRTRasterBand>
  <BlockXSize>512</BlockXSize>
  <BlockYSize>128</BlockYSize>
  <GDALWarpOptions>
    <WarpMemoryLimit>6.71089e+07</WarpMemoryLimit>
    <ResampleAlg>NearestNeighbour</ResampleAlg>
    <WorkingDataType>Float32</WorkingDataType>
    <Option name="INIT_DEST">NO_DATA</Option>
    <SourceDataset relativeToVRT="0">/vsis3/mapzen-dynamic-tiler-test/ned/0/ned19_n38x00_w122x75_ca_sanfrancisocoast_2010.tif.msk</SourceDataset>
    <Transformer>
      <ApproxTransformer>
        <MaxError>0.125</MaxError>
        <BaseTransformer>
          <GenImgProjTransformer>
            <SrcGeoTransform>-122.750185185185217,3.08641975308649369e-05,0,38.0001851851851882,0,-3.0864197530864056e-05</SrcGeoTransform>
            <SrcInvGeoTransform>3977105.99999990594,32399.9999999992251,0,1231206.00000000582,0,-32400.0000000001492</SrcInvGeoTransform>
            <DstGeoTransform>-20037508.3399999999,2.38865713357925413,0,20037508.3399999999,0,-2.38865713357925413</DstGeoTransform>
            <DstInvGeoTransform>8388608,0.418645265552014256,0,8388608,0,-0.418645265552014256</DstInvGeoTransform>
            <ReprojectTransformer>
              <ReprojectionTransformer>
                <SourceSRS>GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.2572221010042,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4269"],EXTENSION["CENTER_LONG",-122.625]]</SourceSRS>
                <TargetSRS>PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]</TargetSRS>
              </ReprojectionTransformer>
            </ReprojectTransformer>
          </GenImgProjTransformer>
        </BaseTransformer>
      </ApproxTransformer>
    </Transformer>
    <BandList>
      <BandMapping dst="1" src="1">
        <SrcNoDataReal>-3.402823466385289e+38</SrcNoDataReal>
        <SrcNoDataImag>0</SrcNoDataImag>
        <DstNoDataReal>-3.402823466385289e+38</DstNoDataReal>
        <DstNoDataImag>0</DstNoDataImag>
      </BandMapping>
    </BandList>
  </GDALWarpOptions>
</VRTDataset>
```

Ideas?