### PR TITLE
Eliminate use of deprecated boundless keyword

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,11 @@ New features:
 - Use of old style range tuples as windows is deprecated and warned
   against (#1074).
 
+Bug fixes:
+
+- Eliminate boundless keyword argument and a DeprecationWarning when calling
+  from_bounds in dataset.window() (#1082).
+
 1.0a9 (2017-06-02)
 ------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,11 +7,17 @@ Next
 Breaking changes:
 
 - In the GeoJSON output of rio-blocks, the windows are now JSON
-  representations of the `Window` class (#1074).
-- The `rasterio.windows.Window` class no longer derives from `tuple`.
-  Comparisons like `Window(0, 0, 1, 1) == ((0, 1), (0, 1))` are no
-  longer possible. Instead, call the `.toranges()` method of the 
-  former or coerce the latter using `Window.from_ranges()` (#1074).
+  representations of the ``Window`` class (#1074).
+- The ``rasterio.windows.Window`` class no longer derives from ``tuple``.
+  Comparisons like ``Window(0, 0, 1, 1) == ((0, 1), (0, 1))`` are no
+  longer possible. Instead, call the ``.toranges()`` method of the 
+  former or coerce the latter using ``Window.from_ranges()`` (#1074).
+- The ``rasterio.windows.from_bounds()`` function now always returns unbounded,
+  meaning uncropped, Windows. For example, if given a bounding box entirely
+  to the west and north of the geotransform's origin, the result will be a 
+  Window entirely to the left and above the dataset's row and column origin.
+  Passing a ``boundless`` keyword argument to this function will result in a 
+  warning.
 
 New features:
 
@@ -20,10 +26,6 @@ New features:
 - Use of old style range tuples as windows is deprecated and warned
   against (#1074).
 
-Bug fixes:
-
-- Eliminate boundless keyword argument and deprecation warnings when calling
-  from_bounds() (#1082).
 
 1.0a9 (2017-06-02)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,8 +22,8 @@ New features:
 
 Bug fixes:
 
-- Eliminate boundless keyword argument and a DeprecationWarning when calling
-  from_bounds in dataset.window() (#1082).
+- Eliminate boundless keyword argument and deprecation warnings when calling
+  from_bounds() (#1082).
 
 1.0a9 (2017-06-02)
 ------------------

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -123,7 +123,7 @@ class WindowMethodsMixin(object):
             Number of decimal points of precision when computing inverse
             transform.
         kwargs: mapping
-            For backwards compatibility: absorbs deprecated keyword args
+            For backwards compatibility: absorbs deprecated keyword args.
 
         Returns
         -------

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -109,6 +109,9 @@ class WindowMethodsMixin(object):
     def window(self, left, bottom, right, top, precision=6, **kwargs):
         """Get the window corresponding to the bounding coordinates.
 
+        The resulting window is not cropped to the row and column
+        limits of the dataset.
+
         Parameters
         ----------
         left: float
@@ -129,9 +132,10 @@ class WindowMethodsMixin(object):
         -------
         window: Window
         """
-        if 'boundless' in kwargs:
+        if 'boundless' in kwargs:  # pragma: no branch
             warnings.warn("boundless keyword arg should not be used",
                           RasterioDeprecationWarning)
+
         transform = guard_transform(self.transform)
         return windows.from_bounds(
             left, bottom, right, top, transform=transform,

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -16,6 +16,7 @@ from rasterio._io import (
 from rasterio import windows
 from rasterio.enums import Resampling
 from rasterio.env import ensure_env
+from rasterio.errors import RasterioDeprecationWarning
 from rasterio.transform import guard_transform, xy, rowcol
 
 
@@ -105,36 +106,36 @@ class WindowMethodsMixin(object):
     properties: `transform`, `height` and `width`
     """
 
-    def window(self, left, bottom, right, top, boundless=True, precision=6):
+    def window(self, left, bottom, right, top, precision=6, **kwargs):
         """Get the window corresponding to the bounding coordinates.
 
         Parameters
         ----------
-        left : float
+        left: float
             Left (west) bounding coordinate
-        bottom : float
+        bottom: float
             Bottom (south) bounding coordinate
-        right : float
+        right: float
             Right (east) bounding coordinate
-        top : float
+        top: float
             Top (north) bounding coordinate
-        boundless: boolean, optional
-            If boundless is False, window is limited
-            to extent of this dataset.
-        precision : int, optional
+        precision: int, optional
             Number of decimal points of precision when computing inverse
             transform.
+        kwargs: mapping
+            For backwards compatibility: absorbs deprecated keyword args
 
         Returns
         -------
         window: Window
         """
-
+        if 'boundless' in kwargs:
+            warnings.warn("boundless keyword arg should not be used",
+                          RasterioDeprecationWarning)
         transform = guard_transform(self.transform)
         return windows.from_bounds(
             left, bottom, right, top, transform=transform,
-            height=self.height, width=self.width, boundless=boundless,
-            precision=precision)
+            height=self.height, width=self.width, precision=precision)
 
     def window_transform(self, window):
         """Get the affine transform for a dataset window.

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -141,16 +141,14 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
 
         # 2. Compute the source window.
         src_window = windows.from_bounds(
-            int_w, int_s, int_e, int_n, src.transform,
-            boundless=True)
+            int_w, int_s, int_e, int_n, src.transform)
         logger.debug("Src %s window: %r", src.name, src_window)
 
         src_window = src_window.round_shape()
 
         # 3. Compute the destination window.
         dst_window = windows.from_bounds(
-            int_w, int_s, int_e, int_n, output_transform,
-            boundless=True)
+            int_w, int_s, int_e, int_n, output_transform)
 
         # 4. Initialize temp array.
         tcount = first.count
@@ -170,6 +168,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
 
         np.copyto(
             region, temp,
-            where=np.logical_and(region == nodataval, temp.mask == False))
+            where=np.logical_and(region == nodataval,
+                                 np.logical_not(temp.mask)))
 
     return dest, output_transform

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -184,16 +184,18 @@ def from_bounds(left, bottom, right, top, transform=None,
 
     Parameters
     ----------
-    left, bottom, right, top : float
+    left, bottom, right, top: float
         Left (west), bottom (south), right (east), and top (north)
         bounding coordinates.
-    transform : Affine
+    transform: Affine
         Affine transform matrix.
-    height, width : int
+    height, width: int
         Number of rows and columns of the window.
-    precision : int, optional
+    precision: int, optional
         Number of decimal points of precision when computing inverse
         transform.
+    kwargs: mapping
+        Absorbs deprecated keyword args
 
     Returns
     -------
@@ -476,7 +478,8 @@ class Window(object):
 
     @property
     def num_cols(self):
-        warnings.warn("use 'width' attribute instead", RasterioDeprecationWarning)
+        warnings.warn("use 'width' attribute instead",
+                      RasterioDeprecationWarning)
         return self.width
 
     @property

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -156,8 +156,7 @@ def test_block_windows_filtered_none(path_rgb_byte_tif):
     """Get no block windows using filter"""
     with rasterio.open(path_rgb_byte_tif) as src:
         w, s, e, n = src.bounds
-        focus_window = src.window(w - 100.0, n + 1.0, w - 1.0, n + 100.0,
-                                  boundless=True)
+        focus_window = src.window(w - 100.0, n + 1.0, w - 1.0, n + 100.0)
         filter_func = partial(windows.intersect, focus_window)
         itr = ((ij, win) for ij, win in src.block_windows() if filter_func(win))
         with pytest.raises(StopIteration):

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -41,7 +41,7 @@ def test_window_no_exception():
         left, bottom, right, top = src.bounds
         left -= 1000.0
         assert_window_almost_equals(
-            src.window(left, bottom, right, top, boundless=True),
+            src.window(left, bottom, right, top),
             ((0, src.height), (-1000 / src.res[0], src.width)))
 
 

--- a/tests/test_io_mixins.py
+++ b/tests/test_io_mixins.py
@@ -2,6 +2,7 @@ from affine import Affine
 import pytest
 
 import rasterio
+from rasterio.errors import RasterioDeprecationWarning
 from rasterio.io import WindowMethodsMixin
 from rasterio.windows import Window
 
@@ -99,3 +100,9 @@ def test_window_bounds_function():
         rows = src.height
         cols = src.width
         assert src.window_bounds(((0, rows), (0, cols))) == src.bounds
+
+
+def test_boundless_deprecation():
+    with pytest.warns(RasterioDeprecationWarning):
+        with rasterio.open('tests/data/RGB.byte.tif') as src:
+            src.window(*src.bounds, boundless=True)

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -88,8 +88,7 @@ def test_read_vfs_none():
 @pytest.mark.parametrize('mode', ['r+', 'w'])
 def test_update_vfs(tmpdir, mode):
     """VFS datasets can not be created or updated"""
+    profile = default_gtiff_profile.copy()
+    profile.update(count=1, width=1, height=1)
     with pytest.raises(TypeError):
-        rasterio.open(
-            'zip://{0}'.format(tmpdir), mode,
-            **default_gtiff_profile(
-                count=1, width=1, height=1))
+        rasterio.open('zip://{0}'.format(tmpdir), mode, **profile)


### PR DESCRIPTION
This PR addresses one class of deprecated API usage in the project. We aren't using the deprecated `boundless` keyword argument when calling `windows.from_bounds()` after this.

Resolves #1082

Ping @perrygeo for review.