### PR TITLE
fixing read imshow

### DIFF
--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -77,6 +77,8 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
 
     if isinstance(source, tuple):
         arr = source[0].read(source[1])
+        if len(arr.shape) >= 3:
+            arr = reshape_as_image(arr)
         if with_bounds:
             kwargs['extent'] = plotting_extent(source[0])
     elif isinstance(source, DatasetReader):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -29,24 +29,34 @@ def test_show_raster():
             show((src, 1))
             fig = plt.gcf()
             plt.close(fig)
+
         except ImportError:
             pass
 
-        with rasterio.open('tests/data/RGB.byte.tif') as src:
-            try:
-                show(src)
-                fig = plt.gcf()
-                plt.close(fig)
-            except ImportError:
-                pass
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        try:
+            show((src, (1, 2, 3)))
+            fig = plt.gcf()
+            plt.close(fig)
 
-        with rasterio.open('tests/data/float.tif') as src:
-            try:
-                show(src)
-                fig = plt.gcf()
-                plt.close(fig)
-            except ImportError:
-                pass
+        except ImportError:
+            pass
+
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        try:
+            show(src)
+            fig = plt.gcf()
+            plt.close(fig)
+        except ImportError:
+            pass
+
+    with rasterio.open('tests/data/float.tif') as src:
+        try:
+            show(src)
+            fig = plt.gcf()
+            plt.close(fig)
+        except ImportError:
+            pass
 
 def test_show_cmyk_interp(tmpdir):
     """A CMYK TIFF has cyan, magenta, yellow, black bands."""
@@ -208,7 +218,7 @@ def test_show_hist_mplargs():
     """
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
-            show_hist(src, bins=50, lw=0.0, stacked=False, alpha=0.3, 
+            show_hist(src, bins=50, lw=0.0, stacked=False, alpha=0.3,
                histtype='stepfilled', title="World Histogram overlaid")
             fig = plt.gcf()
             plt.close(fig)
@@ -237,7 +247,7 @@ def test_show_contour_mplargs():
     """
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
-            show((src, 1), contour=True, 
+            show((src, 1), contour=True,
                 levels=[25, 125], colors=['white', 'red'], linewidths=4,
                 contour_label_kws=dict(fontsize=18, fmt="%1.0f", inline_spacing=15, use_clabeltext=True))
             fig = plt.gcf()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -17,49 +17,42 @@ from rasterio.plot import show, show_hist, get_plt, plotting_extent
 from rasterio.enums import ColorInterp
 
 
-@pytest.mark.skipif(plt is None,
-                    reason="requires matplotlib")
-def test_show_raster():
-    """
-    This test only verifies that code up to the point of plotting with
-    matplotlib works correctly.  Tests do not exercise matplotlib.
-    """
+def test_show_raster_band():
+    """Test plotting a single raster band."""
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        try:
-            show((src, 1))
-            fig = plt.gcf()
-            plt.close(fig)
+        show((src, 1))
+        fig = plt.gcf()
+        plt.close(fig)
 
-        except ImportError:
-            pass
-
+def test_show_raster_mult_bands():
+    """Test multiple bands plotting."""
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        try:
-            show((src, (1, 2, 3)))
-            fig = plt.gcf()
-            plt.close(fig)
+        show((src, (1, 2, 3)))
+        fig = plt.gcf()
+        plt.close(fig)
 
-        except ImportError:
-            pass
-
+def test_show_raster_object():
+    """Test plotting a raster object."""
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        try:
-            show(src)
-            fig = plt.gcf()
-            plt.close(fig)
-        except ImportError:
-            pass
+        show(src)
+        fig = plt.gcf()
+        plt.close(fig)
 
+def test_show_raster_float():
+    """Test plotting a raster object with float data."""
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/float.tif') as src:
-        try:
-            show(src)
-            fig = plt.gcf()
-            plt.close(fig)
-        except ImportError:
-            pass
+        show(src)
+        fig = plt.gcf()
+        plt.close(fig)
+
 
 def test_show_cmyk_interp(tmpdir):
     """A CMYK TIFF has cyan, magenta, yellow, black bands."""
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         meta = src.meta
     meta['photometric'] = 'CMYK'
@@ -80,12 +73,13 @@ def test_show_cmyk_interp(tmpdir):
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
+
 def test_show_raster_no_bounds():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), with_bounds=False)
@@ -95,12 +89,12 @@ def test_show_raster_no_bounds():
             pass
 
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_raster_title():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), title="insert title here")
@@ -109,12 +103,12 @@ def test_show_raster_title():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_hist_large():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     try:
         rand_arr = np.random.randn(10, 718, 791)
         show_hist(rand_arr)
@@ -123,12 +117,12 @@ def test_show_hist_large():
     except ImportError:
         pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_raster_cmap():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), cmap='jet')
@@ -137,12 +131,12 @@ def test_show_raster_cmap():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_raster_ax():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             fig, ax = plt.subplots(1)
@@ -152,12 +146,12 @@ def test_show_raster_ax():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_array():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show(src.read(1))
@@ -167,12 +161,12 @@ def test_show_array():
             pass
 
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_array3D():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show(src.read((1, 2, 3)))
@@ -181,12 +175,12 @@ def test_show_array3D():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_hist():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show_hist((src, 1), bins=256)
@@ -210,12 +204,12 @@ def test_show_hist():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_hist_mplargs():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show_hist(src, bins=50, lw=0.0, stacked=False, alpha=0.3,
@@ -225,12 +219,12 @@ def test_show_hist_mplargs():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_contour():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), contour=True)
@@ -239,12 +233,12 @@ def test_show_contour():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_show_contour_mplargs():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), contour=True,
@@ -255,20 +249,20 @@ def test_show_contour_mplargs():
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_get_plt():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif'):
         try:
             assert plt == get_plt()
         except ImportError:
             pass
 
-@pytest.mark.skipif(plt is None, reason="requires matplotlib")
 def test_plt_transform():
+    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         show(src.read(), transform=src.transform)
         show(src.read(1), transform=src.transform)


### PR DESCRIPTION
I noticed that the function `reshape_as_image` wasn't being called if I explicitly passed 3 bands to my `rio.plot.show` function. This was causing `imshow` to break. This PR adds that in, as well as a test for it. It also removes the indentation on some of the other `with` statements in that block because it seemed like they were inadvertently indented one extra tab, but LMK if that was intentional and I can revert.