### PR TITLE
Use height/width instead of num_row/num_col in mask

### DIFF
--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -1,7 +1,6 @@
 """Mask the area outside of the input shapes with no data."""
 
 import logging
-import math
 import warnings
 
 import rasterio
@@ -105,8 +104,8 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
         # Get the window with integer height
         # and width that contains the bounds window.
         out_window = bounds_window.round_shape(op='ceil')
-        height = int(out_window.num_rows)
-        width = int(out_window.num_cols)
+        height = int(out_window.height)
+        width = int(out_window.width)
 
         out_shape = (raster.count, height, width)
         out_transform = raster.window_transform(out_window)


### PR DESCRIPTION
The window attributes `num_row`/`num_col` were deprecated in #1074.