### PR TITLE
plot normalization

### DIFF
--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -34,7 +34,7 @@ def get_plt():
 
 
 def show(source, with_bounds=True, contour=False, contour_label_kws=None,
-         ax=None, title=None, transform=None, **kwargs):
+         ax=None, title=None, transform=None, normalize=False, **kwargs):
     """Display a raster or raster band using matplotlib.
 
     Parameters
@@ -60,6 +60,10 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
         Title for the figure.
     transform : Affine, optional
         Defines the affine transform if source is an array
+    normalize : bool
+        If the plotted data is an RGB image, whether to normalize the values of
+        each band so that they fall between 0 and 1 before plotting. Default
+        is False.
     **kwargs : key, value pairings optional
         These will be passed to the matplotlib imshow or contour method
         depending on contour argument.
@@ -105,6 +109,12 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
             arr = source
         if transform and with_bounds:
             kwargs['extent'] = plotting_extent(arr, transform)
+    if normalize is True and arr.ndim >= 3:
+        # Normalize each band by the min/max so it will plot as RGB.
+        arr = reshape_as_raster(arr)
+        for ii, band in enumerate(arr):
+            arr[ii] = normalize_band(band, 'linear')
+        arr = reshape_as_image(arr)
 
     show = False
     if not ax:
@@ -270,3 +280,28 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
     ax.set_ylabel('Frequency')
     if show:
         plt.show()
+
+
+def normalize_band(band, kind):
+    """Normalize a band to be between 0 and 1.
+
+    Parameters
+    ----------
+    band : array, shape (height, width)
+        A band of a raster object.
+    kind : 'linear'
+        The kind of normalization to apply. For now, there
+        is only one option ('linear').
+
+    Returns
+    -------
+    band_normed : array, shape (height, width)
+        A normalized version of the input band.
+    """
+    band_normed = np.zeros_like(band)
+    if kind == 'linear':
+        # Including this `if` statement in case future norms are added.
+        imin = np.nanmin(band)
+        imax = np.nanmax(band)
+        band_normed = (band - imin) / (imax - imin)
+    return band_normed

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -34,7 +34,7 @@ def get_plt():
 
 
 def show(source, with_bounds=True, contour=False, contour_label_kws=None,
-         ax=None, title=None, transform=None, normalize=False, **kwargs):
+         ax=None, title=None, transform=None, adjust='linear', **kwargs):
     """Display a raster or raster band using matplotlib.
 
     Parameters
@@ -60,10 +60,11 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
         Title for the figure.
     transform : Affine, optional
         Defines the affine transform if source is an array
-    normalize : bool
-        If the plotted data is an RGB image, whether to normalize the values of
-        each band so that they fall between 0 and 1 before plotting. Default
-        is False.
+    adjust : 'linear' | None
+        If the plotted data is an RGB image, adjust the values of
+        each band so that they fall between 0 and 1 before plotting. If
+        'linear', values will be adjusted by the min / max of each band. If
+        None, no adjustment will be applied.
     **kwargs : key, value pairings optional
         These will be passed to the matplotlib imshow or contour method
         depending on contour argument.
@@ -109,11 +110,11 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
             arr = source
         if transform and with_bounds:
             kwargs['extent'] = plotting_extent(arr, transform)
-    if normalize is True and arr.ndim >= 3:
-        # Normalize each band by the min/max so it will plot as RGB.
+    if adjust is True and arr.ndim >= 3:
+        # Adjust each band by the min/max so it will plot as RGB.
         arr = reshape_as_raster(arr)
         for ii, band in enumerate(arr):
-            arr[ii] = normalize_band(band, 'linear')
+            arr[ii] = adjust_band(band, kind='linear')
         arr = reshape_as_image(arr)
 
     show = False
@@ -282,8 +283,8 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
         plt.show()
 
 
-def normalize_band(band, kind):
-    """Normalize a band to be between 0 and 1.
+def adjust_band(band, kind='linear'):
+    """Adjust a band to be between 0 and 1.
 
     Parameters
     ----------
@@ -296,7 +297,7 @@ def normalize_band(band, kind):
     Returns
     -------
     band_normed : array, shape (height, width)
-        A normalized version of the input band.
+        An adjusted version of the input band.
     """
     band_normed = np.zeros_like(band)
     if kind == 'linear':

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -13,7 +13,8 @@ except ImportError:
     plt = None
 
 import rasterio
-from rasterio.plot import show, show_hist, get_plt, plotting_extent
+from rasterio.plot import (show, show_hist, get_plt,
+                           plotting_extent, normalize_band)
 from rasterio.enums import ColorInterp
 
 
@@ -208,7 +209,7 @@ def test_show_hist_mplargs():
     """
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
-            show_hist(src, bins=50, lw=0.0, stacked=False, alpha=0.3, 
+            show_hist(src, bins=50, lw=0.0, stacked=False, alpha=0.3,
                histtype='stepfilled', title="World Histogram overlaid")
             fig = plt.gcf()
             plt.close(fig)
@@ -237,7 +238,7 @@ def test_show_contour_mplargs():
     """
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
-            show((src, 1), contour=True, 
+            show((src, 1), contour=True,
                 levels=[25, 125], colors=['white', 'red'], linewidths=4,
                 contour_label_kws=dict(fontsize=18, fmt="%1.0f", inline_spacing=15, use_clabeltext=True))
             fig = plt.gcf()
@@ -275,3 +276,8 @@ def test_plotting_extent():
         # array requires a transform
         with pytest.raises(ValueError):
             plotting_extent(src.read(1))
+
+def test_plot_normalize():
+    a = np.linspace(1, 6, 10)
+    b = normalize_band(a, 'linear')
+    np.testing.assert_array_almost_equal(np.linspace(0, 1, 10), b)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -14,7 +14,7 @@ except ImportError:
 
 import rasterio
 from rasterio.plot import (show, show_hist, get_plt,
-                           plotting_extent, normalize_band)
+                           plotting_extent, adjust_band)
 from rasterio.enums import ColorInterp
 
 
@@ -279,5 +279,5 @@ def test_plotting_extent():
 
 def test_plot_normalize():
     a = np.linspace(1, 6, 10)
-    b = normalize_band(a, 'linear')
+    b = adjust_band(a, 'linear')
     np.testing.assert_array_almost_equal(np.linspace(0, 1, 10), b)


### PR DESCRIPTION
This adds a `normalize` function to `show` so that bands of the raster are normalized between 0 and 1. This makes it possible to visualize them as images. It'd be easy to extend this in the future to other kinds of normalization (e.g. log-spacing), but I don't think it's necessary for this PR.