### PR TITLE
[WIP] Support non-path connection strings

### DIFF
--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -2,10 +2,39 @@
 Helper objects used by multiple CLI commands.
 """
 
+
 import json
 import os
 
+import rasterio
 from rasterio.errors import FileOverwriteError
+
+
+def path_exists(path):
+
+    """Indicates if a path exists.  If ``path`` is a path to a local file on
+    disk ``True`` is returned, otherwise Rasterio attempts to open ``path``
+    in read-only mode.  If no exceptions are raised then the path is
+    assumed to exist.
+
+    Parameters
+    ----------
+    path : str
+        Path (or connection string) to raster.
+
+    Returns
+    -------
+    bool
+    """
+
+    if os.path.exists(path):
+        return True
+
+    try:
+        with rasterio.open(path):
+            return True
+    except Exception:
+        return False
 
 
 def coords(obj):
@@ -83,11 +112,11 @@ def resolve_inout(input=None, output=None, files=None, force_overwrite=False):
     :param:`force_overwrite` is `True`.
     """
     resolved_output = output or (files[-1] if files else None)
-    if not force_overwrite and resolved_output and os.path.exists(
-            resolved_output):
+    if not force_overwrite and resolved_output \
+            and path_exists(resolved_output):
         raise FileOverwriteError(
-            "file exists and won't be overwritten without use of the "
-            "`--force-overwrite` option.")
+            "raster exists and won't be overwritten without use of the "
+            "'--force-overwrite' option.")
     resolved_inputs = (
         [input] if input else [] +
         list(files[:-1 if not output else None]) if files else [])

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -125,8 +125,8 @@ def file_in_handler(ctx, param, value):
         else:
             path = abspath_forward_slashes(path)
         return path
-    except Exception:
-        raise click.BadParameter("{} is not a valid input file".format(value))
+    except Exception as e:
+        raise click.BadParameter(str(e))
 
 
 def from_like_context(ctx, param, value):

--- a/rasterio/rio/rasterize.py
+++ b/rasterio/rio/rasterize.py
@@ -14,7 +14,7 @@ import rasterio
 from rasterio.errors import CRSError
 from rasterio.coords import disjoint_bounds
 from rasterio.rio import options
-from rasterio.rio.helpers import resolve_inout
+from rasterio.rio.helpers import path_exists, resolve_inout
 
 
 logger = logging.getLogger('rio')
