### PR TITLE
No more work done in dataset start()

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -280,7 +280,7 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
             else:
                 raise ValueError(
                     "mode must be one of 'r', 'r+', or 'w', not %s" % mode)
-            s.start()
+            # s.start()
             return s
 
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -280,7 +280,6 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
             else:
                 raise ValueError(
                     "mode must be one of 'r', 'r+', or 'w', not %s" % mode)
-            # s.start()
             return s
 
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -946,8 +946,6 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         name_b = path.encode('utf-8')
         fname = name_b
 
-        #kwds = []
-
         if mode == 'w':
 
             # Delete existing file, create.
@@ -979,7 +977,6 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                     if k.lower() in ['affine']:
                         continue
 
-                    #kwds.append((k.lower(), v))
                     k, v = k.upper(), str(v).upper()
 
                     # Guard against block size that exceed image size.
@@ -1868,13 +1865,11 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
         if drv == NULL:
             raise ValueError("NULL driver for %s", self.driver)
 
-        #kwds = []
         # Creation options
         for k, v in self._options.items():
             # Skip items that are definitely *not* valid driver options.
             if k.lower() in ['affine']:
                 continue
-            #kwds.append((k.lower(), v))
             k, v = k.upper(), str(v).upper()
             key_b = k.encode('utf-8')
             val_b = v.encode('utf-8')

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -899,6 +899,17 @@ cdef class DatasetWriterBase(DatasetReaderBase):
     def __init__(self, path, mode, driver=None, width=None, height=None,
                  count=None, crs=None, transform=None, dtype=None, nodata=None,
                  gcps=None, **kwargs):
+        """Initialize a DatasetWriterBase instance."""
+
+        cdef char **options = NULL
+        cdef char *key_c = NULL
+        cdef char *val_c = NULL
+        cdef const char *drv_name = NULL
+        cdef GDALDriverH drv = NULL
+        cdef GDALRasterBandH band = NULL
+        cdef int success = -1
+        cdef const char *fname = NULL
+
         # Validate write mode arguments.
         log.debug("Path: %s, mode: %s, driver: %s", path, mode, driver)
         if mode == 'w':
@@ -918,46 +929,14 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 _ = np.dtype(dtype)
             except:
                 raise TypeError("A valid dtype is required.")
-        self.name = path
-        self.mode = mode
-        self.driver = driver
-        self.width = width
-        self.height = height
-        self._count = count
+
         self._init_dtype = np.dtype(dtype).name
-        self._init_nodata = nodata
-        self._hds = NULL
-        self._count = count
-        self._crs = crs
-        if transform is not None:
-            self._transform = transform.to_gdal()
-        self._gcps = None
-        self._init_gcps = gcps
-        self._closed = True
-        self._dtypes = []
-        self._nodatavals = []
-        self._units = ()
-        self._descriptions = ()
-        self._options = kwargs.copy()
 
-    def __repr__(self):
-        return "<%s RasterUpdater name='%s' mode='%s'>" % (
-            self.closed and 'closed' or 'open',
-            self.name,
-            self.mode)
-
-    def start(self):
-        cdef const char *drv_name = NULL
-        cdef char **options = NULL
-        cdef char *key_c = NULL
-        cdef char *val_c = NULL
-        cdef GDALDriverH drv = NULL
-        cdef GDALRasterBandH band = NULL
-        cdef int success
+        # Make and store a GDAL dataset handle.
 
         # Parse the path to determine if there is scheme-specific
         # configuration to be done.
-        path, archive, scheme = parse_path(self.name)
+        path, archive, scheme = parse_path(path)
         path = vsi_path(path, archive, scheme)
 
         if scheme and scheme != 'file':
@@ -966,17 +945,17 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                     scheme))
 
         name_b = path.encode('utf-8')
-        cdef const char *fname = name_b
+        fname = name_b
 
         kwds = []
 
-        if self.mode == 'w':
+        if mode == 'w':
 
             # Delete existing file, create.
             if os.path.exists(path):
                 os.unlink(path)
 
