### PR TITLE
Remove deprecated ul() method from TransformMethodsMixin class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ Breaking changes:
   Comparisons like `Window(0, 0, 1, 1) == ((0, 1), (0, 1))` are no
   longer possible. Instead, call the `.toranges()` method of the 
   former or coerce the latter using `Window.from_ranges()` (#1074).
+- The ``TransformMethodsMixin.ul()`` method, deprecated since 0.36, has been
+  removed (#1100).
 
 New features:
 

--- a/docs/topics/migrating-to-v1.rst
+++ b/docs/topics/migrating-to-v1.rst
@@ -220,8 +220,12 @@ Tickets
 Removed: ``rasterio.warp.RESAMPLING``
 -------------------------------------
 
-Replaced with ``rasterio.warp.Resampling``
+This enum has been replaced by ``rasterio.warp.Resampling``.
 
+Removed: dataset's ``ul()`` method
+----------------------------------
+
+This method has been replaced by the ``xy()`` method.
 
 Signature Changes
 -----------------

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -16,6 +16,7 @@ from rasterio._io import (
 from rasterio import windows
 from rasterio.enums import Resampling
 from rasterio.env import ensure_env
+from rasterio.errors import RasterioDeprecationWarning
 from rasterio.transform import guard_transform, xy, rowcol
 
 
@@ -55,17 +56,6 @@ class TransformMethodsMixin(object):
             ``(x, y)``
         """
         return xy(self.transform, row, col, offset=offset)
-
-    def ul(self, row, col):
-        """Returns the coordinates (x, y) of the upper left corner of a
-        pixel at `row` and `col` in the units of the dataset's
-        coordinate reference system.
-
-        Deprecated; Use `xy(row, col, offset='ul')` instead.
-        """
-        warnings.warn("ul method is deprecated. Use xy(row, col, offset='ul')",
-                      DeprecationWarning)
-        return xy(self.transform, row, col, offset='ul')
 
     def index(self, x, y, op=math.floor, precision=6):
         """


### PR DESCRIPTION
Its functionality is entirely covered by the `xy()` method and deprecation has been warned for a year in preparation for its deletion.

Resolves #1100