@@ -153,7 +153,7 @@ def rasterize(
 
         geojson_bounds = geojson.get('bbox', calculate_bounds(geojson))
 
-        if os.path.exists(output):
+        if path_exists(output):
             with rasterio.open(output, 'r+') as out:
                 if has_src_crs and src_crs != out.crs:
                     raise click.BadParameter('GeoJSON does not match crs of '

--- a/rasterio/rio/transform.py
+++ b/rasterio/rio/transform.py
@@ -2,12 +2,11 @@
 
 import json
 import logging
-import os
 
 import click
 from cligj import precision_opt
 
-import rasterio
+from rasterio.rio.helpers import path_exists
 
 
 @click.command(short_help="Transform coordinates.")
@@ -33,12 +32,12 @@ def transform(ctx, input, src_crs, dst_crs, precision):
         with ctx.obj['env']:
             if src_crs.startswith('EPSG'):
                 src_crs = {'init': src_crs}
-            elif os.path.exists(src_crs):
+            elif path_exists(src_crs):
                 with rasterio.open(src_crs) as f:
                     src_crs = f.crs
             if dst_crs.startswith('EPSG'):
                 dst_crs = {'init': dst_crs}
-            elif os.path.exists(dst_crs):
+            elif path_exists(dst_crs):
                 with rasterio.open(dst_crs) as f:
                     dst_crs = f.crs
             for line in src:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [tool:pytest]
+addopts = -p no:warnings
 testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ import pytest
 import numpy as np
 
 from rasterio.crs import CRS
-import rasterio
 
 
 DEFAULT_SHAPE = (10, 10)
@@ -277,3 +276,17 @@ def path_zip_file():
                              '389225main_sw_1965_1024.jpg']:
                 zip.write(os.path.join(data_dir(), filename), filename)
     return path
+
+
+@pytest.fixture(scope='session')
+def path_l8_s3_b1():
+    """S3 URL for band 1 of the standard Landsat 8 scene used by the
+    test suite."""
+    return 's3://landsat-pds/L8/139/045/LC81390452014295LGN00/LC81390452014295LGN00_B1.TIF'
+
+
+@pytest.fixture(scope='session')
+def path_l8_https_b1():
+    """HTTPS S3 URL for band 1 of the standard Landsat 8 scene used by the
+    test suite."""
+    return 'https://landsat-pds.s3.amazonaws.com/L8/139/045/LC81390452014295LGN00/LC81390452014295LGN00_B1.TIF'

--- a/tests/test_rio_helpers.py
+++ b/tests/test_rio_helpers.py
@@ -29,6 +29,7 @@ def test_fail_overwrite(tmpdir):
         helpers.resolve_inout(files=[str(x) for x in tmpdir.listdir()])
         assert "file exists and won't be overwritten without use of the " in str(excinfo.value)
 
+
 def test_force_overwrite(tmpdir):
     """Forced overwrite of existing file succeeds."""
     foo_tif = tmpdir.join('foo.tif')
@@ -48,3 +49,22 @@ def test_implicit_overwrite(tmpdir):
 
 def test_to_lower():
     assert helpers.to_lower(None, None, 'EPSG:3857') == 'epsg:3857'
+
+
+@pytest.mark.parametrize("path,expected", [
+    ('tests/data/RGB.byte.tif', True),
+    ('setup.py', True),
+    ('trash', False)])
+def test_path_exists(path, expected):
+    """A remote file is tested in a different function that has been marked
+    as requiring network access.
+    """
+    assert helpers.path_exists(path) is expected
+
+
+@pytest.mark.network
+def test_path_exists_s3(path_l8_s3_b1):
+    """This doesn't test something like a PostGIS connection string, but
+    its still a non-local file.
+    """
+    assert helpers.path_exists(path_l8_s3_b1)

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -84,7 +84,7 @@ def test_file_in_handler_with_vfs_nonexistent():
     ctx = MockContext()
     with pytest.raises(click.BadParameter):
         file_in_handler(
-            ctx, 'INPUT', 'zip://{0}/files.zip!/inputs/RGB.byte.tif'.format(
+            ctx, 'INPUT', 'zip://{0}/files.zip!/RGB.byte.tif'.format(
                 uuid.uuid4()))
 
 
@@ -92,8 +92,8 @@ def test_file_in_handler_with_vfs():
     """vfs file path is expanded"""
     ctx = MockContext()
     retval = file_in_handler(
-        ctx, 'INPUT', 'zip://tests/data/files.zip!/inputs/RGB.byte.tif')
-    assert retval.endswith('tests/data/files.zip!/inputs/RGB.byte.tif')
+        ctx, 'INPUT', 'zip://tests/data/files.zip!/RGB.byte.tif')
+    assert retval.endswith('tests/data/files.zip!/RGB.byte.tif')
 
 
 def test_file_in_handler_with_vfs_file():
@@ -103,18 +103,19 @@ def test_file_in_handler_with_vfs_file():
     assert retval.endswith('tests/data/RGB.byte.tif')
 
 
-def test_file_in_handler_http():
+@pytest.mark.network
+def test_file_in_handler_http(path_l8_https_b1):
     """HTTP(S) URLs are handled"""
     ctx = MockContext()
-    retval = file_in_handler(ctx, 'INPUT', 'https://example.com/RGB.byte.tif')
-    assert retval == 'https://example.com/RGB.byte.tif'
+    retval = file_in_handler(ctx, 'INPUT', path_l8_https_b1)
+    assert retval == path_l8_https_b1
 
 
-def test_file_in_handler_s3():
+def test_file_in_handler_s3(path_l8_s3_b1):
     """HTTP(S) URLs are handled"""
     ctx = MockContext()
-    retval = file_in_handler(ctx, 'INPUT', 's3://example.com/RGB.byte.tif')
-    assert retval == 's3://example.com/RGB.byte.tif'
+    retval = file_in_handler(ctx, 'INPUT', path_l8_s3_b1)
+    assert retval == path_l8_s3_b1
 
 
 def test_like_dataset_callback(data):


### PR DESCRIPTION
**Not ready**

Closes #871

I tried demonstrating this with a PostGIS raster table, but had some problems with my `$ brew install`'ed version of PostGIS lacking `raster2pgsql`.  The only other raster driver I am aware of that uses connection strings is Planet's `PLScenes` driver, although it requires setting up a https://planet.com/explorer account to get an API key.

Currently on master:

```console
$ PL_API_KEY=$(cat planet-api) rio info "PLScenes:scene=20170602_180403_1008"
Usage: rio info [OPTIONS] INPUT

Error: Invalid value for "INPUT": PLScenes:scene=20170602_180403_1008 is not a valid input file
```

The analogous GDAL command: `$ PL_API_KEY=$(cat planet-api) gdalinfo "PLScenes:scene=20170602_180403_1008"`

### Problems ###

There are a bunch of `click.Path(exists=True)` that need to be resolved, but before I do that:

My initial goal for this PR was to change as little behavior as possible, however because the CLI does an existence check on every input image before executing, the CLI now incurs all of the network overhead associated with a `rasterio.open()` on remote datasets, including S3.  The tradeoff is that the CLI can raise a useful "the input raster doesn't exist" but the network overhead is a major drag that translates to real money for heavy users of the CLI in production.

The solution is to never do a file existence check and just let `rasterio.open()` fail, but that won't work for ensuring existing output files aren't overwritten, plus the resulting error isn't nearly as useful:

```console
$ rio info trash
ERROR:rasterio._gdal:CPLE_OpenFailed in trash: No such file or directory
Aborted!
```

The above error is less useful than:

```console
$ gdalinfo trash
ERROR 4: trash: No such file or directory
gdalinfo failed - unable to open 'trash'.
```

### Solution ###

Anyone working with remote rasters is probably at least a little bit experienced with this stuff, and the CLI level sanity checks are _most_ useful for those that are inexperienced.  I think I can rework the `click` handlers to just assume a connection string exists, which is how VSI URL's work right now on `master`, so for most cases we still get the errors, but in some cases users will have to parse the CPLE log to figure out what went wrong.  The remaining `click.Path()` instances will all have to be replaced with a smarter callback, but I think we already have a generic one somewhere.

This PR does not address write support, but to my knowledge none of the remote raster drivers do, including [PostGIS Raster](https://trac.osgeo.org/gdal/wiki/frmts_wtkraster.html).  I left the `os.path.exists()` checks in the core write code path, so if its actually a problem eventually someone will hit them.