### PR TITLE
Fix 'brew upgrade' -> 'brew update' in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -249,7 +249,7 @@ For a Homebrew based Python environment, do the following.
 
 .. code-block:: console
 
-    $ brew upgrade
+    $ brew update
     $ brew install gdal
     $ pip install -U pip
     $ pip install --no-use-wheel rasterio


### PR DESCRIPTION
I think the original intent was to insure that homebrew is up to date, not that everything installed by homebrew is upgraded.