### PR TITLE
Properly close destination dataset after copy operation

### DIFF
--- a/rasterio/_copy.pyx
+++ b/rasterio/_copy.pyx
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @ensure_env
-def copy(src, dst, driver='GTiff', strict=False, **creation_options):
+def copy(src, dst, driver='GTiff', strict=True, **creation_options):
 
     """Copy a raster from a path or open dataset handle to a new destination
     with driver specific creation options.
@@ -28,7 +28,7 @@ def copy(src, dst, driver='GTiff', strict=False, **creation_options):
         Output dataset path.
     driver : str, optional
         Output driver name.
-    strict : bool, optional
+    strict : bool, optional.  Default: True
         Indicates if the output must be strictly equivalent or if the
         driver may adapt as necessary.
     creation_options : **kwargs, optional
@@ -76,3 +76,6 @@ def copy(src, dst, driver='GTiff', strict=False, **creation_options):
         CSLDestroy(options)
         if close_src:
             GDALClose(src_dataset)
+
+        if dst_dataset != NULL:
+            GDALClose(dst_dataset)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,6 +267,11 @@ def path_rgb_byte_tif(data_dir):
 
 
 @pytest.fixture(scope='session')
+def path_float_tif(data_dir):
+    return os.path.join(data_dir, 'float.tif')
+
+
+@pytest.fixture(scope='session')
 def path_zip_file():
     """Creates ``coutwildrnp.zip`` if it does not exist and returns
     the absolute file path."""

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,9 +1,11 @@
 """Tests for ``rasterio.copy()``."""
 
+import numpy
 
 import pytest
 
 import rasterio
+from rasterio._err import CPLE_NotSupportedError
 from rasterio.errors import DriverRegistrationError
 
 
@@ -21,25 +23,60 @@ def test_copy(tmpdir, path_rgb_byte_tif, pass_handle):
     else:
         src = path_rgb_byte_tif
 
-    try:
-        rasterio.copy(
-            src,
-            outfile,
-            # Test a mix of boolean, ints, and strings to make sure creation
-            # options passed as Python types are properly cast.
-            tiled=True,
-            blockxsize=512,
-            BLOCKYSIZE='256')
+    rasterio.copy(
+        src,
+        outfile,
+        # Test a mix of boolean, ints, and strings to make sure creation
+        # options passed as Python types are properly cast.
+        tiled=True,
+        blockxsize=512,
+        BLOCKYSIZE='256')
 
-    finally:
-        if not isinstance(src, str):
-            src.close()
+    if isinstance(src, str):
+        src = rasterio.open(path_rgb_byte_tif)
 
-    with rasterio.open(outfile) as src:
-        assert src.driver == 'GTiff'
-        assert set(src.block_shapes) == {(256, 512)}
+    with rasterio.open(outfile) as dst:
+        assert dst.driver == 'GTiff'
+        assert set(dst.block_shapes) == {(256, 512)}
+
+        src_data = src.read()
+        dst_data = dst.read()
+
+        assert numpy.array_equal(src_data, dst_data)
+
+    src.close()
 
 
 def test_bad_driver():
     with pytest.raises(DriverRegistrationError):
         rasterio.copy('tests/data/RGB.byte.tif', None, driver='trash')
+
+
+def test_copy_strict_failure(tmpdir, path_float_tif):
+    """Ensure that strict=True raises an exception
+     for a bad write instead of failing silently."""
+
+    outfile = str(tmpdir.join('test_copy.jpg'))
+
+    with pytest.raises(CPLE_NotSupportedError):
+        rasterio.copy(
+            path_float_tif, outfile, strict=True,
+            driver='JPEG')
+
+
+def test_copy_strict_silent_failure(tmpdir, path_float_tif):
+    """Ensure that strict=False allows a bad write
+    to fail silently.  The raster will exist but
+    will not be valid"""
+
+    outfile = str(tmpdir.join('test_copy.jpg'))
+
+    rasterio.copy(
+        path_float_tif, outfile, strict=False,
+        driver='JPEG')
+
+    with rasterio.open(outfile) as dst:
+        assert dst.driver == 'JPEG'
+        assert dst.read().max() == 0  # it should be 1.4099; 0 indicates bad data
+
+


### PR DESCRIPTION
Resolves #1107 

We were not closing the destination dataset after copy operation in Cython.  The default setting for the `strict` parameter was also not helping us here; it defaults to allowing incompatible destination rasters to be created silently.  I changed the default so that it raises an exception by default.

We may want to wrap the exception we get back to be return a better Python Exception class instead of `rasterio._err.CPLE_NotSupportedError`

Currently this branch is causing segfaults in a completely unrelated part of `rasterio` on OSX.