### PR TITLE
DOC: wrong keyword in resample example

### DIFF
--- a/docs/topics/resampling.rst
+++ b/docs/topics/resampling.rst
@@ -40,7 +40,7 @@ by ``x``, you need to *divide* the affine parameters defining the cell size by `
         dst_transform = newaff,
         src_crs = src.crs,
         dst_crs = src.crs,
-        resample = Resampling.bilinear)
+        resampling = Resampling.bilinear)
 
 
 Use scipy


### PR DESCRIPTION
We ran into this issue: https://github.com/mapbox/rasterio/issues/860 (using `resample=` instead of `resampling=` and this silently being ignored), but apparently we did this based on a typo in the docs. This PR fixes that.