-            driver_b = self.driver.encode('utf-8')
+            driver_b = driver.encode('utf-8')
             drv_name = driver_b
             try:
                 drv = exc_wrap_pointer(GDALGetDriverByName(drv_name))
@@ -994,7 +973,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 gdal_dtype = dtypes.dtype_rev.get(self._init_dtype)
 
             # Creation options
-            for k, v in self._options.items():
+            for k, v in kwargs.items():
                 # Skip items that are definitely *not* valid driver options.
                 if k.lower() in ['affine']:
                     continue
@@ -1002,9 +981,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 k, v = k.upper(), str(v).upper()
 
                 # Guard against block size that exceed image size.
-                if k == 'BLOCKXSIZE' and int(v) > self.width:
+                if k == 'BLOCKXSIZE' and int(v) > width:
                     raise ValueError("blockxsize exceeds raster width.")
-                if k == 'BLOCKYSIZE' and int(v) > self.height:
+                if k == 'BLOCKYSIZE' and int(v) > height:
                     raise ValueError("blockysize exceeds raster height.")
 
                 key_b = k.encode('utf-8')
@@ -1016,35 +995,26 @@ cdef class DatasetWriterBase(DatasetReaderBase):
 
             try:
                 self._hds = exc_wrap_pointer(
-                    GDALCreate(drv, fname, self.width, self.height,
-                               self._count, gdal_dtype, options))
-            except Exception as err:
+                    GDALCreate(drv, fname, width, height,
+                               count, gdal_dtype, options))
+            finally:
                 if options != NULL:
                     CSLDestroy(options)
-                raise
 
-            if self._init_nodata is not None:
+            if nodata is not None:
 
-                if not in_dtype_range(self._init_nodata, self._init_dtype):
+                if not in_dtype_range(nodata, dtype):
                     raise ValueError(
                         "Given nodata value, %s, is beyond the valid "
                         "range of its data type, %s." % (
-                            self._init_nodata, self._init_dtype))
+                            nodata, dtype))
 
                 # Broadcast the nodata value to all bands.
-                for i in range(self._count):
+                for i in range(count):
                     band = self.band(i + 1)
-                    success = GDALSetRasterNoDataValue(band,
-                                                       self._init_nodata)
+                    success = GDALSetRasterNoDataValue(band, nodata)
 
-            if self._transform:
-                self.write_transform(self._transform)
-            if self._crs:
-                self.set_crs(self._crs)
-            if self._init_gcps:
-                self.set_gcps(self._init_gcps, self.crs)
-
-        elif self.mode == 'r+':
+        elif mode == 'r+':
             try:
                 self._hds = exc_wrap_pointer(GDALOpenShared(fname, <GDALAccess>1))
             except CPLE_OpenFailedError as err:
@@ -1052,7 +1022,35 @@ cdef class DatasetWriterBase(DatasetReaderBase):
 
         else:
             # Raise an exception if we have any other mode.
-            raise ValueError("Invalid mode: '%s'", self.mode)
+            raise ValueError("Invalid mode: '%s'", mode)
+
+        self.name = path
+        self.mode = mode
+        self.driver = driver
+        self.width = width
+        self.height = height
+        self._count = count
+        self._init_nodata = nodata
+        self._count = count
+        self._crs = crs
+        if transform is not None:
+            self._transform = transform.to_gdal()
+        self._gcps = None
+        self._init_gcps = gcps
+        self._closed = True
+        self._dtypes = []
+        self._nodatavals = []
+        self._units = ()
+        self._descriptions = ()
+        self._options = kwargs.copy()
+
+        if self.mode == 'w':
+            if self._transform:
+                self.write_transform(self._transform)
+            if self._crs:
+                self.set_crs(self._crs)
+            if self._init_gcps:
+                self.set_gcps(self._init_gcps, self.crs)
 
         drv = GDALGetDatasetDriver(self._hds)
         drv_name = GDALGetDriverShortName(drv)
@@ -1066,14 +1064,20 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         self._transform = self.read_transform()
         self._crs = self.read_crs()
 
