### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+all: deps clean install test
+
+.PHONY: docs
+
+install:
+	python setup.py build_ext
+	pip install -e .[all]
+
+deps:
+	pip install -r requirements-dev.txt
+
+clean:
+	pip uninstall -y rasterio || echo "no need to uninstall"
+	python setup.py clean --all
+	find . -name '__pycache__' -delete -print -o -name '*.pyc' -delete -print
+	touch rasterio/*.pyx
+
+test:
+	py.test --maxfail 1 -v --cov rasterio --cov-report html --pdb tests
+
+docs:
+	cd docs && make apidocs && make html
+
+doctest:
+	py.test --doctest-modules rasterio --doctest-glob='*.rst' docs/*.rst


### PR DESCRIPTION
Adds a Makefile to clean the source tree, install, run tests, and build docs. Resolves #1114 

TODO
- ~~Use the Makefile to install on travis~~ (the constraints of installing locally are different enough on travis to where this isn't useful)
- [x] manually test on linux
- ~~simplify the `clean` target~~ (I'm ok for now with leaving the kitchen-sink approach - make sure we clean everything)