### PR TITLE
Warped vrt source georeferencing

### DIFF
--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -1,8 +1,6 @@
 """rasterio.vrt: a module concerned with GDAL VRTs"""
 
 from rasterio._warp import WarpedVRTReaderBase
-from rasterio.enums import Resampling
-from rasterio.env import ensure_env
 from rasterio.io import WindowMethodsMixin, TransformMethodsMixin
 
 


### PR DESCRIPTION
Switches to using `GDALCreateGenImgProjTransformer3` with explicit source and target CRSes and transformations. This allows source georeferencing information to be provided explicitly if it's not available in the source file(s) for some reason.

(Actual reason: GDAL / rasterio's behavior when reading masks (containing overviews, but not georeferencing, as they're considered sidecars) over HTTP is sub-optimal (results in _many_ more Range requests than not reading the masks), so I'm creating a `WarpedVRT` and reading them as though they're normal sources. I don't know how to effectively describe a repro / identify a cause, so no issue for that.)