### PR TITLE
Update docs: rasterio.tools.mask.mask() -> rasterio.mask.mask()

### DIFF
--- a/docs/topics/masking-by-shapefile.rst
+++ b/docs/topics/masking-by-shapefile.rst
@@ -6,7 +6,7 @@ Using ``rasterio`` with ``fiona``, it is simple to open a shapefile, read geomet
 
         import fiona
         import rasterio
-        import rasterio.tools.mask
+        import rasterio.mask
 
         with fiona.open("tests/data/box.shp", "r") as shapefile:
             features = [feature["geometry"] for feature in shapefile] 
@@ -16,7 +16,7 @@ This shapefile contains a single polygon, a box near the center of the raster, s
 .. code-block:: python
 
         with rasterio.open("tests/data/RGB.byte.tif") as src:
-            out_image, out_transform = rasterio.tools.mask.mask(src, features,
+            out_image, out_transform = rasterio.mask.mask(src, features,
                                                                 crop=True)
             out_meta = src.meta.copy()
 


### PR DESCRIPTION
Closes #1095

@perrygeo Didn't you have a linter running against the docs at one point, or was that just docstrings?  I think we were briefly running `doctest` on docstrings but eventually disabled it when the test formatting became painful.  I don't recall if we have ever run anything against the docs though.