-        if options != NULL:
-            CSLDestroy(options)
-
         # touch self.meta
         _ = self.meta
 
-        self.update_tags(ns='rio_creation_kwds', **kwds)
+        self.update_tags(ns='rio_creation_kwds', **kwargs)
         self._closed = False
+
+    def __repr__(self):
+        return "<%s RasterUpdater name='%s' mode='%s'>" % (
+            self.closed and 'closed' or 'open',
+            self.name,
+            self.mode)
+
+    def start(self):
+        pass
 
     def stop(self):
         """Ends the dataset's life cycle"""
@@ -1706,19 +1710,70 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
             self.name,
             self.mode)
 
-    def start(self):
-        cdef const char *drv_name = NULL
+    def __init__(self, path, mode, driver=None, width=None, height=None,
+                 count=None, crs=None, transform=None, dtype=None, nodata=None,
+                 gcps=None, **kwargs):
+
+        cdef char **options = NULL
+        cdef char *key_c = NULL
+        cdef char *val_c = NULL
         cdef GDALDriverH drv = NULL
-        cdef GDALDriverH memdrv = NULL
         cdef GDALRasterBandH band = NULL
+        cdef int success = -1
+        cdef const char *fname = NULL
+        cdef const char *drv_name = NULL
+        cdef GDALDriverH memdrv = NULL
         cdef GDALDatasetH temp = NULL
-        cdef int success
+
+        # Validate write mode arguments.
+
+        log.debug("Path: %s, mode: %s, driver: %s", path, mode, driver)
+        if mode == 'w':
+            if not isinstance(driver, string_types):
+                raise TypeError("A driver name string is required.")
+            try:
+                width = int(width)
+                height = int(height)
+            except:
+                raise TypeError("Integer width and height are required.")
+            try:
+                count = int(count)
+            except:
+                raise TypeError("Integer band count is required.")
+            try:
+                assert dtype is not None
+                _ = np.dtype(dtype)
+            except:
+                raise TypeError("A valid dtype is required.")
+
+        self._init_dtype = np.dtype(dtype).name
+
+        self.name = path
+        self.mode = mode
+        self.driver = driver
+        self.width = width
+        self.height = height
+        self._count = count
+        self._init_nodata = nodata
+        self._count = count
+        self._crs = crs
+        if transform is not None:
+            self._transform = transform.to_gdal()
+        self._gcps = None
+        self._init_gcps = gcps
+        self._closed = True
+        self._dtypes = []
+        self._nodatavals = []
+        self._units = ()
+        self._descriptions = ()
+        self._options = kwargs.copy()
+
+        # Make and store a GDAL dataset handle.
 
         # Parse the path to determine if there is scheme-specific
         # configuration to be done.
-        path = vsi_path(*parse_path(self.name))
+        path = vsi_path(*parse_path(path))
         name_b = path.encode('utf-8')
-        cdef const char *fname = name_b
 
         memdrv = GDALGetDriverByName("MEM")
 
@@ -1765,6 +1820,8 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
             self.driver = get_driver_name(drv)
             GDALClose(temp)
 
+        # Instead of calling _begin() we do the following.
+
         self._count = GDALGetRasterCount(self._hds)
         self.width = GDALGetRasterXSize(self._hds)
         self.height = GDALGetRasterYSize(self._hds)
@@ -1773,9 +1830,13 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
         self._transform = self.read_transform()
         self._crs = self.read_crs()
 
+        if options != NULL:
+            CSLDestroy(options)
+
         # touch self.meta
         _ = self.meta
 
+        self.update_tags(ns='rio_creation_kwds', **kwargs)
         self._closed = False
 
     def close(self):
@@ -1785,9 +1846,11 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
         cdef char *val_c = NULL
         cdef GDALDriverH drv = NULL
         cdef GDALDatasetH temp = NULL
-        cdef int success
+        cdef int success = -1
+        cdef const char *fname = NULL
+
         name_b = self.name.encode('utf-8')
