### PR TITLE
Add a block() method to dataset objects.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,10 +8,10 @@ Breaking changes:
 
 - In the GeoJSON output of rio-blocks, the windows are now JSON
   representations of the `Window` class (#1074).
-- The `rasterio.windows.Window` class no longer derives from `tuple`.
-  Comparisons like `Window(0, 0, 1, 1) == ((0, 1), (0, 1))` are no
-  longer possible. Instead, call the `.toranges()` method of the 
-  former or coerce the latter using `Window.from_ranges()` (#1074).
+- The ``rasterio.windows.Window`` class no longer derives from ``tuple``.
+  Comparisons like ``Window(0, 0, 1, 1) == ((0, 1), (0, 1))`` are no
+  longer possible. Instead, call the ``.toranges()`` method of the 
+  former or coerce the latter using ``Window.from_ranges()`` (#1074).
 
 New features:
 
@@ -19,6 +19,7 @@ New features:
   Rasterio (#1074).
 - Use of old style range tuples as windows is deprecated and warned
   against (#1074).
+- Addition of dataset ``block()`` method (#1077).
 
 1.0a9 (2017-06-02)
 ------------------

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -13,7 +13,6 @@ from rasterio._err import (
     CPLE_NotSupportedError)
 from rasterio._err cimport exc_wrap_pointer, exc_wrap_int
 
-from rasterio.block import BlockInfo
 from rasterio.compat import string_types
 from rasterio.control import GroundControlPoint
 from rasterio.crs import CRS

--- a/rasterio/block.py
+++ b/rasterio/block.py
@@ -1,6 +1,0 @@
-"""Raster Blocks"""
-
-from collections import namedtuple
-
-
-BlockInfo = namedtuple('BlockInfo', ['row', 'col', 'window', 'size'])

--- a/rasterio/block.py
+++ b/rasterio/block.py
@@ -1,0 +1,6 @@
+"""Raster Blocks"""
+
+from collections import namedtuple
+
+
+BlockInfo = namedtuple('BlockInfo', ['row', 'col', 'window', 'size'])

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -68,3 +68,7 @@ class WindowEvaluationError(ValueError):
 
 class RasterioDeprecationWarning(UserWarning):
     """Rasterio module deprecations"""
+
+
+class TIFFTagError(RasterioError):
+    """Raised when TIFF tag access fails"""

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -70,5 +70,5 @@ class RasterioDeprecationWarning(UserWarning):
     """Rasterio module deprecations"""
 
 
-class TIFFTagError(RasterioError):
-    """Raised when TIFF tag access fails"""
+class RasterBlockError(RasterioError):
+    """Raised when raster block access fails"""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 affine>=1.3.0
+attrs>=16.0.0
 boto3>=1.2.4
 cligj
 cython>=0.23.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 affine>=1.3.0
-attrs>=16.0.0
 boto3>=1.2.4
 cligj
 cython>=0.23.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 affine>=1.3.0
-attrs>=16.0.0
 boto3>=1.2.4
 cligj
 enum34

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 affine>=1.3.0
+attrs>=16.0.0
 boto3>=1.2.4
 cligj
 enum34

--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ with open('README.rst') as f:
 
 # Runtime requirements.
 inst_reqs = [
-    'affine', 'cligj', 'numpy', 'snuggs>=1.4.1', 'click-plugins']
+    'affine', 'attrs', 'cligj', 'numpy', 'snuggs>=1.4.1', 'click-plugins']
 
 if sys.version_info < (3, 4):
     inst_reqs.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -299,8 +299,7 @@ with open('README.rst') as f:
 
 # Runtime requirements.
 inst_reqs = [
-    'affine', 'attrs>=16.0.0', 'cligj', 'numpy', 'snuggs>=1.4.1',
-    'click-plugins']
+    'affine', 'cligj', 'numpy', 'snuggs>=1.4.1', 'click-plugins']
 
 if sys.version_info < (3, 4):
     inst_reqs.append('enum34')

--- a/setup.py
+++ b/setup.py
@@ -298,7 +298,9 @@ with open('README.rst') as f:
     readme = f.read()
 
 # Runtime requirements.
-inst_reqs = ['affine', 'attrs', 'cligj', 'numpy', 'snuggs>=1.4.1', 'click-plugins']
+inst_reqs = [
+    'affine', 'attrs>=16.0.0', 'cligj', 'numpy', 'snuggs>=1.4.1',
+    'click-plugins']
 
 if sys.version_info < (3, 4):
     inst_reqs.append('enum34')

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -168,6 +168,6 @@ def test_block_tiff(path_rgb_byte_tif):
     """Without compression a TIFF's blocks are all the same size"""
     with rasterio.open(path_rgb_byte_tif) as src:
         block_windows = list(src.block_windows())
-        sizes = [src.block(1, i, j)['size'] for (i, j), w in block_windows]
+        sizes = [src.block(1, i, j).size for (i, j), w in block_windows]
         assert sizes.count(2373) == 1
         assert sizes.count(7119) == len(block_windows) - 1

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -162,3 +162,12 @@ def test_block_windows_filtered_none(path_rgb_byte_tif):
         itr = ((ij, win) for ij, win in src.block_windows() if filter_func(win))
         with pytest.raises(StopIteration):
             next(itr)
+
+
+def test_block_tiff(path_rgb_byte_tif):
+    """Without compression a TIFF's blocks are all the same size"""
+    with rasterio.open(path_rgb_byte_tif) as src:
+        block_windows = list(src.block_windows())
+        sizes = [src.block(1, i, j)['size'] for (i, j), w in block_windows]
+        assert sizes.count(2373) == 1
+        assert sizes.count(7119) == len(block_windows) - 1

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from packaging.version import parse
 import pytest
 
 import rasterio
@@ -61,6 +62,7 @@ def test_window_index():
     arr = np.ones((20, 20))
     assert arr[idx].shape == (4, 11)
 
+
 class RasterBlocksTest(unittest.TestCase):
 
     def test_blocks(self):
@@ -80,7 +82,8 @@ class RasterBlocksTest(unittest.TestCase):
             self.assertEqual(second, windows.Window.from_ranges((3, 6), (0, 791)))
             (j, i), last = list(itr)[~0]
             self.assertEqual((j, i), (239, 0))
-            self.assertEqual(last, windows.Window.from_ranges((717, 718), (0, 791)))
+            self.assertEqual(
+                last, windows.Window.from_ranges((717, 718), (0, 791)))
 
     def test_block_coverage(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
@@ -88,6 +91,7 @@ class RasterBlocksTest(unittest.TestCase):
                 s.width * s.height,
                 sum((w[0][1] - w[0][0]) * (w[1][1] - w[1][0])
                     for ji, w in s.block_windows(1)))
+
 
 class WindowReadTest(unittest.TestCase):
     def test_read_window(self):
@@ -99,6 +103,7 @@ class WindowReadTest(unittest.TestCase):
             self.assertEqual(
                 first_block.shape,
                 rasterio.window_shape(first_window))
+
 
 class WindowWriteTest(unittest.TestCase):
 
@@ -163,7 +168,9 @@ def test_block_windows_filtered_none(path_rgb_byte_tif):
         with pytest.raises(StopIteration):
             next(itr)
 
-
+@pytest.mark.skipif(
+    parse(rasterio.__gdal_version__) < parse('2.0.0'),
+    reason="TIFF block size access requires GDAL 2.0")
 def test_block_tiff(path_rgb_byte_tif):
     """Without compression a TIFF's blocks are all the same size"""
     with rasterio.open(path_rgb_byte_tif) as src:


### PR DESCRIPTION
block() returns the window and size in bytes of a TIFF block. The size is undefined for other formats and will be None.

Resolves #1077 

Ping @perrygeo for review.