### PR TITLE
Float precision read/write windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ install:
   - "pip list"
 script:
   - "if [[ $TRAVIS_PYTHON_VERSION == 3.5 && $GDALVERSION == 2.1.0 ]]; then python -m pytest --doctest-ignore-import-errors --doctest-glob='*.rst' docs/*.rst -k 'not index and not quickstart and not switch' ; fi"
-  - py.test --cov rasterio --cov-report term-missing
+  - python -Wall -m pytest --cov rasterio --cov-report term-missing
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,6 @@ install:
   - "pip list"
 script:
   - "if [[ $TRAVIS_PYTHON_VERSION == 3.5 && $GDALVERSION == 2.1.0 ]]; then python -m pytest --doctest-ignore-import-errors --doctest-glob='*.rst' docs/*.rst -k 'not index and not quickstart and not switch' ; fi"
-  - python -Wall -m pytest --cov rasterio --cov-report term-missing
+  - python -m pytest --cov rasterio --cov-report term-missing
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,25 @@
 Changes
 =======
 
+Next
+----
+
+Breaking changes:
+
+- In the GeoJSON output of rio-blocks, the windows are now JSON
+  representations of the `Window` class (#1074).
+- The `rasterio.windows.Window` class no longer derives from `tuple`.
+  Comparisons like `Window(0, 0, 1, 1) == ((0, 1), (0, 1))` are no
+  longer possible. Instead, call the `.toranges()` method of the 
+  former or coerce the latter using `Window.from_ranges()` (#1074).
+
+New features:
+
+- Float precision read/write windows are now supported throughout
+  Rasterio (#1074).
+- Use of old style range tuples as windows is deprecated and warned
+  against (#1074).
+
 1.0a9 (2017-06-02)
 ------------------
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -54,7 +54,7 @@ def window_index(*args, **kwargs):
 
 __all__ = [
     'band', 'open', 'copy', 'pad']
-__version__ = "1.0a9"
+__version__ = "1.0a10"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -24,7 +24,7 @@ from rasterio.enums import (
 from rasterio.env import Env
 from rasterio.errors import (
     RasterioIOError, CRSError, DriverRegistrationError,
-    NotGeoreferencedWarning)
+    NotGeoreferencedWarning, RasterioDeprecationWarning)
 from rasterio.profiles import Profile
 from rasterio.transform import Affine, guard_transform, tastes_like_gdal
 from rasterio.vfs import parse_path, vsi_path
@@ -425,7 +425,7 @@ cdef class DatasetBase(object):
         def __get__(self):
             warnings.warn(
                 "'mask_flags' is deprecated. Switch to 'mask_flag_enums'",
-                DeprecationWarning,
+                RasterioDeprecationWarning,
                 stacklevel=2)
             return self._mask_flags
 
@@ -535,7 +535,7 @@ cdef class DatasetBase(object):
                 col = i * w
                 width = min(w, self.width - col)
                 yield (j, i), windows.Window(
-                    col_off=col, row_off=row, num_cols=width, num_rows=height)
+                    col_off=col, row_off=row, width=width, height=height)
 
     property bounds:
         """Returns the lower left and upper right bounds of the dataset
@@ -703,7 +703,7 @@ cdef class DatasetBase(object):
                 "'src.affine' is deprecated.  Please switch to "
                 "'src.transform'. See "
                 "https://github.com/mapbox/rasterio/issues/86 for details.",
-                DeprecationWarning,
+                RasterioDeprecationWarning,
                 stacklevel=2)
             return Affine.from_gdal(*self.get_transform())
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -546,7 +546,7 @@ cdef class DatasetBase(object):
         """
         def __get__(self):
             a, b, c, d, e, f, _, _, _ = self.transform
-            return BoundingBox(c, f+e*self.height, c+a*self.width, f)
+            return BoundingBox(c, f + e * self.height, c + a * self.width, f)
 
     property res:
         """Returns the (width, height) of pixels in the units of its
@@ -556,7 +556,7 @@ cdef class DatasetBase(object):
             if b == d == 0:
                 return a, -e
             else:
-                return math.sqrt(a*a+d*d), math.sqrt(b*b+e*e)
+                return math.sqrt(a * a+ d * d), math.sqrt(b * b + e * e)
 
     @property
     def meta(self):

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -534,7 +534,8 @@ cdef class DatasetBase(object):
             for i in range(ncols):
                 col = i * w
                 width = min(w, self.width - col)
-                yield (j, i), ((row, row+height), (col, col+width))
+                yield (j, i), windows.Window(
+                    col_off=col, row_off=row, num_cols=width, num_rows=height)
 
     property bounds:
         """Returns the lower left and upper right bounds of the dataset

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -331,8 +331,14 @@ def _explode(coords):
                 yield f
 
 
-def _bounds(geometry):
-    """Bounding box of a GeoJSON geometry.  
+def _bounds(geometry, north_up=True):
+    """Bounding box of a GeoJSON geometry.
+
+    left, bottom, right, top
+    *not* xmin, ymin, xmax, ymax
+
+    If not north_up, y will be switched to guarantee the above.
+
     From Fiona 1.4.8 with updates here to handle feature collections.
     TODO: add to Fiona.
     """
@@ -347,10 +353,17 @@ def _bounds(geometry):
             ymins.append(ymin)
             xmaxs.append(xmax)
             ymaxs.append(ymax)
-        return min(xmins), min(ymins), max(xmaxs), max(ymaxs)
+        if north_up:
+            return min(xmins), min(ymins), max(xmaxs), max(ymaxs)
+        else:
+            return min(xmins), max(ymaxs), max(xmaxs), min(ymins)
+
     else:
         xyz = tuple(zip(*list(_explode(geometry['coordinates']))))
-        return min(xyz[0]), min(xyz[1]), max(xyz[0]), max(xyz[1])
+        if north_up:
+            return min(xyz[0]), min(xyz[1]), max(xyz[0]), max(xyz[1])
+        else:
+            return min(xyz[0]), max(xyz[1]), max(xyz[0]), min(xyz[1])
 
 
 # Mapping of OGR integer geometry types to GeoJSON type names.

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -234,7 +234,7 @@ cdef class DatasetReaderBase(DatasetBase):
                     self.height, self.width)
 
             int_window = windows.int_reshape(window)
-            win_shape += (int_window.num_rows, int_window.num_cols)
+            win_shape += (int(int_window.num_rows), int(int_window.num_cols))
 
         else:
             win_shape += self.shape
@@ -472,7 +472,7 @@ cdef class DatasetReaderBase(DatasetBase):
                     self.height, self.width)
 
             int_window = windows.int_reshape(window)
-            win_shape += (int_window.num_rows, int_window.num_cols)
+            win_shape += (int(int_window.num_rows), int(int_window.num_cols))
 
         else:
             win_shape += self.shape

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -225,14 +225,14 @@ cdef class DatasetReaderBase(DatasetBase):
         if window:
 
             if isinstance(window, tuple):
-                windows.warn_window_deprecation()
+                window = windows.coerce_and_warn(window)
 
             if not boundless:
                 window = windows.crop(
                     windows.evaluate(window, self.height, self.width),
                     self.height, self.width)
 
-            int_window = windows.int_reshape(window)
+            int_window = window.round_shape()
             win_shape += (int(int_window.num_rows), int(int_window.num_cols))
 
         else:
@@ -463,14 +463,14 @@ cdef class DatasetReaderBase(DatasetBase):
         if window:
 
             if isinstance(window, tuple):
-                windows.warn_window_deprecation()
+                window = windows.coerce_and_warn(window)
 
             if not boundless:
                 window = windows.crop(
                     windows.evaluate(window, self.height, self.width),
                     self.height, self.width)
 
-            int_window = windows.int_reshape(window)
+            int_window = window.round_shape()
             win_shape += (int(int_window.num_rows), int(int_window.num_cols))
 
         else:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -31,7 +31,6 @@ from rasterio.vfs import parse_path, vsi_path
 from rasterio import windows
 
 from libc.stdio cimport FILE
-from libc.math cimport ceil
 cimport numpy as np
 
 from rasterio._base cimport _osr_from_crs, get_driver_name, DatasetBase

--- a/rasterio/coords.py
+++ b/rasterio/coords.py
@@ -33,7 +33,7 @@ def disjoint_bounds(bounds1, bounds2):
     Parameters
     ----------
     bounds1: 4-tuple
-        rasterio bounds tuple (xmin, ymin, xmax, ymax)
+        rasterio bounds tuple (left, bottom, right, top)
     bounds2: 4-tuple
         rasterio bounds tuple
 
@@ -43,5 +43,16 @@ def disjoint_bounds(bounds1, bounds2):
     ``True`` if bounds are disjoint,
     ``False`` if bounds overlap
     """
-    return (bounds1[0] > bounds2[2] or bounds1[2] < bounds2[0] or
-            bounds1[1] > bounds2[3] or bounds1[3] < bounds2[1])
+    bounds1_north_up = bounds1[3] > bounds1[1]
+    bounds2_north_up = bounds2[3] > bounds2[1]
+
+    if not bounds1_north_up and bounds2_north_up:
+        # or both south-up (also True)
+        raise ValueError("Bounds must both have the same orientation")
+
+    if bounds1_north_up:
+        return (bounds1[0] > bounds2[2] or bounds2[0] > bounds1[2] or
+                bounds1[1] > bounds2[3] or bounds2[1] > bounds2[3])
+    else:
+        return (bounds1[0] > bounds2[2] or bounds2[0] > bounds1[2] or
+                bounds1[3] > bounds2[1] or bounds2[3] > bounds2[1])

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -2,7 +2,7 @@
 
 Since 0.13 we are not importing numpy here and data types are strings.
 Happily strings can be used throughout Numpy and so existing code will
-break.
+not break.
 
 Within Rasterio, to test data types, we use Numpy's dtype() factory to
 do something like this:
@@ -77,12 +77,11 @@ def _gdal_typename(dt):
 
 def check_dtype(dt):
     """Check if dtype is a known dtype."""
-    if dt not in dtype_rev:
-        try:
-            return dt().dtype.name in dtype_rev
-        except:
-            return False
-    return True
+    if str(dt) in dtype_rev:
+        return True
+    elif callable(dt) and str(dt().dtype) in dtype_rev:
+        return True
+    return False
 
 
 def get_minimum_dtype(values):

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -30,7 +30,7 @@ class RasterioIOError(IOError):
     registered format drivers."""
 
 
-class NodataShadowWarning(Warning):
+class NodataShadowWarning(UserWarning):
     """Warn that a dataset's nodata attribute is shadowing its alpha band."""
 
     def __str__(self):
@@ -39,7 +39,7 @@ class NodataShadowWarning(Warning):
                 "by the nodata attribute")
 
 
-class NotGeoreferencedWarning(Warning):
+class NotGeoreferencedWarning(UserWarning):
     """Warn that a dataset isn't georeferenced."""
 
 

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -3,12 +3,20 @@
 from click import FileError
 
 
+class RasterioError(Exception):
+    """Root exception class"""
+
+
+class WindowError(RasterioError):
+    """Raised when errors occur during window operations"""
+
+
 class CRSError(ValueError):
     """Raised when a CRS string or mapping is invalid or cannot serve
     to define a coordinate transformation."""
 
 
-class EnvError(Exception):
+class EnvError(RasterioError):
     """Raised when the state of GDAL/AWS environment cannot be created
     or modified."""
 
@@ -48,8 +56,15 @@ class GDALBehaviorChangeException(RuntimeError):
     example, antimeridian cutting is always on as of GDAL 2.2.0.  Users
     expecting it to be off will be presented with a MultiPolygon when the
     rest of their code expects a Polygon.
-        
+
         # Raises an exception on GDAL >= 2.2.0
         rasterio.warp.transform_geometry(
             src_crs, dst_crs, antimeridian_cutting=False)
     """
+
+class WindowEvaluationError(ValueError):
+    """Raised when window evaluation fails"""
+
+
+class RasterioDeprecationWarning(UserWarning):
+    """Rasterio module deprecations"""

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -286,8 +286,8 @@ def rasterize(
     return out
 
 
-def bounds(geometry):
-    """Return a (minx, miny, maxx, maxy) bounding box.
+def bounds(geometry, north_up=True):
+    """Return a (left, bottom, right, top) bounding box.
 
     From Fiona 1.4.8. Modified to return bbox from geometry if available.
 
@@ -298,10 +298,10 @@ def bounds(geometry):
     Returns
     -------
     tuple
-        Bounding box: (minx, miny, maxx, maxy)
+        Bounding box: (left, bottom, right, top)
     """
     if 'bbox' in geometry:
         return tuple(geometry['bbox'])
 
     geom = geometry.get('geometry') or geometry
-    return _bounds(geom)
+    return _bounds(geom, north_up=north_up)

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -144,8 +144,8 @@ class WindowMethodsMixin(object):
 
         Parameters
         ----------
-        window: tuple
-            Dataset window tuple
+        window: rasterio.windows.Window
+            Dataset window
 
         Returns
         -------
@@ -161,8 +161,8 @@ class WindowMethodsMixin(object):
 
         Parameters
         ----------
-        window: tuple
-            Dataset window tuple
+        window: rasterio.windows.Window
+            Dataset window
 
         Returns
         -------

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -105,7 +105,7 @@ class WindowMethodsMixin(object):
     properties: `transform`, `height` and `width`
     """
 
-    def window(self, left, bottom, right, top, boundless=False, precision=6):
+    def window(self, left, bottom, right, top, boundless=True, precision=6):
         """Get the window corresponding to the bounding coordinates.
 
         Parameters
@@ -127,10 +127,7 @@ class WindowMethodsMixin(object):
 
         Returns
         -------
-        window: tuple
-            ((row_start, row_stop), (col_start, col_stop))
-            corresponding to the bounding coordinates
-
+        window: Window
         """
 
         transform = guard_transform(self.transform)

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -6,7 +6,6 @@ import warnings
 
 import rasterio
 from rasterio.features import geometry_mask
-from rasterio.windows import int_reshape
 
 
 logger = logging.getLogger(__name__)
@@ -103,9 +102,9 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
     if crop:
         bounds_window = raster.window(*mask_bounds)
 
-        # Call int_reshape to get the window with integer height
+        # Get the window with integer height
         # and width that contains the bounds window.
-        out_window = int_reshape(bounds_window)
+        out_window = bounds_window.round_shape()
         height = int(out_window.num_rows)
         width = int(out_window.num_cols)
 

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -104,7 +104,7 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
 
         # Get the window with integer height
         # and width that contains the bounds window.
-        out_window = bounds_window.round_shape()
+        out_window = bounds_window.round_shape(op='ceil')
         height = int(out_window.num_rows)
         width = int(out_window.num_cols)
 

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -101,25 +101,7 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
                           "reference systems?")
 
     if crop:
-
-#         # TODO: pull this out to another module for reuse?
-#         pixel_precision = 3
-# 
-#         if invert_y:
-#             cropped_mask_bounds = (
-#                 math.floor(round(mask_bounds[0], pixel_precision)),
-#                 math.ceil(round(mask_bounds[1], pixel_precision)),
-#                 math.ceil(round(mask_bounds[2], pixel_precision)),
-#                 math.floor(round(mask_bounds[3], pixel_precision))]
-#         else:
-#             cropped_mask_bounds = [
-#                 math.floor(round(mask_bounds[0], pixel_precision)),
-#                 math.floor(round(mask_bounds[1], pixel_precision)),
-#                 math.ceil(round(mask_bounds[2], pixel_precision)),
-#                 math.ceil(round(mask_bounds[3], pixel_precision))]
-
-        cropped_mask_bounds = mask_bounds
-        bounds_window = raster.window(*cropped_mask_bounds)
+        bounds_window = raster.window(*mask_bounds)
 
         # Call int_reshape to get the window with integer height
         # and width that contains the bounds window.

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -145,7 +145,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
             boundless=True)
         logger.debug("Src %s window: %r", src.name, src_window)
 
-        src_window = windows.int_reshape(src_window)
+        src_window = src_window.round_shape()
 
         # 3. Compute the destination window.
         dst_window = windows.from_bounds(

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -155,7 +155,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         # 4. Initialize temp array.
         tcount = first.count
         trows, tcols = (
-            int(round(dst_window.num_rows)), int(round(dst_window.num_cols)))
+            int(round(dst_window.height)), int(round(dst_window.width)))
 
         temp_shape = (tcount, trows, tcols)
 

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 from rasterio import windows
+from rasterio.enums import Resampling
 from rasterio.transform import Affine
 
 
@@ -127,8 +128,8 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
 
     for src in sources:
         # Real World (tm) use of boundless reads.
-        # This approach uses the maximum amount of memory to solve the problem.
-        # Making it more efficient is a TODO.
+        # This approach uses the maximum amount of memory to solve the
+        # problem. Making it more efficient is a TODO.
 
         # 1. Compute spatial intersection of destination and source.
         src_w, src_s, src_e, src_n = src.bounds
@@ -141,31 +142,32 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         # 2. Compute the source window.
         src_window = windows.from_bounds(
             int_w, int_s, int_e, int_n, src.transform,
-            boundless=True, precision=precision)
+            boundless=True)
         logger.debug("Src %s window: %r", src.name, src_window)
+
+        src_window = windows.int_reshape(src_window)
 
         # 3. Compute the destination window.
         dst_window = windows.from_bounds(
             int_w, int_s, int_e, int_n, output_transform,
-            boundless=True, precision=precision)
-
-        logger.debug("Dst window: %r", dst_window)
+            boundless=True)
 
         # 4. Initialize temp array.
         tcount = first.count
-        trows, tcols = tuple(int(round(b - a)) for a, b in dst_window)
+        trows, tcols = (
+            int(round(dst_window.num_rows)), int(round(dst_window.num_cols)))
 
         temp_shape = (tcount, trows, tcols)
-        logger.debug("Temp shape: %r", temp_shape)
 
-        temp = np.zeros(tuple(int(round(x)) for  x in temp_shape), dtype=dtype)
-        temp = src.read(out=temp, window=src_window, boundless=False,
-                        masked=True)
+        temp = src.read(out_shape=temp_shape, window=src_window,
+                        boundless=False, masked=True)
 
         # 5. Copy elements of temp into dest.
-        roff, coff = int(round(dst_window[0][0])), int(round(dst_window[1][0]))
+        roff, coff = (
+            int(round(dst_window.row_off)), int(round(dst_window.col_off)))
 
         region = dest[:, roff:roff + trows, coff:coff + tcols]
+
         np.copyto(
             region, temp,
             where=np.logical_and(region == nodataval, temp.mask == False))

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -153,17 +153,17 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
 
         # 4. Initialize temp array.
         tcount = first.count
-        trows, tcols = tuple(b - a for a, b in dst_window)
+        trows, tcols = tuple(int(round(b - a)) for a, b in dst_window)
 
         temp_shape = (tcount, trows, tcols)
         logger.debug("Temp shape: %r", temp_shape)
 
-        temp = np.zeros(temp_shape, dtype=dtype)
+        temp = np.zeros(tuple(int(round(x)) for  x in temp_shape), dtype=dtype)
         temp = src.read(out=temp, window=src_window, boundless=False,
                         masked=True)
 
         # 5. Copy elements of temp into dest.
-        roff, coff = dst_window[0][0], dst_window[1][0]
+        roff, coff = int(round(dst_window[0][0])), int(round(dst_window[1][0]))
 
         region = dest[:, roff:roff + trows, coff:coff + tcols]
         np.copyto(

--- a/rasterio/profiles.py
+++ b/rasterio/profiles.py
@@ -4,6 +4,7 @@ import warnings
 
 from rasterio.compat import UserDict
 from rasterio.dtypes import uint8
+from rasterio.errors import RasterioDeprecationWarning
 
 
 class Profile(UserDict):
@@ -24,11 +25,11 @@ class Profile(UserDict):
 
         if 'affine' in initdata and 'transform' in initdata:
             warnings.warn("affine item is deprecated, use transform only",
-                          DeprecationWarning)
+                          RasterioDeprecationWarning)
             del initdata['affine']
         elif 'affine' in initdata:
             warnings.warn("affine item is deprecated, use transform instead",
-                          DeprecationWarning)
+                          RasterioDeprecationWarning)
             initdata['transform'] = initdata.pop('affine')
 
         self.data.update(initdata)
@@ -38,7 +39,7 @@ class Profile(UserDict):
         if key == 'affine':
             key = 'transform'
             warnings.warn("affine item is deprecated, use transform instead",
-                          DeprecationWarning)
+                          RasterioDeprecationWarning)
         return self.data[key]
 
     def __setitem__(self, key, val):
@@ -53,7 +54,7 @@ class Profile(UserDict):
         DEPRECATED.
         """
         warnings.warn("__call__() is deprecated, use mapping methods instead",
-                      DeprecationWarning)
+                      RasterioDeprecationWarning)
         profile = self.data.copy()
         profile.update(**kwds)
         return profile

--- a/rasterio/rio/clip.py
+++ b/rasterio/rio/clip.py
@@ -7,7 +7,6 @@ from .helpers import resolve_inout
 from . import options
 import rasterio
 from rasterio.coords import disjoint_bounds
-from rasterio.windows import int_reshape
 
 
 # Geographic (default), projected, or Mercator switch.
@@ -102,9 +101,9 @@ def clip(ctx, files, output, bounds, like, driver, projection,
 
             bounds_window = src.window(*bounds)
 
-            # Call int_reshape to get the window with integer height
+            # Get the window with integer height
             # and width that contains the bounds window.
-            out_window = int_reshape(bounds_window)
+            out_window = bounds_window.round_shape()
 
             height = int(out_window.num_rows)
             width = int(out_window.num_cols)

--- a/rasterio/rio/clip.py
+++ b/rasterio/rio/clip.py
@@ -7,6 +7,7 @@ from .helpers import resolve_inout
 from . import options
 import rasterio
 from rasterio.coords import disjoint_bounds
+from rasterio.windows import Window
 
 
 # Geographic (default), projected, or Mercator switch.
@@ -100,13 +101,15 @@ def clip(ctx, files, output, bounds, like, driver, projection,
                 raise click.UsageError('--bounds or --like required')
 
             bounds_window = src.window(*bounds)
+            bounds_window = bounds_window.intersection(
+                Window(0, 0, src.width, src.height))
 
             # Get the window with integer height
             # and width that contains the bounds window.
-            out_window = bounds_window.round_shape()
+            out_window = bounds_window.round_lengths(op='ceil')
 
-            height = int(out_window.num_rows)
-            width = int(out_window.num_cols)
+            height = int(out_window.height)
+            width = int(out_window.width)
 
             out_kwargs = src.meta.copy()
             out_kwargs.update({

--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -1,6 +1,10 @@
 # Workaround for issue #378. A pure Python generator.
 
+from rasterio.windows import Window
+
+
 def sample_gen(dataset, xy, indexes=None):
+    """Generator for sampled pixels"""
     index = dataset.index
     read = dataset.read
 
@@ -9,6 +13,6 @@ def sample_gen(dataset, xy, indexes=None):
 
     for x, y in xy:
         r, c = index(x, y)
-        window = ((r, r+1), (c, c+1))
+        window = Window(c, r, 1, 1)
         data = read(indexes, window=window, masked=False, boundless=True)
-        yield data[:,0,0]
+        yield data[:, 0, 0]

--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -12,7 +12,7 @@ def sample_gen(dataset, xy, indexes=None):
         indexes = [indexes]
 
     for x, y in xy:
-        r, c = index(x, y)
-        window = Window(c, r, 1, 1)
+        row_off, col_off = index(x, y)
+        window = Window(col_off, row_off, 1, 1)
         data = read(indexes, window=window, masked=False, boundless=True)
         yield data[:, 0, 0]

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -172,8 +172,11 @@ def rowcol(transform, xs, ys, op=math.floor, precision=6):
     cols = []
     for x, y in zip(xs, ys):
         fcol, frow = invtransform * (x + eps, y - eps)
-        cols.append(int(op(fcol)))
-        rows.append(int(op(frow)))
+        # cols.append(int(op(fcol)))
+        # rows.append(int(op(frow)))
+
+        cols.append(op(fcol))
+        rows.append(op(frow))
 
     if single_x:
         cols = cols[0]

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -172,9 +172,6 @@ def rowcol(transform, xs, ys, op=math.floor, precision=6):
     cols = []
     for x, y in zip(xs, ys):
         fcol, frow = invtransform * (x + eps, y - eps)
-        # cols.append(int(op(fcol)))
-        # rows.append(int(op(frow)))
-
         cols.append(op(fcol))
         rows.append(op(frow))
 

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -534,7 +534,8 @@ class Window(object):
     @property
     def __array_interface__(self):
         return {'shape': (2, 2), 'typestr': 'f', 'version': 3,
-                'data': np.array(self.toranges())}
+                'data': np.array(
+                    [[a, b] for a, b in self.toranges()], dtype='float')}
 
     def __getitem__(self, index):
         return self.toranges()[index]

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -180,10 +180,12 @@ def from_bounds(left, bottom, right, top, transform,
         A new Window
     """
     window_start = rowcol(
-        transform, left, top, op=math.floor, precision=precision)
+        # transform, left, top, op=math.floor, precision=precision)
+        transform, left, top, op=float, precision=precision)
 
     window_stop = rowcol(
-        transform, right, bottom, op=math.ceil, precision=precision)
+        # transform, right, bottom, op=math.ceil, precision=precision)
+        transform, right, bottom, op=float, precision=precision)
 
     window = Window.from_ranges(*tuple(zip(window_start, window_stop)))
 

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -115,7 +115,7 @@ def union(*windows):
     Parameters
     ----------
     windows: sequence
-        One or more Windows or window tuples.
+        One or more Windows.
 
     Returns
     -------
@@ -136,7 +136,7 @@ def intersection(*windows):
     Parameters
     ----------
     windows: sequence
-        One or more Windows or window tuples.
+        One or more Windows.
 
     Returns
     -------
@@ -158,7 +158,7 @@ def intersect(*windows):
     Parameters
     ----------
     windows: sequence
-        One or more Windows or window tuples.
+        One or more Windows.
 
     Returns
     -------
@@ -227,7 +227,7 @@ def transform(window, transform):
 
     Parameters
     ----------
-    window : a Window or window tuple
+    window: Window
         The input window.
     transform: Affine
         an affine transform matrix.
@@ -250,7 +250,7 @@ def bounds(window, transform):
 
     Parameters
     ----------
-    window: a Window or window tuple
+    window: Window
         The input window.
     transform: Affine
         an affine transform matrix.
@@ -278,7 +278,7 @@ def crop(window, height, width):
 
     Parameters
     ----------
-    window : a Window or window tuple
+    window : Window.
         The input window.
     height, width : int
         The number of rows and cols in the cropped window.
@@ -307,7 +307,7 @@ def evaluate(window, height, width):
 
     Parameters
     ----------
-    window : a Window or window tuple
+    window : Window.
         The input window.
     height, width : int
         The number of rows or columns in the array that the window
@@ -360,7 +360,7 @@ def shape(window, height=-1, width=-1):
 
     Parameters
     ----------
-    window : a Window or window tuple
+    window: Window
         The input window.
     height, width : int, optional
         The number of rows or columns in the array that the window
@@ -382,7 +382,7 @@ def window_index(window):
 
     Parameters
     ----------
-    window : a Window or window tuple
+    window: Window
         The input window.
 
     Returns
@@ -405,7 +405,7 @@ def round_window_to_full_blocks(window, block_shapes):
 
     Parameters
     ----------
-    window : a Window or window tuple
+    window: Window
         The input window.
 
     block_shapes : tuple of block shapes

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -26,7 +26,7 @@ def warn_window_deprecation():
     """Standard warning about range tuple deprecation"""
     warnings.warn(
         "Range tuple window are deprecated. Please switch to Window class",
-        DeprecationWarning, stacklevel=2)
+        DeprecationWarning)
 
 
 def iter_args(function):

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,8 @@ extra_reqs = {
     's3': ['boto3>=1.2.4'],
     'plot': ['matplotlib'],
     'test': [
-        'pytest>=2.8.2', 'pytest-cov>=2.2.0', 'boto3>=1.2.4', 'packaging'],
+        'pytest>=2.8.2', 'pytest-cov>=2.2.0', 'boto3>=1.2.4', 'packaging',
+        'hypothesis'],
     'docs': ['ghp-import', 'numpydoc', 'sphinx', 'sphinx-rtd-theme']}
 
 # Add futures to 'test' for Python < 3.2.

--- a/setup.py
+++ b/setup.py
@@ -298,7 +298,7 @@ with open('README.rst') as f:
     readme = f.read()
 
 # Runtime requirements.
-inst_reqs = ['affine', 'cligj', 'numpy', 'snuggs>=1.4.1', 'click-plugins']
+inst_reqs = ['affine', 'attrs', 'cligj', 'numpy', 'snuggs>=1.4.1', 'click-plugins']
 
 if sys.version_info < (3, 4):
     inst_reqs.append('enum34')

--- a/tests/test_band_masks.py
+++ b/tests/test_band_masks.py
@@ -7,10 +7,7 @@ import pytest
 
 import rasterio
 from rasterio.enums import MaskFlags
-from rasterio.errors import NodataShadowWarning
-
-
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+from rasterio.errors import NodataShadowWarning, RasterioDeprecationWarning
 
 
 @pytest.fixture(scope='function')
@@ -46,8 +43,7 @@ def tiffs(tmpdir):
 
 def test_mask_flags_deprecation():
     """mask_flags is deprecated"""
-    warnings.simplefilter('always')
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(RasterioDeprecationWarning):
         with rasterio.open('tests/data/RGB.byte.tif') as src:
             src.mask_flags
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -23,36 +23,36 @@ class WindowTest(unittest.TestCase):
         self.assertRaises(
             ValueError,
             rasterio.window_shape,
-            (((10, 20),(10, None)),) )
+            (((10, 20), (10, None)),))
         self.assertRaises(
             ValueError,
             rasterio.window_shape,
-            (((None, 10),(10, 20)),) )
+            (((None, 10), (10, 20)),))
 
     def test_window_shape_None_start(self):
         self.assertEqual(
-            rasterio.window_shape(((None,4),(None,102))),
+            rasterio.window_shape(((None, 4), (None, 102))),
             (4, 102))
 
     def test_window_shape_None_stop(self):
         self.assertEqual(
-            rasterio.window_shape(((10, None),(10, None)), 100, 90),
+            rasterio.window_shape(((10, None), (10, None)), 100, 90),
             (90, 80))
 
     def test_window_shape_positive(self):
         self.assertEqual(
-            rasterio.window_shape(((0,4),(1,102))),
+            rasterio.window_shape(((0, 4), (1, 102))),
             (4, 101))
 
     def test_window_shape_negative(self):
         self.assertEqual(
-            rasterio.window_shape(((-10, None),(-10, None)), 100, 90),
+            rasterio.window_shape(((-10, None), (-10, None)), 100, 90),
             (10, 10))
         self.assertEqual(
-            rasterio.window_shape(((~0, None),(~0, None)), 100, 90),
+            rasterio.window_shape(((~0, None), (~0, None)), 100, 90),
             (1, 1))
         self.assertEqual(
-            rasterio.window_shape(((None, ~0),(None, ~0)), 100, 90),
+            rasterio.window_shape(((None, ~0), (None, ~0)), 100, 90),
             (99, 89))
 
     def test_eval(self):
@@ -64,14 +64,14 @@ class WindowTest(unittest.TestCase):
             windows.Window.from_ranges((0, 90), (0, 80)))
 
 def test_window_index():
-    idx = rasterio.window_index(((0,4),(1,12)))
+    idx = rasterio.window_index(((0, 4), (1, 12)))
     assert len(idx) == 2
     r, c = idx
     assert r.start == 0
     assert r.stop == 4
     assert c.start == 1
     assert c.stop == 12
-    arr = np.ones((20,20))
+    arr = np.ones((20, 20))
     assert arr[idx].shape == (4, 11)
 
 class RasterBlocksTest(unittest.TestCase):
@@ -80,26 +80,26 @@ class RasterBlocksTest(unittest.TestCase):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(len(s.block_shapes), 3)
             self.assertEqual(s.block_shapes, ((3, 791), (3, 791), (3, 791)))
-            windows = s.block_windows(1)
-            (j,i), first = next(windows)
-            self.assertEqual((j,i), (0, 0))
-            self.assertEqual(first, ((0, 3), (0, 791)))
-            windows = s.block_windows()
-            (j,i), first = next(windows)
-            self.assertEqual((j,i), (0, 0))
-            self.assertEqual(first, ((0, 3), (0, 791)))
-            (j, i), second = next(windows)
-            self.assertEqual((j,i), (1, 0))
-            self.assertEqual(second, ((3, 6), (0, 791)))
-            (j, i), last = list(windows)[~0]
-            self.assertEqual((j,i), (239, 0))
-            self.assertEqual(last, ((717, 718), (0, 791)))
+            itr = s.block_windows(1)
+            (j, i), first = next(itr)
+            self.assertEqual((j, i), (0, 0))
+            self.assertEqual(first, windows.Window.from_ranges((0, 3), (0, 791)))
+            itr = s.block_windows()
+            (j, i), first = next(itr)
+            self.assertEqual((j, i), (0, 0))
+            self.assertEqual(first, windows.Window.from_ranges((0, 3), (0, 791)))
+            (j, i), second = next(itr)
+            self.assertEqual((j, i), (1, 0))
+            self.assertEqual(second, windows.Window.from_ranges((3, 6), (0, 791)))
+            (j, i), last = list(itr)[~0]
+            self.assertEqual((j, i), (239, 0))
+            self.assertEqual(last, windows.Window.from_ranges((717, 718), (0, 791)))
 
     def test_block_coverage(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(
-                s.width*s.height,
-                sum((w[0][1]-w[0][0])*(w[1][1]-w[1][0])
+                s.width * s.height,
+                sum((w[0][1] - w[0][0]) * (w[1][1] - w[1][0])
                     for ji, w in s.block_windows(1)))
 
 class WindowReadTest(unittest.TestCase):
@@ -128,7 +128,7 @@ class WindowWriteTest(unittest.TestCase):
                 name, 'w',
                 driver='GTiff', width=100, height=100, count=1,
                 dtype=a.dtype) as s:
-            s.write(a, indexes=1, window=((30, 80), (10, 60)))
+            s.write(a, indexes=1, window=windows.Window(10, 30, 50, 50))
         # subprocess.call(["open", name])
         info = subprocess.check_output(["gdalinfo", "-stats", name])
         self.assert_(
@@ -160,7 +160,7 @@ def test_block_windows_filtered_one(path_rgb_byte_tif):
         focus_window = src.window(w, n - 1.0, w + 1.0, n)
         filter_func = partial(windows.intersect, focus_window)
         itr = ((ij, win) for ij, win in src.block_windows() if filter_func(win))
-        assert next(itr) == ((0, 0), ((0, 3), (0, 791)))
+        assert next(itr) == ((0, 0), windows.Window.from_ranges((0, 3), (0, 791)))
         with pytest.raises(StopIteration):
             next(itr)
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -14,20 +14,7 @@ import rasterio
 from rasterio import windows
 
 
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
-
 class WindowTest(unittest.TestCase):
-
-    def test_window_shape_errors(self):
-        # Positive height and width are needed when stop is None.
-        self.assertRaises(
-            ValueError,
-            rasterio.window_shape,
-            (((10, 20), (10, None)),))
-        self.assertRaises(
-            ValueError,
-            rasterio.window_shape,
-            (((None, 10), (10, 20)),))
 
     def test_window_shape_None_start(self):
         self.assertEqual(
@@ -131,7 +118,7 @@ class WindowWriteTest(unittest.TestCase):
             s.write(a, indexes=1, window=windows.Window(10, 30, 50, 50))
         # subprocess.call(["open", name])
         info = subprocess.check_output(["gdalinfo", "-stats", name])
-        self.assert_(
+        self.assertTrue(
             "Minimum=0.000, Maximum=127.000, "
             "Mean=31.750, StdDev=54.993" in info.decode('utf-8'),
             info)
@@ -169,7 +156,8 @@ def test_block_windows_filtered_none(path_rgb_byte_tif):
     """Get no block windows using filter"""
     with rasterio.open(path_rgb_byte_tif) as src:
         w, s, e, n = src.bounds
-        focus_window = src.window(w - 100.0, n + 100.0, w - 1.0, n + 1.0)
+        focus_window = src.window(w - 100.0, n + 1.0, w - 1.0, n + 100.0,
+                                  boundless=True)
         filter_func = partial(windows.intersect, focus_window)
         itr = ((ij, win) for ij, win in src.block_windows() if filter_func(win))
         with pytest.raises(StopIteration):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -17,6 +17,7 @@ from rasterio import windows
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 class WindowTest(unittest.TestCase):
+
     def test_window_shape_errors(self):
         # Positive height and width are needed when stop is None.
         self.assertRaises(
@@ -27,18 +28,22 @@ class WindowTest(unittest.TestCase):
             ValueError,
             rasterio.window_shape,
             (((None, 10),(10, 20)),) )
+
     def test_window_shape_None_start(self):
         self.assertEqual(
             rasterio.window_shape(((None,4),(None,102))),
             (4, 102))
+
     def test_window_shape_None_stop(self):
         self.assertEqual(
             rasterio.window_shape(((10, None),(10, None)), 100, 90),
             (90, 80))
+
     def test_window_shape_positive(self):
         self.assertEqual(
             rasterio.window_shape(((0,4),(1,102))),
             (4, 101))
+
     def test_window_shape_negative(self):
         self.assertEqual(
             rasterio.window_shape(((-10, None),(-10, None)), 100, 90),
@@ -49,13 +54,14 @@ class WindowTest(unittest.TestCase):
         self.assertEqual(
             rasterio.window_shape(((None, ~0),(None, ~0)), 100, 90),
             (99, 89))
+
     def test_eval(self):
         self.assertEqual(
             rasterio.eval_window(((-10, None), (-10, None)), 100, 90),
-            ((90, 100), (80, 90)))
+            windows.Window.from_ranges((90, 100), (80, 90)))
         self.assertEqual(
             rasterio.eval_window(((None, -10), (None, -10)), 100, 90),
-            ((0, 90), (0, 80)))
+            windows.Window.from_ranges((0, 90), (0, 80)))
 
 def test_window_index():
     idx = rasterio.window_index(((0,4),(1,12)))
@@ -69,6 +75,7 @@ def test_window_index():
     assert arr[idx].shape == (4, 11)
 
 class RasterBlocksTest(unittest.TestCase):
+
     def test_blocks(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(len(s.block_shapes), 3)
@@ -87,6 +94,7 @@ class RasterBlocksTest(unittest.TestCase):
             (j, i), last = list(windows)[~0]
             self.assertEqual((j,i), (239, 0))
             self.assertEqual(last, ((717, 718), (0, 791)))
+
     def test_block_coverage(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(
@@ -106,10 +114,13 @@ class WindowReadTest(unittest.TestCase):
                 rasterio.window_shape(first_window))
 
 class WindowWriteTest(unittest.TestCase):
+
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
+
     def tearDown(self):
         shutil.rmtree(self.tempdir)
+
     def test_write_window(self):
         name = os.path.join(self.tempdir, "test_write_window.tif")
         a = np.ones((50, 50), dtype=rasterio.ubyte) * 127

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -6,9 +6,9 @@ def test_bounds():
 
 def test_ul():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        assert src.ul(0, 0) == (101985.0, 2826915.0)
-        assert src.ul(1, 0) == (101985.0, 2826614.95821727)
-        assert src.ul(src.height, src.width) == (339315.0, 2611485.0)
+        assert src.xy(0, 0, offset='ul') == (101985.0, 2826915.0)
+        assert src.xy(1, 0, offset='ul') == (101985.0, 2826614.95821727)
+        assert src.xy(src.height, src.width, offset='ul') == (339315.0, 2611485.0)
 
 def test_res():
     with rasterio.open('tests/data/RGB.byte.tif') as src:

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -25,4 +25,4 @@ class CopyTest(unittest.TestCase):
             'tests/data/RGB.byte.tif',
             name)
         info = subprocess.check_output(["gdalinfo", name])
-        self.assert_("GTiff" in info.decode('utf-8'))
+        self.assertTrue("GTiff" in info.decode('utf-8'))

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -5,6 +5,7 @@ import affine
 import pytest
 
 import rasterio
+from rasterio.errors import RasterioDeprecationWarning
 
 
 def test_open_affine_and_transform(path_rgb_byte_tif):
@@ -18,12 +19,11 @@ def test_open_affine_and_transform(path_rgb_byte_tif):
         with rasterio.open(
                 path_rgb_byte_tif,
                 affine=rasterio,
-                transform=affine.Affine.identity()) as src:
+                transform=affine.Affine.identity()):
             pass
         assert len(record) == 2
         assert "The 'affine' kwarg in rasterio.open() is deprecated" in str(record[0].message)
         assert "choosing 'transform'" in str(record[1].message)
-
 
 
 def test_open_transform_gdal_geotransform(path_rgb_byte_tif):
@@ -33,7 +33,7 @@ def test_open_transform_gdal_geotransform(path_rgb_byte_tif):
     with pytest.raises(TypeError):
         with rasterio.open(
                 path_rgb_byte_tif,
-                transform=tuple(affine.Affine.identity())) as src:
+                transform=tuple(affine.Affine.identity())):
             pass
 
 
@@ -42,12 +42,12 @@ def test_open_affine_kwarg_warning(path_rgb_byte_tif):
     with pytest.warns(DeprecationWarning):
         with rasterio.open(
                 path_rgb_byte_tif,
-                affine=affine.Affine.identity()) as src:
+                affine=affine.Affine.identity()):
             pass
 
 
 def test_src_affine_warning(path_rgb_byte_tif):
     """Calling src.affine should raise a warning."""
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(RasterioDeprecationWarning):
         with rasterio.open(path_rgb_byte_tif) as src:
             assert src.affine == src.transform

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -7,6 +7,12 @@ from rasterio import windows
 DATA_WINDOW = ((3, 5), (2, 6))
 
 
+def assert_window_almost_equals(a, b, precision=6):
+    for pair_outer in zip(a, b):
+        for x, y in zip(*pair_outer):
+            assert round(x, precision) == round(y, precision)
+
+
 def test_index():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds
@@ -19,15 +25,18 @@ def test_index():
 def test_full_window():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds
-        assert src.window(left, bottom, right, top) == tuple(zip((0, 0), src.shape))
+        assert_window_almost_equals(
+            src.window(left, bottom, right, top),
+            tuple(zip((0, 0), src.shape)))
 
 
 def test_window_no_exception():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds
         left -= 1000.0
-        assert src.window(left, bottom, right, top, boundless=True) == (
-                (0, src.height), (-4, src.width))
+        assert_window_almost_equals(
+            src.window(left, bottom, right, top, boundless=True),
+            ((0, src.height), (-4, src.width)))
 
 
 def test_index_values():
@@ -62,8 +71,8 @@ def test_window_full_cover():
     def bound_covers(bounds1, bounds2):
         """Does bounds1 cover bounds2?
         """
-        return (bounds1[0] <= bounds2[0] and bounds1[1] <= bounds2[1] and
-                bounds1[2] >= bounds2[2] and bounds1[3] >= bounds2[3])
+        return (round(bounds1[0], 6) <= round(bounds2[0], 6) and round(bounds1[1], 6) <= round(bounds2[1], 6) and
+                round(bounds1[2], 6) >= round(bounds2[2], 6) and round(bounds1[3], 6) >= round(bounds2[3], 6))
 
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         bounds = list(src.window_bounds(((100, 200), (100, 200))))

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -6,13 +6,14 @@ import numpy as np
 import pytest
 
 import rasterio
+from rasterio.errors import WindowError
 from rasterio import windows
 
 
 DATA_WINDOW = ((3, 5), (2, 6))
 
 
-def assert_window_almost_equals(a, b, precision=6):
+def assert_window_almost_equals(a, b, precision=3):
     for pair_outer in zip(a, b):
         for x, y in zip(*pair_outer):
             assert round(x, precision) == round(y, precision)
@@ -163,7 +164,7 @@ def test_window_intersection():
 
 
 def test_window_intersection_disjunct():
-    with pytest.raises(ValueError):
+    with pytest.raises(WindowError):
         windows.intersection(
             ((0, 6), (3, 6)),
             ((100, 200), (0, 12)),
@@ -208,7 +209,7 @@ def test_3x3matrix():
     arrangement = product(pairs, pairs)
     for wins in combinations(arrangement, 2):
         assert not windows.intersect(*wins)
-        with pytest.raises(ValueError):
+        with pytest.raises(WindowError):
             windows.intersection(*wins)
 
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,10 +1,16 @@
 """Unittests for rasterio.mask"""
 
-
+from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio.mask import mask as mask_tool
+
+
+# Custom markers.
+xfail_pixel_sensitive_gdal2 = pytest.mark.xfail(
+    parse(rasterio.__gdal_version__) < parse('2.0dev'),
+    reason="This test is sensitive to pixel values and requires GDAL 2.0+")
 
 
 def test_nodata(basic_image_file, basic_geometry):
@@ -24,6 +30,7 @@ def test_no_nodata(basic_image_file, basic_geometry):
     assert(masked.data.all() == default_nodata_val)
 
 
+@xfail_pixel_sensitive_gdal2
 def test_crop(basic_image, basic_image_file, basic_geometry):
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file, "r") as src:
@@ -37,6 +44,7 @@ def test_crop(basic_image, basic_image_file, basic_geometry):
     assert (masked[0] == image[2:5, 2:5]).all()
 
 
+@xfail_pixel_sensitive_gdal2
 def test_crop_all_touched(basic_image, basic_image_file, basic_geometry):
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file, "r") as src:

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -34,7 +34,7 @@ def test_no_nodata(basic_image_file, basic_geometry):
 def test_crop(basic_image, basic_image_file, basic_geometry):
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, crop=True)
+        masked, transform = mask_tool(src, geometries, crop=True, pad=False)
 
     image = basic_image
     image[4, :] = 0

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -32,8 +32,9 @@ def test_crop(basic_image, basic_image_file, basic_geometry):
     image = basic_image
     image[4, :] = 0
     image[:, 4] = 0
-    assert(masked.shape == (1, 4, 3))
-    assert((masked[0] == image[1:5, 2:5]).all())
+
+    assert masked.shape == (1, 3, 3)
+    assert (masked[0] == image[2:5, 2:5]).all()
 
 
 def test_crop_all_touched(basic_image, basic_image_file, basic_geometry):
@@ -42,8 +43,8 @@ def test_crop_all_touched(basic_image, basic_image_file, basic_geometry):
         masked, transform = mask_tool(src, geometries, crop=True,
                                       all_touched=True)
 
-    assert(masked.shape == (1, 4, 3))
-    assert((masked[0] == basic_image[1:5, 2:5]).all())
+    assert masked.shape == (1, 3, 3)
+    assert (masked[0] == basic_image[2:5, 2:5]).all()
 
 
 def test_crop_and_invert(basic_image_file, basic_geometry):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -8,9 +8,9 @@ from rasterio.mask import mask as mask_tool
 
 
 # Custom markers.
-xfail_pixel_sensitive_gdal2 = pytest.mark.xfail(
-    parse(rasterio.__gdal_version__) < parse('2.0dev'),
-    reason="This test is sensitive to pixel values and requires GDAL 2.0+")
+xfail_pixel_sensitive_gdal22 = pytest.mark.xfail(
+    parse(rasterio.__gdal_version__) < parse('2.2'),
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 
 
 def test_nodata(basic_image_file, basic_geometry):
@@ -30,7 +30,7 @@ def test_no_nodata(basic_image_file, basic_geometry):
     assert(masked.data.all() == default_nodata_val)
 
 
-@xfail_pixel_sensitive_gdal2
+@xfail_pixel_sensitive_gdal22
 def test_crop(basic_image, basic_image_file, basic_geometry):
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file, "r") as src:
@@ -44,7 +44,7 @@ def test_crop(basic_image, basic_image_file, basic_geometry):
     assert (masked[0] == image[2:5, 2:5]).all()
 
 
-@xfail_pixel_sensitive_gdal2
+@xfail_pixel_sensitive_gdal22
 def test_crop_all_touched(basic_image, basic_image_file, basic_geometry):
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file, "r") as src:

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 
 import rasterio
+from rasterio.errors import RasterioDeprecationWarning
 from rasterio.profiles import Profile, DefaultGTiffProfile
 from rasterio.profiles import default_gtiff_profile
 
@@ -15,12 +16,10 @@ def test_base_profile_kwarg():
     assert Profile(foo='bar')['foo'] == 'bar'
 
 
-def test_gtiff_profile_format(recwarn):
+def test_gtiff_profile_format():
     assert DefaultGTiffProfile()['driver'] == 'GTiff'
-    warnings.simplefilter('always')
-    assert DefaultGTiffProfile()()['driver'] == 'GTiff'
-    assert len(recwarn) == 1
-    assert recwarn.pop(DeprecationWarning)
+    with pytest.warns(RasterioDeprecationWarning):
+        assert DefaultGTiffProfile()()['driver'] == 'GTiff'
 
 
 def test_gtiff_profile_interleave():
@@ -116,33 +115,27 @@ def test_dataset_profile_creation_kwds(data):
         assert src.profile['foo'] == 'bar'
 
 
-def test_profile_affine_stashing(recwarn):
+def test_profile_affine_stashing():
     """Passing affine sets transform, with a warning"""
-    warnings.simplefilter('always')
-    profile = Profile(affine='foo')
-    assert len(recwarn) == 1
-    assert recwarn.pop(DeprecationWarning)
-    assert 'affine' not in profile
-    assert profile['transform'] == 'foo'
+    with pytest.warns(RasterioDeprecationWarning):
+        profile = Profile(affine='foo')
+        assert 'affine' not in profile
+        assert profile['transform'] == 'foo'
 
 
-def test_profile_mixed_error(recwarn):
+def test_profile_mixed_error():
     """Warn if both affine and transform are passed"""
-    warnings.simplefilter('always')
-    profile = Profile(affine='foo', transform='bar')
-    assert len(recwarn) == 1
-    assert recwarn.pop(DeprecationWarning)
-    assert 'affine' not in profile
-    assert profile['transform'] == 'bar'
+    with pytest.warns(RasterioDeprecationWarning):
+        profile = Profile(affine='foo', transform='bar')
+        assert 'affine' not in profile
+        assert profile['transform'] == 'bar'
 
 
-def test_profile_affine_alias(recwarn):
+def test_profile_affine_alias():
     """affine is an alias for transform, with a warning"""
     profile = Profile(transform='foo')
-    warnings.simplefilter('always')
-    assert profile['affine'] == 'foo'
-    assert len(recwarn) == 1
-    assert recwarn.pop(DeprecationWarning)
+    with pytest.warns(RasterioDeprecationWarning):
+        assert profile['affine'] == 'foo'
 
 
 def test_profile_affine_set():

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -36,7 +36,7 @@ class ReaderContextTest(unittest.TestCase):
             self.assertEqual(s.nodatavals, (0, 0, 0))
             self.assertEqual(s.indexes, (1, 2, 3))
             self.assertEqual(s.crs['init'], 'epsg:32618')
-            self.assert_(s.crs.wkt.startswith('PROJCS'), s.crs.wkt)
+            self.assertTrue(s.crs.wkt.startswith('PROJCS'), s.crs.wkt)
             for i, v in enumerate((101985.0, 2611485.0, 339315.0, 2826915.0)):
                 self.assertAlmostEqual(s.bounds[i], v)
             self.assertEqual(
@@ -69,10 +69,10 @@ class ReaderContextTest(unittest.TestCase):
 
     def test_derived_spatial(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
-            self.assert_(s.crs.wkt.startswith('PROJCS'), s.crs.wkt)
+            self.assertTrue(s.crs.wkt.startswith('PROJCS'), s.crs.wkt)
             for i, v in enumerate((101985.0, 2611485.0, 339315.0, 2826915.0)):
                 self.assertAlmostEqual(s.bounds[i], v)
-            for a, b in zip(s.ul(0, 0), (101985.0, 2826915.0)):
+            for a, b in zip(s.xy(0, 0, offset='ul'), (101985.0, 2826915.0)):
                 self.assertAlmostEqual(a, b)
 
     def test_read_ubyte(self):
@@ -127,7 +127,7 @@ class ReaderContextTest(unittest.TestCase):
             a = s.read(masked=True)  # floating point values
             self.assertEqual(a.ndim, 3)
             self.assertEqual(a.shape, (1, 2, 3))
-            self.assert_(hasattr(a, 'mask'))
+            self.assertTrue(hasattr(a, 'mask'))
             self.assertEqual(list(set(s.nodatavals)), [None])
             self.assertEqual(a.dtype, rasterio.float64)
 
@@ -169,8 +169,6 @@ class ReaderContextTest(unittest.TestCase):
 
     def test_read_window(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
-            # correct format
-            self.assertRaises(ValueError, s.read, window=(300, 320, 320, 330))
             # window with 1 nodata on band 3
             a = s.read(window=((300, 320), (320, 330)), masked=True)
             self.assertEqual(a.ndim, 3)

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -8,9 +8,6 @@ import rasterio
 from rasterio.windows import Window
 
 
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
-
-
 @pytest.fixture(scope='session')
 def rgb_array(path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as src:
@@ -134,17 +131,3 @@ def test_read_boundless_noshift():
         r2 = src.read(boundless=True,
                       window=((-1, src.shape[0] + 1), (100, 101)))[0, 0, 0:9]
         assert np.array_equal(r1, r2)
-
-
-def test_np_warning(recwarn, rgb_byte_tif_reader):
-    """Ensure no deprecation warnings
-    On np 1.11 and previous versions of rasterio you might see:
-        VisibleDeprecationWarning: using a non-integer number
-        instead of an integer will result in an error in the future
-    """
-    import warnings
-    warnings.simplefilter('always')
-    with rgb_byte_tif_reader as src:
-        window = Window(-10, -10, 110, 110)
-        src.read(1, window=window, boundless=True)
-    assert len(recwarn) == 0

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 import rasterio
+from rasterio.windows import Window
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -67,20 +68,20 @@ def test_read_boundless_overlap(rgb_byte_tif_reader):
         data = src.read(window=((-200, 200), (-200, 200)), boundless=True)
         assert data.shape == (3, 400, 400)
         assert data.any()
-        assert data[0,399,399] == 13
+        assert data[0, 399, 399] == 13
 
 
 def test_read_boundless_resample(rgb_byte_tif_reader):
     with rgb_byte_tif_reader as src:
         out = np.zeros((3, 800, 800), dtype=np.uint8)
         data = src.read(
-                out=out,
-                window=((-200, 200), (-200, 200)),
-                masked=True,
-                boundless=True)
+            out=out,
+            window=((-200, 200), (-200, 200)),
+            masked=True,
+            boundless=True)
         assert data.shape == (3, 800, 800)
         assert data.any()
-        assert data[0,798,798] == 13
+        assert data[0, 798, 798] == 13
 
 
 def test_read_boundless_masked_no_overlap(rgb_byte_tif_reader):
@@ -98,8 +99,8 @@ def test_read_boundless_masked_overlap(rgb_byte_tif_reader):
         assert data.shape == (3, 400, 400)
         assert data.mask.any()
         assert not data.mask.all()
-        assert data.mask[0,399,399] == False
-        assert data.mask[0,0,0] == True
+        assert not data.mask[0, 399, 399]
+        assert data.mask[0, 0, 0]
 
 
 def test_read_boundless_zero_stop(rgb_byte_tif_reader):
@@ -144,6 +145,6 @@ def test_np_warning(recwarn, rgb_byte_tif_reader):
     import warnings
     warnings.simplefilter('always')
     with rgb_byte_tif_reader as src:
-        window = ((-10, 100), (-10, 100))
+        window = Window(-10, -10, 110, 110)
         src.read(1, window=window, boundless=True)
     assert len(recwarn) == 0

--- a/tests/test_rio_blocks.py
+++ b/tests/test_rio_blocks.py
@@ -37,9 +37,9 @@ def check_features_block_windows(features, src, bidx):
             json.loads(feat['properties']['block']),
             block))
 
-        out.append(np.array_equal(
-            json.loads(feat['properties']['window']),
-            window))
+        f_win = feat['properties']['window']
+        assert f_win['col_off'] == window.col_off
+        assert f_win['row_off'] == window.row_off
 
     return all(out)
 
@@ -111,7 +111,7 @@ def test_windows_indent(runner, path_rgb_byte_tif):
     lines = result.output.splitlines()
     assert result.output.count('"FeatureCollection') == 1
     assert result.output.count('"Feature"') == 240
-    assert len(lines) == 7451
+    assert len(lines) == 8651
     for l in lines:
         if l.strip() not in ('{', '}'):
             assert l.startswith('    ')
@@ -138,7 +138,8 @@ def test_windows_exception(runner, path_rgb_byte_tif):
         'blocks',
         path_rgb_byte_tif,
         '--bidx', 4])
-    assert result.exit_code == 1
+    assert result.exit_code == 2
+    assert "Not a valid band index" in result.output
 
 
 def test_windows_projected(runner, path_rgb_byte_tif):

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -26,7 +26,7 @@ def test_clip_bounds(runner, tmpdir):
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
-        assert out.shape == (420, 173)
+        assert out.shape == (419, 173)
 
 
 def test_clip_bounds_geographic(runner, tmpdir):

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -191,8 +191,8 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
 
     output = str(tmpdir.join('test.tif'))
 
-    truth = np.zeros((4, 3))
-    truth[1:3, 0:2] = 1
+    truth = np.zeros((3, 3))
+    truth[0:2, 0:2] = 1
 
     result = runner.invoke(
         main_group,
@@ -214,8 +214,8 @@ def test_mask_crop_inverted_y(runner, tmpdir, basic_feature, pixelated_image_fil
 
     output = str(tmpdir.join('test.tif'))
 
-    truth = np.zeros((4, 3))
-    truth[1:3, 0:2] = 1
+    truth = np.zeros((3, 3))
+    truth[0:2, 0:2] = 1
 
     result = runner.invoke(
         main_group, [

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -21,9 +21,9 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 # Custom markers.
-xfail_without_gdal2 = pytest.mark.xfail(
-    parse(rasterio.__gdal_version__) < parse('2.0dev'),
-    reason="This test is sensitive to pixel values and requires GDAL 2.0+")
+xfail_pixel_sensitive_gdal22 = pytest.mark.xfail(
+    parse(rasterio.__gdal_version__) < parse('2.2'),
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 
 
 def bbox(*args):
@@ -176,7 +176,7 @@ def test_mask_invalid_geojson(runner, tmpdir, pixelated_image_file):
     assert 'Invalid GeoJSON' in result.output
 
 
-@xfail_without_gdal2
+@xfail_pixel_sensitive_gdal22
 def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
     """
     In order to test --crop option, we need to use a transform more similar to
@@ -214,7 +214,7 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
             out.read(1, masked=True).filled(0))
 
 
-@xfail_without_gdal2
+@xfail_pixel_sensitive_gdal22
 def test_mask_crop_inverted_y(runner, tmpdir, basic_feature, pixelated_image_file):
     """
     --crop option should also work if raster has a positive y pixel size

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -7,6 +7,7 @@ import warnings
 
 from affine import Affine
 import numpy as np
+from packaging.version import parse
 import pytest
 
 import rasterio
@@ -17,6 +18,12 @@ from rasterio.rio.main import main_group
 DEFAULT_SHAPE = (10, 10)
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+# Custom markers.
+xfail_without_gdal2 = pytest.mark.xfail(
+    parse(rasterio.__gdal_version__) < parse('2.0dev'),
+    reason="This test is sensitive to pixel values and requires GDAL 2.0+")
 
 
 def bbox(*args):
@@ -169,6 +176,7 @@ def test_mask_invalid_geojson(runner, tmpdir, pixelated_image_file):
     assert 'Invalid GeoJSON' in result.output
 
 
+@xfail_without_gdal2
 def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
     """
     In order to test --crop option, we need to use a transform more similar to
@@ -206,6 +214,7 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
             out.read(1, masked=True).filled(0))
 
 
+@xfail_without_gdal2
 def test_mask_crop_inverted_y(runner, tmpdir, basic_feature, pixelated_image_file):
     """
     --crop option should also work if raster has a positive y pixel size

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -1,4 +1,3 @@
-import logging
 import json
 import os
 import re
@@ -16,8 +15,6 @@ from rasterio.rio.main import main_group
 
 
 DEFAULT_SHAPE = (10, 10)
-
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 # Custom markers.
@@ -124,13 +121,13 @@ def test_mask_out_of_bounds(runner, tmpdir, basic_feature,
 
     output = str(tmpdir.join('test.tif'))
 
-    with pytest.warns(UserWarning) as warnings:
+    with pytest.warns(UserWarning) as rec:
         result = runner.invoke(
             main_group,
             ['mask', pixelated_image_file, output, '--geojson-mask', '-'],
             input=json.dumps(basic_feature))
     assert result.exit_code == 0
-    assert any(['outside bounds' in w.message.args[0] for w in warnings])
+    assert any(['outside bounds' in w.message.args[0] for w in rec])
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
@@ -277,8 +274,7 @@ def test_mask_crop_and_invert(runner, tmpdir, basic_feature, pixelated_image,
 
 
 def test_shapes(runner, pixelated_image_file):
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(None):
 
         result = runner.invoke(main_group, ['shapes', pixelated_image_file])
 
@@ -303,8 +299,7 @@ def test_shapes_sequence(runner, pixelated_image_file):
     --sequence option should produce 4 features in series rather than
     inside a feature collection.
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(None):
 
         result = runner.invoke(
             main_group, ['shapes', pixelated_image_file, '--sequence'])
@@ -349,8 +344,7 @@ def test_shapes_indent(runner, pixelated_image_file):
     """
     --indent option should produce lots of newlines and contiguous spaces
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(None):
 
         result = runner.invoke(
             main_group, ['shapes', pixelated_image_file, '--indent', 2])
@@ -363,8 +357,7 @@ def test_shapes_indent(runner, pixelated_image_file):
 
 
 def test_shapes_compact(runner, pixelated_image_file):
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(None):
 
         result = runner.invoke(
             main_group, ['shapes', pixelated_image_file, '--compact'])
@@ -408,8 +401,7 @@ def test_shapes_mask(runner, pixelated_image, pixelated_image_file):
     with rasterio.open(pixelated_image_file, 'r+') as out:
         out.write(pixelated_image, indexes=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(None):
         result = runner.invoke(
             main_group, ['shapes', pixelated_image_file, '--mask'])
         assert result.exit_code == 0
@@ -431,8 +423,8 @@ def test_shapes_mask_sampling(runner, pixelated_image, pixelated_image_file):
     with rasterio.open(pixelated_image_file, 'r+') as out:
         out.write(pixelated_image, indexes=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(None):
+
         result = runner.invoke(
             main_group,
             ['shapes', pixelated_image_file, '--mask', '--sampling', 5])
@@ -457,8 +449,7 @@ def test_shapes_band1_as_mask(runner, pixelated_image, pixelated_image_file):
     with rasterio.open(pixelated_image_file, 'r+') as out:
         out.write(pixelated_image, indexes=1)
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with pytest.warns(None):
         result = runner.invoke(
             main_group,
             ['shapes', pixelated_image_file, '--band', '--bidx', '1', '--as-mask'])

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -4,16 +4,13 @@ import sys
 
 import click
 from click.testing import CliRunner
-from packaging.version import Version
+from packaging.version import Version, parse
 import pytest
 
 import rasterio
 from rasterio.rio.edit_info import (
     all_handler, crs_handler, tags_handler, transform_handler)
 from rasterio.rio.main import main_group
-
-
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 def test_delete_nodata_exclusive_opts(data):
@@ -34,8 +31,8 @@ def test_delete_crs_exclusive_opts(data):
     assert result.exit_code == 2
 
 
-@pytest.mark.xfail(
-    Version(rasterio.__gdal_version__) < Version('1.10'),
+@pytest.mark.skip(
+    parse(rasterio.__gdal_version__) < parse('1.10'),
     reason='GDAL version >= 1.10 required')
 def test_unset_crs(data):
     runner = CliRunner()
@@ -48,7 +45,7 @@ def test_unset_crs(data):
 
 
 @pytest.mark.skip(
-    Version(rasterio.__gdal_version__) >= Version('1.10'),
+    parse(rasterio.__gdal_version__) >= parse('1.10'),
     reason='Test applies to GDAL version < 1.10')
 def test_unset_crs_gdal19(data):
     """unsetting crs doesn't work for geotiff and gdal 1.9
@@ -59,7 +56,7 @@ def test_unset_crs_gdal19(data):
         orig_crs = src.crs
     with pytest.warns(UserWarning):
         result = runner.invoke(main_group,
-                            ['edit-info', inputfile, '--unset-crs'])
+                               ['edit-info', inputfile, '--unset-crs'])
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
         assert src.crs == orig_crs  # nochange

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -382,6 +382,8 @@ def test_merge_tiny_output_opt(tiffs):
 
 
 @xfail_pixel_sensitive_gdal2
+@pytest.mark.xfail(sys.version_info < (3,),
+                   reason="Test is sensitive to rounding behavior")
 def test_merge_tiny_res_bounds(tiffs):
     outputname = str(tiffs.join('merged.tif'))
     inputs = [str(x) for x in tiffs.listdir()]

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -324,7 +324,7 @@ def tiffs(tmpdir):
     return tmpdir
 
 
-def test_merge_tiny(tiffs):
+def test_merge_tiny_base(tiffs):
     outputname = str(tiffs.join('merged.tif'))
     inputs = [str(x) for x in tiffs.listdir()]
     inputs.sort()
@@ -341,6 +341,7 @@ def test_merge_tiny(tiffs):
 
     with rasterio.open(outputname) as src:
         data = src.read()
+        print(data)
         assert (data[0][0:2, 1] == 120).all()
         assert (data[0][0:2, 2:4] == 90).all()
         assert data[0][2][1] == 60
@@ -380,39 +381,39 @@ def test_merge_tiny_res_bounds(tiffs):
     assert result.exit_code == 0
 
     # Output should be
-    # [[[120  90]
-    #   [ 40   0]]]
+    # [[[0  90]
+    #   [0   0]]]
 
     with rasterio.open(outputname) as src:
         data = src.read()
         print(data)
-        assert data[0, 0, 0] == 120
+        assert data[0, 0, 0] == 0
         assert data[0, 0, 1] == 90
-        assert data[0, 1, 0] == 40
+        assert data[0, 1, 0] == 0
         assert data[0, 1, 1] == 0
 
 
-def test_merge_tiny_res_high_precision(tiffs):
-    outputname = str(tiffs.join('merged.tif'))
-    inputs = [str(x) for x in tiffs.listdir()]
-    inputs.sort()
-    runner = CliRunner()
-    result = runner.invoke(
-        main_group,
-        ['merge'] + inputs + [outputname, '--res', 2, '--precision', 15])
-    assert result.exit_code == 0
-
-    # Output should be
-    # [[[120  90]
-    #   [ 40   0]]]
-
-    with rasterio.open(outputname) as src:
-        data = src.read()
-        print(data)
-        assert data[0, 0, 0] == 120
-        assert data[0, 0, 1] == 90
-        assert data[0, 1, 0] == 40
-        assert data[0, 1, 1] == 0
+# def test_merge_tiny_res_high_precision(tiffs):
+#     outputname = str(tiffs.join('merged.tif'))
+#     inputs = [str(x) for x in tiffs.listdir()]
+#     inputs.sort()
+#     runner = CliRunner()
+#     result = runner.invoke(
+#         main_group,
+#         ['merge'] + inputs + [outputname, '--res', 2, '--precision', 15])
+#     assert result.exit_code == 0
+# 
+#     # Output should be
+#     # [[[120  90]
+#     #   [ 40   0]]]
+# 
+#     with rasterio.open(outputname) as src:
+#         data = src.read()
+#         print(data)
+#         assert data[0, 0, 0] == 120
+#         assert data[0, 0, 1] == 90
+#         assert data[0, 1, 0] == 40
+#         assert data[0, 1, 1] == 0
 
 
 def test_merge_rgb(tmpdir):

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -393,29 +393,6 @@ def test_merge_tiny_res_bounds(tiffs):
         assert data[0, 1, 1] == 0
 
 
-# def test_merge_tiny_res_high_precision(tiffs):
-#     outputname = str(tiffs.join('merged.tif'))
-#     inputs = [str(x) for x in tiffs.listdir()]
-#     inputs.sort()
-#     runner = CliRunner()
-#     result = runner.invoke(
-#         main_group,
-#         ['merge'] + inputs + [outputname, '--res', 2, '--precision', 15])
-#     assert result.exit_code == 0
-# 
-#     # Output should be
-#     # [[[120  90]
-#     #   [ 40   0]]]
-# 
-#     with rasterio.open(outputname) as src:
-#         data = src.read()
-#         print(data)
-#         assert data[0, 0, 0] == 120
-#         assert data[0, 0, 1] == 90
-#         assert data[0, 1, 0] == 40
-#         assert data[0, 1, 1] == 0
-
-
 def test_merge_rgb(tmpdir):
     """Get back original image"""
     outputname = str(tmpdir.join('merged.tif'))

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -8,6 +8,7 @@ import logging
 import affine
 from click.testing import CliRunner
 import numpy as np
+from packaging.version import parse
 from pytest import fixture
 import pytest
 
@@ -17,7 +18,10 @@ from rasterio.rio.main import main_group
 from rasterio.transform import Affine
 
 
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+# Custom markers.
+xfail_pixel_sensitive_gdal2 = pytest.mark.xfail(
+    parse(rasterio.__gdal_version__) < parse('2.0dev'),
+    reason="This test is sensitive to pixel values and requires GDAL 2.0+")
 
 
 # Fixture to create test datasets within temporary directory
@@ -95,6 +99,7 @@ def test_merge_with_colormap(test_data_dir_1):
         assert cmap[255] == (0, 0, 0, 255)
 
 
+@xfail_pixel_sensitive_gdal2
 def test_merge_with_nodata(test_data_dir_1):
     outputname = str(test_data_dir_1.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_1.listdir()]
@@ -125,6 +130,7 @@ def test_merge_warn(test_data_dir_1):
     assert os.path.exists(outputname)
 
 
+@xfail_pixel_sensitive_gdal2
 def test_merge_without_nodata(test_data_dir_2):
     outputname = str(test_data_dir_2.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_2.listdir()]
@@ -268,6 +274,10 @@ def test_data_dir_float(tmpdir):
     return tmpdir
 
 
+@xfail_pixel_sensitive_gdal2
+@pytest.mark.xfail(
+    os.environ.get('GDALVERSION', 'a.b.c').startswith('1.9'),
+    reason="GDAL 1.9 doesn't catch this error")
 def test_merge_float(test_data_dir_float):
     outputname = str(test_data_dir_float.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_float.listdir()]
@@ -371,6 +381,7 @@ def test_merge_tiny_output_opt(tiffs):
         assert data[0][3][0] == 40
 
 
+@xfail_pixel_sensitive_gdal2
 def test_merge_tiny_res_bounds(tiffs):
     outputname = str(tiffs.join('merged.tif'))
     inputs = [str(x) for x in tiffs.listdir()]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -3,6 +3,7 @@ import pytest
 import rasterio
 from rasterio import transform
 from rasterio.transform import xy, rowcol
+from rasterio.windows import Window
 
 
 def test_window_transform():
@@ -59,7 +60,7 @@ def test_window_bounds():
 
         # Test a small window in each corner, both in and slightly out of bounds
         p = 10
-        for window in (
+        for ranges in (
                 # In bounds (UL, UR, LL, LR)
                 ((0, p), (0, p)),
                 ((0, p), (cols - p, p)),
@@ -74,7 +75,8 @@ def test_window_bounds():
 
             # Alternate formula
 
-            ((row_min, row_max), (col_min, col_max)) = window
+            window = Window.from_ranges(*ranges)
+            (row_min, row_max), (col_min, col_max) = ranges
             win_aff = src.window_transform(window)
 
             x_min, y_max = win_aff.c, win_aff.f

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -2,6 +2,7 @@ from copy import copy
 import logging
 import math
 import sys
+import warnings
 
 from affine import Affine
 from hypothesis import given
@@ -10,50 +11,19 @@ import numpy as np
 import pytest
 
 import rasterio
+from rasterio.errors import RasterioDeprecationWarning, WindowError
 from rasterio.windows import (
-    crop, from_bounds, bounds, transform, evaluate, window_index, shape, Window,
-    intersect, intersection, get_data_window, union, round_window_to_full_blocks,
-    toranges)
+    crop, from_bounds, bounds, transform, evaluate, window_index, shape,
+    Window, intersect, intersection, get_data_window, union,
+    round_window_to_full_blocks, toranges)
 
 EPS = 1.0e-8
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def assert_window_almost_equals(a, b, precision=3):
-    for pair_outer in zip(a, b):
-        for x, y in zip(*pair_outer):
-            assert round(x, precision) == round(y, precision)
-
-
-@given(col_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       row_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       num_cols=floats(min_value=0.0, max_value=1.0e+7),
-       num_rows=floats(min_value=0.0, max_value=1.0e+7)) 
-def test_window_ctor(col_off, row_off, num_cols, num_rows):
-    window = Window(col_off, row_off, num_cols, num_rows)
-    assert window.col_off == col_off
-    assert window.row_off == row_off
-    assert window.num_cols == num_cols
-    assert window.num_rows == num_rows
-
-
-
-@given(col_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       row_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       num_cols=floats(min_value=0.0, max_value=1.0e+7),
-       num_rows=floats(min_value=0.0, max_value=1.0e+7)) 
-def test_window_round_up(col_off, row_off, num_cols, num_rows):
-    window = Window(col_off, row_off, num_cols, num_rows).round_shape()
-    assert window.col_off == col_off
-    assert window.row_off == row_off
-    assert window.num_cols == math.ceil(round(num_cols, 3))
-    assert window.num_rows == math.ceil(round(num_rows, 3))
-
-
-def test_round_shape_invalid_op():
-    with pytest.raises(ValueError):
-        Window(0, 0, 1, 1).round_shape(op='bogus')
+def assert_window_almost_equals(a, b):
+    assert np.allclose(a.flatten(), b.flatten(), rtol=1e-3, atol=1e-4)
 
 
 @given(col_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
@@ -66,23 +36,8 @@ def test_crop(col_off, row_off, num_cols, num_rows, height, width):
     window = crop(Window(col_off, row_off, num_cols, num_rows), height, width)
     assert 0.0 <= round(window.col_off, 3) <= width
     assert 0.0 <= round(window.row_off, 3) <= height
-    assert round(window.num_cols, 3) <= round(width - window.col_off, 3)
-    assert round(window.num_rows, 3) <= round(height - window.row_off, 3)
-
-
-def test_crop_coerce():
-    with pytest.warns(DeprecationWarning):
-        assert crop(((-10, 10), (-10, 10)), 5, 5).num_cols == 5
-
-
-def test_transform_coerce():
-    with pytest.warns(DeprecationWarning):
-        assert transform(((-10, 10), (-10, 10)), Affine.identity()).a == 1.0
-
-
-def test_window_index_coerce():
-    with pytest.warns(DeprecationWarning):
-        assert window_index(((-10, 10), (-10, 10)))[0].start == -10
+    assert round(window.width, 3) <= round(width - window.col_off, 3)
+    assert round(window.height, 3) <= round(height - window.row_off, 3)
 
 
 def test_window_function():
@@ -95,16 +50,19 @@ def test_window_function():
 
         assert_window_almost_equals(from_bounds(
             left + EPS, bottom + EPS, right - EPS, top - EPS, src.transform,
-            height, width), ((0, height), (0, width)))
+            height, width), Window.from_slices((0, height), (0, width)))
 
         assert_window_almost_equals(from_bounds(
             left, top - 2 * dy - EPS, left + 2 * dx - EPS, top, src.transform,
-            height, width), ((0, 2), (0, 2)))
+            height, width), Window.from_slices((0, 2), (0, 2)))
 
         # boundless
-        assert_window_almost_equals(from_bounds(
-            left - 2 * dx, top - 2 * dy, left + 2 * dx, top + 2 * dy,
-            src.transform, boundless=True), ((-2, 2), (-2, 2)))
+        assert_window_almost_equals(
+            from_bounds(left - 2 * dx, top - 2 * dy, left + 2 * dx,
+                        top + 2 * dy, src.transform, height=height,
+                        width=width),
+            Window.from_slices((-2, 2), (-2, 2), boundless=True, height=height,
+                               width=width))
 
 
 def test_window_float():
@@ -117,97 +75,21 @@ def test_window_float():
 
         assert_window_almost_equals(from_bounds(
             left, top - 400, left + 400, top, src.transform,
-            height, width), ((0, 400 / src.res[1]), (0, 400 / src.res[0])))
+            height, width), Window.from_slices((0, 400 / src.res[1]), (0, 400 / src.res[0])))
 
 
 def test_window_bounds_south_up():
     identity = Affine.identity()
     assert_window_almost_equals(
         from_bounds(0, 10, 10, 0, identity, 10, 10),
-        Window(0, 0, 10, 10),
-        precision=5)
-
-
-def test_toranges():
-    assert Window(0, 0, 1, 1).toranges() == ((0, 1), (0, 1))
-
-
-def test_toranges_warn():
-    with pytest.warns(DeprecationWarning):
-        toranges(((0, 1), (0, 1)))
-
-
-def test_window_function():
-    # TODO: break this test up.
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        left, bottom, right, top = src.bounds
-        dx, dy = src.res
-        height = src.height
-        width = src.width
-
-        assert_window_almost_equals(from_bounds(
-            left + EPS, bottom + EPS, right - EPS, top - EPS, src.transform,
-            height, width), ((0, height), (0, width)))
-
-        assert_window_almost_equals(from_bounds(
-            left, top - 2 * dy - EPS, left + 2 * dx - EPS, top, src.transform,
-            height, width), ((0, 2), (0, 2)))
-
-        # boundless
-        assert_window_almost_equals(from_bounds(
-            left - 2 * dx, top - 2 * dy, left + 2 * dx, top + 2 * dy,
-            src.transform, boundless=True), ((-2, 2), (-2, 2)))
-
-
-def test_window_float():
-    """Test window float values"""
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        left, bottom, right, top = src.bounds
-        dx, dy = src.res
-        height = src.height
-        width = src.width
-
-        assert_window_almost_equals(from_bounds(
-            left, top - 400, left + 400, top, src.transform,
-            height, width), ((0, 400 / src.res[1]), (0, 400 / src.res[0])))
-
-
-def test_window_bounds_south_up():
-    identity = Affine.identity()
-    assert_window_almost_equals(
-        from_bounds(0, 10, 10, 0, identity, 10, 10),
-        Window(0, 0, 10, 10),
-        precision=5)
-
-def test_toranges():
-    assert Window(0, 0, 1, 1).toranges() == ((0, 1), (0, 1))
-
-@given(col_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       row_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       num_cols=floats(min_value=0.0, max_value=1.0e+7),
-       num_rows=floats(min_value=0.0, max_value=1.0e+7)) 
-def test_array_interface(col_off, row_off, num_cols, num_rows):
-    arr = np.array(Window(col_off, row_off, num_cols, num_rows))
-    assert arr.shape == (2, 2)
+        Window(0, 0, 10, 10))
 
 
 def test_window_bounds_north_up():
     transform = Affine.translation(0.0, 10.0) * Affine.scale(1.0, -1.0) * Affine.identity()
     assert_window_almost_equals(
         from_bounds(0, 0, 10, 10, transform, 10, 10),
-        Window(0, 0, 10, 10),
-        precision=5)
-
-
-@pytest.mark.xfail(reason="feature eliminated")
-def test_window_function_valuerror():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
-        left, bottom, right, top = src.bounds
-
-        with pytest.raises(ValueError):
-            # No height or width
-            from_bounds(left + EPS, bottom + EPS, right - EPS, top - EPS,
-                        src.transform)
+        Window(0, 0, 10, 10))
 
 
 def test_window_transform_function():
@@ -231,49 +113,15 @@ def test_window_bounds_function():
         assert bounds(((0, rows), (0, cols)), src.transform) == src.bounds
 
 
-bad_value_windows = [
-    (1, 2, 3),
-    ((1, 0), (2,))]
-
 bad_type_windows = [
     (1, 2),
     ((1, 0), 2)]
 
 
-@pytest.mark.parametrize("window", bad_value_windows)
-def test_eval_window_bad_value(window):
-    with pytest.raises(ValueError):
-        evaluate(window, 10, 10)
-
-
 @pytest.mark.parametrize("window", bad_type_windows)
 def test_eval_window_bad_type(window):
-    with pytest.raises(TypeError):
+    with pytest.raises(WindowError):
         evaluate(window, 10, 10)
-
-
-bad_params = (
-    (((-1, 10), (0, 10)), -1, 10),
-    (((1, -1), (0, 10)), -1, 10),
-    (((0, 10), (-1, 10)), 10, -1),
-    (((0, 10), (1, -1)), 10, -1),
-    (((10, 5), (0, 5)), 10, 10),
-    (((0, 5), (10, 5)), 10, 10))
-
-
-@pytest.mark.parametrize("params", bad_params)
-def test_eval_window_invalid_dims(params):
-    with pytest.raises(ValueError):
-        evaluate(*params)
-
-
-@pytest.mark.parametrize("params,expected", [
-    ([((2, 4), (2, 4)), 10, 10], ((2, 4), (2, 4))),
-    ([((-10, None), (-10, None)), 100, 90], ((90, 100), (80, 90))),
-    ([((None, -10), (None, -10)), 100, 90], ((0, 90), (0, 80))),
-    ([((0, 256), (0, 256)), 7791, 7621], ((0, 256), (0, 256)))])
-def test_windows_evaluate(params, expected):
-    assert evaluate(*params) == Window.from_ranges(*expected)
 
 
 def test_window_index():
@@ -290,11 +138,8 @@ def test_window_index():
 
 def test_window_shape_errors():
     # Positive height and width are needed when stop is None.
-    with pytest.raises(ValueError):
+    with pytest.raises(WindowError):
         assert shape(((10, 20), (10, None)))
-
-    with pytest.raises(ValueError):
-        assert shape(((-1, 10), (10, 20)))
 
 
 def test_window_shape_None_start():
@@ -318,57 +163,6 @@ def test_shape_negative_start():
     assert shape(((None, ~0), (None, ~0)), 100, 90) == (99, 89)
 
 
-def test_window_class_constructor():
-    """Construct a Window from offsets, height, and width"""
-    window = Window(row_off=0, col_off=1, num_rows=100, num_cols=200)
-    assert window == Window.from_ranges((0, 100), (1, 201))
-
-
-def test_window_class_constructor_positional():
-    """Construct a Window using positional parameters"""
-    window = Window(1, 0, 200, 100)
-    assert window == Window.from_ranges((0, 100), (1, 201))
-
-
-def test_window_class_attrs():
-    """Test Window attributes"""
-    window = Window(row_off=0, col_off=1, num_rows=100, num_cols=200)
-    assert window.col_off == 1
-    assert window.row_off == 0
-    assert window.num_cols == 200
-    assert window.num_rows == 100
-
-
-def test_window_class_repr():
-    """Test Window respresentation"""
-    window = Window(row_off=0, col_off=1, num_rows=100, num_cols=200)
-    assert repr(window) == 'Window(col_off=1, row_off=0, num_cols=200, num_rows=100)'
-    assert eval(repr(window)) == Window.from_ranges((0, 100), (1, 201))
-
-
-def test_window_class_copy():
-    """Test Window copying"""
-    window = Window(row_off=0, col_off=1, num_rows=100, num_cols=200)
-    assert copy(window) == Window.from_ranges((0, 100), (1, 201))
-
-
-def test_window_class_todict():
-    """Test Window.todict"""
-    window = Window(row_off=0, col_off=1, num_rows=100, num_cols=200)
-    assert window.todict() == {
-        'col_off': 1, 'num_cols': 200, 'num_rows': 100, 'row_off': 0}
-
-
-def test_window_class_toslices():
-    """Test Window.toslices"""
-    window = Window(row_off=0, col_off=1, num_rows=100, num_cols=200)
-    yslice, xslice = window.toslices()
-    assert yslice.start == 0
-    assert yslice.stop == 100
-    assert xslice.start == 1
-    assert xslice.stop == 201
-
-
 def test_window_class_intersects():
     """Windows intersect"""
     assert intersect(Window(0, 0, 10, 10), Window(8, 8, 10, 10))
@@ -384,14 +178,15 @@ def test_window_class_nonintersects():
     assert not intersect(Window(0, 0, 10, 10), Window(10, 10, 10, 10))
 
 
-def test_window_from_ranges():
-    """from_ranges classmethod works."""
-    assert Window.from_ranges((0, 1), (2, 3)) == Window.from_ranges((0, 1), (2, 3))
+def test_window_from_slices():
+    """from_slices classmethod works."""
+    assert Window.from_slices((0, 1), (2, 3)) == Window.from_slices((0, 1), (2, 3))
 
 
 def test_window_from_offlen():
     """from_offlen classmethod works."""
-    assert Window.from_offlen(2, 0, 1, 1) == Window.from_ranges((0, 1), (2, 3))
+    with pytest.warns(RasterioDeprecationWarning):
+        assert Window.from_offlen(2, 0, 1, 1) == Window.from_slices((0, 1), (2, 3))
 
 
 def test_read_with_window_class():
@@ -404,7 +199,7 @@ def test_read_with_window_class():
 def test_data_window_invalid_arr_dims():
     """An array of more than 3 dimensions is invalid."""
     arr = np.ones((3, 3, 3, 3))
-    with pytest.raises(ValueError):
+    with pytest.raises(WindowError):
         get_data_window(arr)
 
 
@@ -412,7 +207,7 @@ def test_data_window_full():
     """Get window of entirely valid data array."""
     arr = np.ones((3, 3))
     window = get_data_window(arr)
-    assert window == Window.from_ranges((0, 3), (0, 3))
+    assert window == Window.from_slices((0, 3), (0, 3))
 
 
 def test_data_window_nodata():
@@ -420,7 +215,7 @@ def test_data_window_nodata():
     arr = np.ones((3, 3))
     arr[0, :] = 0
     window = get_data_window(arr, nodata=0)
-    assert window == Window.from_ranges((1, 3), (0, 3))
+    assert window == Window.from_slices((1, 3), (0, 3))
 
 
 def test_data_window_novalid():
@@ -428,7 +223,7 @@ def test_data_window_novalid():
     arr = np.ones((3, 3))
     arr[:, :] = 0
     window = get_data_window(arr, nodata=0)
-    assert window == Window.from_ranges((0, 0), (0, 0))
+    assert window == Window.from_slices((0, 0), (0, 0))
 
 
 def test_data_window_maskedarray():
@@ -437,7 +232,7 @@ def test_data_window_maskedarray():
     arr[0, :] = 0
     arr = np.ma.masked_array(arr, arr == 0)
     window = get_data_window(arr)
-    assert window == Window.from_ranges((1, 3), (0, 3))
+    assert window == Window.from_slices((1, 3), (0, 3))
 
 
 def test_data_window_nodata_3d():
@@ -445,43 +240,43 @@ def test_data_window_nodata_3d():
     arr = np.ones((3, 3, 3))
     arr[:, 0, :] = 0
     window = get_data_window(arr, nodata=0)
-    assert window == Window.from_ranges((1, 3), (0, 3))
+    assert window == Window.from_slices((1, 3), (0, 3))
 
 
 def test_window_union():
     """Window union works."""
     window = union(Window(0, 0, 1, 1), Window(1, 1, 2, 2))
-    assert window == Window.from_ranges((0, 3), (0, 3))
+    assert window == Window.from_slices((0, 3), (0, 3))
 
 
 def test_no_intersection():
     """Non intersecting windows raises error."""
-    with pytest.raises(ValueError):
+    with pytest.raises(WindowError):
         intersection(Window(0, 0, 1, 1), Window(1, 1, 2, 2))
 
 
 def test_intersection():
     """Window intersection works."""
     window = intersection(Window(0, 0, 10, 10), Window(8, 8, 12, 12))
-    assert window == Window.from_ranges((8, 10), (8, 10))
+    assert window == Window.from_slices((8, 10), (8, 10))
 
 
 def test_round_window_to_full_blocks():
-    with rasterio.open('tests/data/alpha.tif') as src, pytest.warns(DeprecationWarning):
+    with rasterio.open('tests/data/alpha.tif') as src:
         block_shapes = src.block_shapes
         test_window = ((321, 548), (432, 765))
         rounded_window = round_window_to_full_blocks(test_window, block_shapes)
         block_shape = block_shapes[0]
         height_shape = block_shape[0]
         width_shape = block_shape[1]
-        assert rounded_window[0][0] % height_shape == 0
-        assert rounded_window[0][1] % height_shape == 0
-        assert rounded_window[1][0] % width_shape == 0
-        assert rounded_window[1][1] % width_shape == 0
+        assert rounded_window.row_off % height_shape == 0
+        assert rounded_window.height % height_shape == 0
+        assert rounded_window.col_off % width_shape == 0
+        assert rounded_window.width % width_shape == 0
 
 
 def test_round_window_to_full_blocks_error():
-    with pytest.raises(ValueError):
+    with pytest.raises(WindowError):
         round_window_to_full_blocks(
             Window(0, 0, 10, 10), block_shapes=[(1, 1), (2, 2)])
 
@@ -491,7 +286,8 @@ def test_round_window_already_at_edge():
         block_shapes = src.block_shapes
         test_window = ((256, 512), (512, 768))
         rounded_window = round_window_to_full_blocks(test_window, block_shapes)
-        assert rounded_window == Window.from_ranges(*test_window)
+        assert rounded_window == Window.from_slices(*test_window)
+
 
 def test_round_window_boundless():
     with rasterio.open('tests/data/alpha.tif') as src:
@@ -501,7 +297,7 @@ def test_round_window_boundless():
         block_shape = block_shapes[0]
         height_shape = block_shape[0]
         width_shape = block_shape[1]
-        assert rounded_window[0][0] % height_shape == 0
-        assert rounded_window[0][1] % height_shape == 0
-        assert rounded_window[1][0] % width_shape == 0
-        assert rounded_window[1][1] % width_shape == 0
+        assert rounded_window.row_off % height_shape == 0
+        assert rounded_window.height % height_shape == 0
+        assert rounded_window.col_off % width_shape == 0
+        assert rounded_window.width % width_shape == 0

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -63,6 +63,22 @@ def test_window_float():
             height, width), ((0, 400 / src.res[1]), (0, 400 / src.res[0])))
 
 
+def test_window_bounds_south_up():
+    identity = Affine.identity()
+    assert_window_almost_equals(
+        from_bounds(0, 10, 10, 0, identity, 10, 10),
+        Window(0, 0, 10, 10),
+        precision=5)
+
+
+def test_window_bounds_north_up():
+    transform = Affine.translation(0.0, 10.0) * Affine.scale(1.0, -1.0) * Affine.identity()
+    assert_window_almost_equals(
+        from_bounds(0, 0, 10, 10, transform, 10, 10),
+        Window(0, 0, 10, 10),
+        precision=5)
+
+
 def test_window_function_valuerror():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         left, bottom, right, top = src.bounds


### PR DESCRIPTION
Since 2.0, GDAL supports float precision read/write windows: https://trac.osgeo.org/gdal/wiki/rfc51_rasterio_resampling_progress. This PR extends the feature throughout Rasterio.

In #1063 you can see some pictures showing the improvements from this PR. Tile edge artifacts in terrain tiles are practically eliminated.

There's one potentially-breaking change here: the `Window` class no longer derives from `tuple` (and `namedtuple`) and this means that users can no longer compare `Window(0.5, 0.5, 10.0, 10.0)` == ((0.5, 10.5), (0.5, 10.5))` as we used to do in our tests. It's my intent that old style tuple windows remain valid input to `read()` and `write()` but that we will warn about future deprecation of this usage (a TODO).