### PR TITLE
Masking with shape returns wrong type [WIP]

### DIFF
--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -6,12 +6,18 @@ import pytest
 import rasterio
 from rasterio.mask import mask as mask_tool
 
+import numpy
 
 # Custom markers.
 xfail_pixel_sensitive_gdal22 = pytest.mark.xfail(
     parse(rasterio.__gdal_version__) < parse('2.2'),
     reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 
+def test_return_type(basic_image_file, basic_geometry):
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries)
+    assert(type(masked) == numpy.ndarray)
 
 def test_nodata(basic_image_file, basic_geometry):
     nodata_val = 0


### PR DESCRIPTION
The `rasterio.mask.mask` function specifies that it returns a `numpy.ndarray`.  Instead, it returns a masked array whose mask consists entirely of `False` values.  For now, this PR consists only of a failing test to show this.

The problem occurs in the following snippet:

```
for i in range(raster.count):
    out_image[i] = out_image[i].filled(nodata)
```

Since `out_image` is an `ndarray`, not a list, assigning to the `i` slice coerces the right-hand side (an `ndarray`) into a masked array.

I can contribute a fix, but I'd need some direction on the desired behavior of the function.  (For my use case, I'd prefer that it return a properly constructed masked array, but this is not what the docstring describes.)