-        cdef const char *fname = name_b
+        fname = name_b
 
         # Delete existing file, create.
         if os.path.exists(self.name):

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -631,8 +631,21 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
                  src_nodata=None, dst_nodata=None, dst_width=None,
                  dst_height=None, src_transform=None, dst_transform=None,
                  init_dest_nodata=True, **warp_extras):
+
+        self.mode = 'r'
+        self.options = {}
+        self._count = 0
+        self._closed = True
+        self._dtypes = []
+        self._block_shapes = None
+        self._nodatavals = []
+        self._units = ()
+        self._descriptions = ()
+        self._crs = None
+        self._gcps = None
+        self._read = False
+
         # kwargs become warp options.
-        super(WarpedVRTReaderBase, self).__init__(self)
         self.src_dataset = src_dataset
         self.src_crs = src_crs
         self.src_transform = src_transform
@@ -758,22 +771,7 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
             CSLDestroy(c_warp_extras)
             GDALDestroyWarpOptions(psWOptions)
 
-
-        driver = GDALGetDatasetDriver(self._hds)
-        self.driver = get_driver_name(driver).decode('utf-8')
-
-        self._count = GDALGetRasterCount(self._hds)
-        self.width = GDALGetRasterXSize(self._hds)
-        self.height = GDALGetRasterYSize(self._hds)
-        self.shape = (self.height, self.width)
-
-        self._transform = self.read_transform()
-        self._crs = self.read_crs()
-
-        # touch self.meta
-        _ = self.meta
-
-        self._closed = False
+        self._begin()
 
     def start(self):
         """Starts the VRT's life cycle."""

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -724,7 +724,8 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
         psWOptions = create_warp_options(
             <GDALResampleAlg>c_resampling, self.src_nodata,
-            self.dst_nodata, GDALGetRasterCount(hds), <const char **>c_warp_extras)
+            self.dst_nodata,
+            GDALGetRasterCount(hds), <const char **>c_warp_extras)
 
         try:
             if dst_width and dst_height and dst_transform:
@@ -771,11 +772,10 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
             CSLDestroy(c_warp_extras)
             GDALDestroyWarpOptions(psWOptions)
 
-        self._begin()
+        self._set_attrs_from_dataset_handle()
 
     def start(self):
         """Starts the VRT's life cycle."""
-
         log.debug("Dataset %r is started.", self)
 
     def stop(self):

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -263,15 +263,13 @@ class MemoryFile(MemoryFileBase):
         if self.closed:
             raise IOError("I/O operation on closed file.")
         if self.exists():
-            s = DatasetReader(vsi_path, 'r+')
+            return DatasetReader(vsi_path, 'r+')
         else:
             writer = get_writer_for_driver(driver)
-            s = writer(vsi_path, 'w', driver=driver, width=width,
-                       height=height, count=count, crs=crs,
-                       transform=transform, dtype=dtype,
-                       nodata=nodata, **kwargs)
-        s.start()
-        return s
+            return writer(vsi_path, 'w', driver=driver, width=width,
+                          height=height, count=count, crs=crs,
+                          transform=transform, dtype=dtype,
+                          nodata=nodata, **kwargs)
 
     def __enter__(self):
         return self
@@ -308,9 +306,7 @@ class ZipMemoryFile(MemoryFile):
 
         if self.closed:
             raise IOError("I/O operation on closed file.")
-        s = DatasetReader(vsi_path, 'r')
-        s.start()
-        return s
+        return DatasetReader(vsi_path, 'r')
 
 
 def get_writer_for_driver(driver):


### PR DESCRIPTION
As mentioned in #1046, the intent of this PR is to move the initialization of datasets and their GDAL dataset handles entirely to `__init__()` from `start()` so that we fail sooner and (ideally) never have partially-initialized and useless datasets in our programs.

There's a bit of duplicated code. I feel like a perfect refactoring is blocked by the `BufferedDatasetWriter` class, but don't intend to rewrite that in this PR.

The `__init__()` methods of dataset classes should now do 3 different things in the following order:

1. validation of arguments
2. creation and initialization of a `GDALDatasetH` dataset handle.
3. setting of Python attributes derived from the dataset handle.

I'll ping a couple of you for review when my work is done.