### PR TITLE
Fix mask return type and overhaul tests

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -331,6 +331,9 @@ def geometry_window(raster, shapes, pad_x=0, pad_y=0, north_up=True,
     pad_y: float
         Amount of padding (as fraction of raster's y pixel size) to add to top 
         and bottom of bounds.
+    north_up: bool
+        If True (default), the origin point of the raster's transform is the 
+        northernmost point and y pixel values are negative.
     pixel_precision: int
         Number of places of rounding precision for evaluating bounds of shapes.
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -2,14 +2,12 @@
 
 
 import logging
-import warnings
 
 import numpy as np
 
 from rasterio._features import _shapes, _sieve, _rasterize, _bounds
 from rasterio.dtypes import validate_dtype, can_cast_dtype, get_minimum_dtype
 from rasterio.env import ensure_env
-from rasterio.errors import WindowError
 from rasterio.transform import IDENTITY, guard_transform
 from rasterio.windows import Window
 
@@ -315,8 +313,7 @@ def geometry_window(raster, shapes, pad_x=0, pad_y=0, north_up=True,
     geometry plus optional padding.  The window is the outermost pixel indices
     that contain the geometry (floor of offsets, ceiling of width and height).
     
-    If shapes do not overlap raster, a warning is raised and an empty window 
-    `Window(0, 0, 0, 0)` is returned.
+    If shapes do not overlap raster, a WindowError is raised.
 
     Parameters
     ----------
@@ -367,12 +364,8 @@ def geometry_window(raster, shapes, pad_x=0, pad_y=0, north_up=True,
 
     # Make sure that window overlaps raster
     raster_window = Window(0, 0, raster.height, raster.width)
-    try:
-        window = window.intersection(raster_window)
 
-    except WindowError:
-        window = Window(0, 0, 0, 0)
-        warnings.warn("shapes are outside bounds of raster. "
-                      "Are they in different coordinate reference systems?")
+    # This will raise a WindowError if windows do not overlap
+    window = window.intersection(raster_window)
 
     return window

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -5,6 +5,7 @@ import warnings
 
 import numpy as np
 
+from rasterio.errors import WindowError
 from rasterio.features import geometry_mask, geometry_window
 
 
@@ -19,7 +20,7 @@ def raster_geometry_mask(raster, shapes, all_touched=False, invert=False,
     By default, mask is intended for use as a numpy mask, where pixels that 
     overlap shapes are False.
     
-    If shapes do not overlap the raster and crop=True, an exception is 
+    If shapes do not overlap the raster and crop=True, a ValueError is 
     raised.  Otherwise, a warning is raised, and a completely True mask
     is returned (if invert is False).
 
@@ -74,12 +75,13 @@ def raster_geometry_mask(raster, shapes, all_touched=False, invert=False,
 
     north_up = raster.transform.e <= 0
 
-    window = geometry_window(raster, shapes, north_up=north_up, pad_x=pad_x, 
-                             pad_y=pad_y)
+    try:
+        window = geometry_window(raster, shapes, north_up=north_up, pad_x=pad_x,
+                                 pad_y=pad_y)
 
-    # If shapes do not overlap raster, raise Exception or UserWarning
-    # depending on value of crop
-    if window.flatten() == (0, 0, 0, 0):
+    except WindowError:
+        # If shapes do not overlap raster, raise Exception or UserWarning
+        # depending on value of crop
         if crop:
             raise ValueError('Input shapes do not overlap raster.')
         else:
@@ -111,7 +113,7 @@ def mask(raster, shapes, all_touched=False, invert=False, nodata=None,
     Pixels are masked or set to nodata outside the input shapes, unless 
     `invert` is `True`.
     
-    If shapes do not overlap the raster and crop=True, an exception is 
+    If shapes do not overlap the raster and crop=True, a ValueError is 
     raised.  Otherwise, a warning is raised.
 
     Parameters

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -11,8 +11,8 @@ from rasterio.features import geometry_mask, geometry_window
 logger = logging.getLogger(__name__)
 
 
-def raster_geom_mask(raster, shapes, all_touched=False, invert=False,
-                    crop=False, pad=False):
+def raster_geometry_mask(raster, shapes, all_touched=False, invert=False,
+                         crop=False, pad=False):
     """Create a mask from shapes, transform, and optional window within original 
     raster.
 
@@ -31,13 +31,13 @@ def raster_geom_mask(raster, shapes, all_touched=False, invert=False,
         GeoJSON-like dict representation of polygons that will be used to 
         create the mask.
     all_touched: bool (opt)
-        Use all pixels touched by features. If False (default), use only
-        pixels whose center is within the polygon or that are selected by
-        Bresenham's line algorithm.
+        Include a pixel in the mask if it touches any of the shapes. 
+        If False (default), include a pixel only if its center is within one of 
+        the shapes, or if it is selected by Bresenham's line algorithm.
     invert: bool (opt)
-        If True, mask will be `True` for pixels inside shapes and `False`
-        outside shapes.
-        False by default.
+        If False (default), mask will be `False` inside shapes and `True` 
+        outside.  If True, mask will be `True` inside shapes and `False` 
+        outside.
     crop: bool (opt)
         Whether to crop the raster to the extent of the shapes. Defaults to
         False.
@@ -92,12 +92,12 @@ def raster_geom_mask(raster, shapes, all_touched=False, invert=False,
 
     if crop:
         transform = raster.window_transform(window)
-        out_shape = (window.height, window.width)
+        out_shape = (int(window.height), int(window.width))
 
     else:
         window = None
         transform = raster.transform
-        out_shape = (raster.height, raster.width)
+        out_shape = (int(raster.height), int(raster.width))
 
     mask = geometry_mask(shapes, transform=transform, invert=invert,
                          out_shape=out_shape, all_touched=all_touched)
@@ -122,13 +122,12 @@ def mask(raster, shapes, all_touched=False, invert=False, nodata=None,
         GeoJSON-like dict representation of polygons that will be used to 
         create the mask.
     all_touched: bool (opt)
-        Use all pixels touched by features. If False (default), use only
-        pixels whose center is within the polygon or that are selected by
-        Bresenham's line algorithm.
+        Include a pixel in the mask if it touches any of the shapes. 
+        If False (default), include a pixel only if its center is within one of 
+        the shapes, or if it is selected by Bresenham's line algorithm.
     invert: bool (opt)
-        If True, mask will be `True` for pixels inside shapes and `False`
-        outside shapes.
-        False by default.
+        If False (default) pixels outside shapes will be masked.  If True, 
+        pixels inside shape will be masked.
     nodata: int or float (opt)
         Value representing nodata within each raster band. If not set,
         defaults to the nodata value for the input raster. If there is no
@@ -151,9 +150,14 @@ def mask(raster, shapes, all_touched=False, invert=False, nodata=None,
         Two elements:
 
             masked : numpy ndarray or numpy.ma.MaskedArray
-                Data contained in raster after applying the mask (`filled` is 
-                `True`) and mask where all pixels are `True` outside shapes 
-                (`invert` is `False`).
+                Data contained in the raster after applying the mask. If 
+                `filled` is `True` and `invert` is `False`, the return will be 
+                an array where pixels outside shapes are set to the nodata value 
+                (or nodata inside shapes if `invert` is `True`). 
+                
+                If `filled` is `False`, the return will be a MaskedArray in 
+                which pixels outside shapes are `True` (or `False` if `invert` 
+                is `True`).
 
             out_transform : affine.Affine()
                 Information for mapping pixel coordinates in `masked` to another
@@ -166,7 +170,7 @@ def mask(raster, shapes, all_touched=False, invert=False, nodata=None,
         else:
             nodata = 0
 
-    shape_mask, transform, window = raster_geom_mask(
+    shape_mask, transform, window = raster_geometry_mask(
         raster, shapes, all_touched=all_touched, invert=invert, crop=crop,
         pad=pad)
 

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -3,43 +3,143 @@
 import logging
 import warnings
 
-import rasterio
-from rasterio.features import geometry_mask
+import numpy as np
+
+from rasterio.features import geometry_mask, geometry_window
 
 
 logger = logging.getLogger(__name__)
 
 
-def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
-         invert=False, pad=False):
-    """Mask the area outside of the input shapes with nodata.
+def raster_geom_mask(raster, shapes, all_touched=False, invert=False,
+                    crop=False, pad=False):
+    """Create a mask from shapes, transform, and optional window within original 
+    raster.
 
-    For all regions in the input raster outside of the regions defined by
-    `shapes`, sets any data present to nodata.  Original pixel values are
-    returned within the `shapes`.
+    By default, mask is intended for use as a numpy mask, where pixels that 
+    overlap shapes are False.
+    
+    If shapes do not overlap the raster and crop=True, an exception is 
+    raised.  Otherwise, a warning is raised, and a completely True mask
+    is returned (if invert is False).
+
+    Parameters
+    ----------
+    raster: rasterio RasterReader object
+        Raster for which the mask will be created.
+    shapes: list of polygons
+        GeoJSON-like dict representation of polygons that will be used to 
+        create the mask.
+    all_touched: bool (opt)
+        Use all pixels touched by features. If False (default), use only
+        pixels whose center is within the polygon or that are selected by
+        Bresenham's line algorithm.
+    invert: bool (opt)
+        If True, mask will be `True` for pixels inside shapes and `False`
+        outside shapes.
+        False by default.
+    crop: bool (opt)
+        Whether to crop the raster to the extent of the shapes. Defaults to
+        False.
+    pad: bool (opt)
+        If True, the features will be padded in each direction by
+        one half of a pixel prior to cropping raster. Defaults to False.
+
+    Returns
+    -------
+    tuple
+
+        Three elements:
+
+            mask : numpy ndarray of type 'bool'
+                Mask that is `True` outside shapes, and `False` within shapes.
+
+            out_transform : affine.Affine()
+                Information for mapping pixel coordinates in `masked` to another
+                coordinate system.
+            
+            window: rasterio.windows.Window instance
+                Window within original raster covered by shapes.  None if crop
+                is False.
+    """
+    if crop and invert:
+        raise ValueError("crop and invert cannot both be True.")
+    
+    if crop and pad:
+        pad_x = 0.5  # pad by 1/2 of pixel size
+        pad_y = 0.5
+    else:
+        pad_x = 0
+        pad_y = 0
+
+    north_up = raster.transform.e <= 0
+
+    window = geometry_window(raster, shapes, north_up=north_up, pad_x=pad_x, 
+                             pad_y=pad_y)
+
+    # If shapes do not overlap raster, raise Exception or UserWarning
+    # depending on value of crop
+    if window.flatten() == (0, 0, 0, 0):
+        if crop:
+            raise ValueError('Input shapes do not overlap raster.')
+        else:
+            warnings.warn('shapes are outside bounds of raster. '
+                          'Are they in different coordinate reference systems?')
+
+        # Return an entirely True mask (if invert is False)
+        mask = np.ones(shape=raster.shape[-2:], dtype='bool') * (not invert)
+        return mask, raster.transform, None
+
+    if crop:
+        transform = raster.window_transform(window)
+        out_shape = (window.height, window.width)
+
+    else:
+        window = None
+        transform = raster.transform
+        out_shape = (raster.height, raster.width)
+
+    mask = geometry_mask(shapes, transform=transform, invert=invert,
+                         out_shape=out_shape, all_touched=all_touched)
+
+    return mask, transform, window
+
+
+def mask(raster, shapes, all_touched=False, invert=False, nodata=None,
+         filled=True, crop=False, pad=False):
+    """Creates a masked or filled array using input shapes.  
+    Pixels are masked or set to nodata outside the input shapes, unless 
+    `invert` is `True`.
+    
+    If shapes do not overlap the raster and crop=True, an exception is 
+    raised.  Otherwise, a warning is raised.
 
     Parameters
     ----------
     raster: rasterio RasterReader object
         Raster to which the mask will be applied.
     shapes: list of polygons
-        Polygons are GeoJSON-like dicts specifying the boundaries of features
-        in the raster to be kept. All data outside of specified polygons
-        will be set to nodata.
+        GeoJSON-like dict representation of polygons that will be used to 
+        create the mask.
+    all_touched: bool (opt)
+        Use all pixels touched by features. If False (default), use only
+        pixels whose center is within the polygon or that are selected by
+        Bresenham's line algorithm.
+    invert: bool (opt)
+        If True, mask will be `True` for pixels inside shapes and `False`
+        outside shapes.
+        False by default.
     nodata: int or float (opt)
         Value representing nodata within each raster band. If not set,
         defaults to the nodata value for the input raster. If there is no
         set nodata value for the raster, it defaults to 0.
+    filled: bool (opt)
+        If True, the pixels outside the features will be set to nodata.  
+        If False, the output array will contain the original pixel data, 
+        and only the mask will be based on shapes.  Defaults to True.
     crop: bool (opt)
         Whether to crop the raster to the extent of the shapes. Defaults to
         False.
-    all_touched: bool (opt)
-        Use all pixels touched by features. If False (default), use only
-        pixels whose center is within the polygon or that are selected by
-        Bresenhams line algorithm.
-    invert: bool (opt)
-        If True, nodata value will be returned for pixels that overlap shapes.
-        False by default.
     pad: bool (opt)
         If True, the features will be padded in each direction by
         one half of a pixel prior to cropping raster. Defaults to False.
@@ -50,15 +150,15 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
 
         Two elements:
 
-            masked : numpy ndarray
-                Data contained in raster after applying the mask.
+            masked : numpy ndarray or numpy.ma.MaskedArray
+                Data contained in raster after applying the mask (`filled` is 
+                `True`) and mask where all pixels are `True` outside shapes 
+                (`invert` is `False`).
 
             out_transform : affine.Affine()
                 Information for mapping pixel coordinates in `masked` to another
                 coordinate system.
     """
-    if crop and invert:
-        raise ValueError("crop and invert cannot both be True.")
 
     if nodata is None:
         if raster.nodata is not None:
@@ -66,69 +166,19 @@ def mask(raster, shapes, nodata=None, crop=False, all_touched=False,
         else:
             nodata = 0
 
-    # "North down" georeferencing or ungeoreferenced rasters require
-    # bounds shuffling.
-    north_up = raster.transform.e <= 0
+    shape_mask, transform, window = raster_geom_mask(
+        raster, shapes, all_touched=all_touched, invert=invert, crop=crop,
+        pad=pad)
 
-    # Calculate the bounds of all features.
-    all_bounds = [
-        rasterio.features.bounds(shape, north_up=north_up) for shape in shapes]
-    lefts, bottoms, rights, tops = zip(*all_bounds)
+    height, width = shape_mask.shape
+    out_shape = (raster.count, height, width)
 
-    source_bounds = raster.bounds
-
-    if crop:
-        if pad:
-            dx = raster.res[0] / 2
-            dy = abs(raster.res[1] / 2)
-        else:
-            dx = 0.0
-            dy = 0.0
-
-        if north_up:
-            mask_bounds = (min(lefts) - dx, min(bottoms) - dy,
-                           max(rights) + dx, max(tops) + dy)
-        else:
-            mask_bounds = (min(lefts) - dx, max(bottoms) + dy,
-                           max(rights) + dx, min(tops) - dy)
-
-        # Raise or warn about bounds mismatches.
-        if rasterio.coords.disjoint_bounds(source_bounds, mask_bounds):
-            if crop:
-                raise ValueError("Input shapes do not overlap raster.")
-            else:
-                warnings.warn("GeoJSON outside bounds of existing output " +
-                              "raster. Are they in different coordinate " +
-                              "reference systems?")
-
-        bounds_window = raster.window(*mask_bounds)
-
-        # Get the window with integer height
-        # and width that contains the bounds window.
-        out_window = bounds_window.round_shape(op='ceil')
-
-        height = int(out_window.height)
-        width = int(out_window.width)
-
-        out_shape = (raster.count, height, width)
-        out_transform = raster.window_transform(out_window)
-
-        logger.debug("Out window: %r", out_window)
-        logger.debug("Out transform: %r", out_transform)
-
-    else:
-        out_window = None
-        out_shape = (raster.count, raster.height, raster.width)
-        out_transform = raster.transform
-
-    # Read the window of imagery.
-    out_image = raster.read(window=out_window, out_shape=out_shape,
-                            masked=True)
-    mask_shape = out_image.shape[1:]
-
-    shape_mask = geometry_mask(shapes, transform=out_transform, invert=invert,
-                               out_shape=mask_shape, all_touched=all_touched)
-
+    out_image = raster.read(window=window, out_shape=out_shape, masked=True)
     out_image.mask = out_image.mask | shape_mask
 
-    return out_image.filled(nodata), out_transform
+    if filled:
+        out_image = out_image.filled(nodata)
+
+    return out_image, transform
+
+

--- a/rasterio/rio/mask.py
+++ b/rasterio/rio/mask.py
@@ -8,6 +8,7 @@ import cligj
 from .helpers import resolve_inout
 from . import options
 import rasterio
+from rasterio.mask import mask as mask_tool
 
 logger = logging.getLogger('rio')
 
@@ -65,8 +66,6 @@ def mask(
     --crop option is not valid if features are completely outside extent of
     input raster.
     """
-    from rasterio.mask import mask as mask_tool
-    from rasterio.features import bounds as calculate_bounds
 
     output, files = resolve_inout(
         files=files, output=output, force_overwrite=force_overwrite)
@@ -112,6 +111,8 @@ def mask(
                                                  'input raster',
                                                  param=crop,
                                                  param_hint='--crop')
+                else: # pragma: no cover
+                    raise e
 
             meta = src.meta.copy()
             meta.update(**creation_options)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -6,6 +6,7 @@ import pytest
 from affine import Affine
 
 import rasterio
+from rasterio.errors import WindowError
 from rasterio.features import (
     bounds, geometry_mask, geometry_window, rasterize, sieve, shapes)
 
@@ -153,13 +154,12 @@ def test_geometry_large_shapes(basic_image_file):
 
 
 def test_geometry_no_overlap(path_rgb_byte_tif, basic_geometry):
+    """Geometries that do not overlap raster raises WindowError"""
+    
     with rasterio.open(path_rgb_byte_tif) as src:
-        with pytest.warns(UserWarning) as warning:
+        with pytest.raises(WindowError):
             window = geometry_window(src, [basic_geometry], north_up=False)
 
-            assert 'outside bounds of raster' in warning[0].message.args[0]
-
-    assert window.flatten() == (0, 0, 0, 0)
 
 
 def test_rasterize(basic_geometry, basic_image_2x2):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -3,50 +3,50 @@ import pytest
 from affine import Affine
 
 import rasterio
-from rasterio.mask import raster_geom_mask, mask
+from rasterio.mask import raster_geometry_mask, mask
 
 
-def test_raster_geom_mask(basic_image_2x2, basic_image_file, basic_geometry):
+def test_raster_geometrymask(basic_image_2x2, basic_image_file, basic_geometry):
     """Pixels inside the geometry are False in the mask"""
 
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
-        geom_mask, transform, window = raster_geom_mask(src, geometries)
+        geometrymask, transform, window = raster_geometry_mask(src, geometries)
 
-    assert np.array_equal(geom_mask, (basic_image_2x2 == 0))
+    assert np.array_equal(geometrymask, (basic_image_2x2 == 0))
     assert transform == Affine.identity()
     assert window is None
 
 
-def test_raster_geom_mask_invert(basic_image_2x2, basic_image_file, basic_geometry):
+def test_raster_geometrymask_invert(basic_image_2x2, basic_image_file, basic_geometry):
     """Pixels inside the geometry are True in the mask"""
 
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
-        geom_mask, transform, window = raster_geom_mask(src, geometries,
-                                                        invert=True)
+        geometrymask, transform, window = raster_geometry_mask(src, geometries,
+                                                            invert=True)
 
-    assert np.array_equal(geom_mask, basic_image_2x2)
+    assert np.array_equal(geometrymask, basic_image_2x2)
     assert transform == Affine.identity()
 
 
-def test_raster_geom_mask_all_touched(basic_image, basic_image_file,
+def test_raster_geometrymask_all_touched(basic_image, basic_image_file,
                                       basic_geometry):
     """Pixels inside the geometry are False in the mask"""
 
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
-        geom_mask, transform, window = raster_geom_mask(src, geometries,
-                                                all_touched=True)
+        geometrymask, transform, window = raster_geometry_mask(src, geometries,
+                                                            all_touched=True)
 
-    assert np.array_equal(geom_mask, (basic_image == 0))
+    assert np.array_equal(geometrymask, (basic_image == 0))
     assert transform == Affine.identity()
 
 
-def test_raster_geom_mask_crop(basic_image_2x2, basic_image_file,
+def test_raster_geometrymask_crop(basic_image_2x2, basic_image_file,
                                basic_geometry):
     """Mask returned will be cropped to extent of geometry, and transform
     is transposed 2 down and 2 over"""
@@ -54,28 +54,28 @@ def test_raster_geom_mask_crop(basic_image_2x2, basic_image_file,
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
-        geom_mask, transform, window = raster_geom_mask(src, geometries,
-                                                        crop=True)
+        geometrymask, transform, window = raster_geometry_mask(src, geometries,
+                                                            crop=True)
 
     image = basic_image_2x2[2:5, 2:5] == 0  # invert because invert=False
 
-    assert geom_mask.shape == (3, 3)
-    assert np.array_equal(geom_mask, image)
+    assert geometrymask.shape == (3, 3)
+    assert np.array_equal(geometrymask, image)
     assert transform == Affine(1, 0, 2, 0, 1, 2)
     assert window is not None and window.flatten() == (2, 2, 3, 3)
 
 
-def test_raster_geom_mask_crop_invert(basic_image_file, basic_geometry):
+def test_raster_geometrymask_crop_invert(basic_image_file, basic_geometry):
     """crop and invert cannot be combined"""
 
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
         with pytest.raises(ValueError):
-            raster_geom_mask(src, geometries, crop=True, invert=True)
+            raster_geometry_mask(src, geometries, crop=True, invert=True)
 
 
-def test_raster_geom_mask_crop_all_touched(basic_image, basic_image_file,
+def test_raster_geometrymask_crop_all_touched(basic_image, basic_image_file,
                                            basic_geometry):
     """Mask returned will be cropped to extent of geometry, and transform
     is transposed 2 down and 2 over"""
@@ -83,19 +83,19 @@ def test_raster_geom_mask_crop_all_touched(basic_image, basic_image_file,
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
-        geom_mask, transform, window = raster_geom_mask(src, geometries,
-                                                        crop=True,
-                                                        all_touched=True)
+        geometrymask, transform, window = raster_geometry_mask(src, geometries,
+                                                            crop=True,
+                                                            all_touched=True)
 
     image = basic_image[2:5, 2:5] == 0  # invert because invert=False
 
-    assert geom_mask.shape == (3, 3)
-    assert np.array_equal(geom_mask, image)
+    assert geometrymask.shape == (3, 3)
+    assert np.array_equal(geometrymask, image)
     assert transform == Affine(1, 0, 2, 0, 1, 2)
     assert window is not None and window.flatten() == (2, 2, 3, 3)
 
 
-def test_raster_geom_mask_crop_pad(basic_image_2x2, basic_image_file,
+def test_raster_geometrymask_crop_pad(basic_image_2x2, basic_image_file,
                                    basic_geometry):
     """Mask returned will be cropped to extent of geometry plus 1/2 pixel on
     all sides, and transform is transposed 1 down and 1 over"""
@@ -103,33 +103,33 @@ def test_raster_geom_mask_crop_pad(basic_image_2x2, basic_image_file,
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
-        geom_mask, transform, window = raster_geom_mask(src, geometries,
-                                                        crop=True, pad=True)
+        geometrymask, transform, window = raster_geometry_mask(src, geometries,
+                                                            crop=True, pad=True)
 
     image = basic_image_2x2[1:5, 1:5] == 0  # invert because invert=False
 
-    assert geom_mask.shape == (4, 4)
-    assert np.array_equal(geom_mask, image)
+    assert geometrymask.shape == (4, 4)
+    assert np.array_equal(geometrymask, image)
     assert transform == Affine(1, 0, 1, 0, 1, 1)
     assert window is not None and window.flatten() == (1, 1, 4, 4)
 
 
-def test_raster_geom_mask_no_overlap(path_rgb_byte_tif, basic_geometry):
+def test_raster_geometrymask_no_overlap(path_rgb_byte_tif, basic_geometry):
     """If there is no overlap, a warning should be raised"""
 
     with rasterio.open(path_rgb_byte_tif) as src:
         with pytest.warns(UserWarning) as warning:
-            raster_geom_mask(src, [basic_geometry])
+            raster_geometry_mask(src, [basic_geometry])
 
             assert 'outside bounds of raster' in warning[0].message.args[0]
 
 
-def test_raster_geom_mask_crop_no_overlap(path_rgb_byte_tif, basic_geometry):
+def test_raster_geometrymask_crop_no_overlap(path_rgb_byte_tif, basic_geometry):
     """If there is no overlap with crop=True, an Exception should be raised"""
 
     with rasterio.open(path_rgb_byte_tif) as src:
         with pytest.raises(ValueError) as excinfo:
-            raster_geom_mask(src, [basic_geometry], crop=True)
+            raster_geometry_mask(src, [basic_geometry], crop=True)
 
             assert 'shapes do not overlap raster' in repr(excinfo)
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,11 +1,138 @@
-"""Unittests for rasterio.mask"""
-
+import numpy as np
+import pytest
+from affine import Affine
 
 import rasterio
-from rasterio.mask import mask as mask_tool
+from rasterio.mask import raster_geom_mask, mask
 
-import numpy
-import pytest
+
+def test_raster_geom_mask(basic_image_2x2, basic_image_file, basic_geometry):
+    """Pixels inside the geometry are False in the mask"""
+
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        geom_mask, transform, window = raster_geom_mask(src, geometries)
+
+    assert np.array_equal(geom_mask, (basic_image_2x2 == 0))
+    assert transform == Affine.identity()
+    assert window is None
+
+
+def test_raster_geom_mask_invert(basic_image_2x2, basic_image_file, basic_geometry):
+    """Pixels inside the geometry are True in the mask"""
+
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        geom_mask, transform, window = raster_geom_mask(src, geometries,
+                                                        invert=True)
+
+    assert np.array_equal(geom_mask, basic_image_2x2)
+    assert transform == Affine.identity()
+
+
+def test_raster_geom_mask_all_touched(basic_image, basic_image_file,
+                                      basic_geometry):
+    """Pixels inside the geometry are False in the mask"""
+
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        geom_mask, transform, window = raster_geom_mask(src, geometries,
+                                                all_touched=True)
+
+    assert np.array_equal(geom_mask, (basic_image == 0))
+    assert transform == Affine.identity()
+
+
+def test_raster_geom_mask_crop(basic_image_2x2, basic_image_file,
+                               basic_geometry):
+    """Mask returned will be cropped to extent of geometry, and transform
+    is transposed 2 down and 2 over"""
+
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        geom_mask, transform, window = raster_geom_mask(src, geometries,
+                                                        crop=True)
+
+    image = basic_image_2x2[2:5, 2:5] == 0  # invert because invert=False
+
+    assert geom_mask.shape == (3, 3)
+    assert np.array_equal(geom_mask, image)
+    assert transform == Affine(1, 0, 2, 0, 1, 2)
+    assert window is not None and window.flatten() == (2, 2, 3, 3)
+
+
+def test_raster_geom_mask_crop_invert(basic_image_file, basic_geometry):
+    """crop and invert cannot be combined"""
+
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        with pytest.raises(ValueError):
+            raster_geom_mask(src, geometries, crop=True, invert=True)
+
+
+def test_raster_geom_mask_crop_all_touched(basic_image, basic_image_file,
+                                           basic_geometry):
+    """Mask returned will be cropped to extent of geometry, and transform
+    is transposed 2 down and 2 over"""
+
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        geom_mask, transform, window = raster_geom_mask(src, geometries,
+                                                        crop=True,
+                                                        all_touched=True)
+
+    image = basic_image[2:5, 2:5] == 0  # invert because invert=False
+
+    assert geom_mask.shape == (3, 3)
+    assert np.array_equal(geom_mask, image)
+    assert transform == Affine(1, 0, 2, 0, 1, 2)
+    assert window is not None and window.flatten() == (2, 2, 3, 3)
+
+
+def test_raster_geom_mask_crop_pad(basic_image_2x2, basic_image_file,
+                                   basic_geometry):
+    """Mask returned will be cropped to extent of geometry plus 1/2 pixel on
+    all sides, and transform is transposed 1 down and 1 over"""
+
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        geom_mask, transform, window = raster_geom_mask(src, geometries,
+                                                        crop=True, pad=True)
+
+    image = basic_image_2x2[1:5, 1:5] == 0  # invert because invert=False
+
+    assert geom_mask.shape == (4, 4)
+    assert np.array_equal(geom_mask, image)
+    assert transform == Affine(1, 0, 1, 0, 1, 1)
+    assert window is not None and window.flatten() == (1, 1, 4, 4)
+
+
+def test_raster_geom_mask_no_overlap(path_rgb_byte_tif, basic_geometry):
+    """If there is no overlap, a warning should be raised"""
+
+    with rasterio.open(path_rgb_byte_tif) as src:
+        with pytest.warns(UserWarning) as warning:
+            raster_geom_mask(src, [basic_geometry])
+
+            assert 'outside bounds of raster' in warning[0].message.args[0]
+
+
+def test_raster_geom_mask_crop_no_overlap(path_rgb_byte_tif, basic_geometry):
+    """If there is no overlap with crop=True, an Exception should be raised"""
+
+    with rasterio.open(path_rgb_byte_tif) as src:
+        with pytest.raises(ValueError) as excinfo:
+            raster_geom_mask(src, [basic_geometry], crop=True)
+
+            assert 'shapes do not overlap raster' in repr(excinfo)
+
 
 
 def test_mask(basic_image_2x2, basic_image_file, basic_geometry):
@@ -13,10 +140,11 @@ def test_mask(basic_image_2x2, basic_image_file, basic_geometry):
 
     geometries = [basic_geometry]
 
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries)
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries)
 
-    assert numpy.array_equal(masked[0], basic_image_2x2)
+    assert np.array_equal(masked[0], basic_image_2x2)
+    assert (type(masked) == np.ndarray)
 
 
 def test_mask_invert(basic_image, basic_image_file, basic_geometry):
@@ -25,13 +153,13 @@ def test_mask_invert(basic_image, basic_image_file, basic_geometry):
     geometries = [basic_geometry]
     basic_image[2:4, 2:4] = 0
 
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, invert=True)
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, invert=True)
 
-    assert numpy.array_equal(masked[0], basic_image)
+    assert np.array_equal(masked[0], basic_image)
 
 
-def test_nodata(basic_image_2x2, basic_image_file, basic_geometry):
+def test_mask_nodata(basic_image_2x2, basic_image_file, basic_geometry):
     """All pixels outside geometry should be masked out as 3"""
 
     nodata = 3
@@ -39,66 +167,72 @@ def test_nodata(basic_image_2x2, basic_image_file, basic_geometry):
 
     basic_image_2x2[basic_image_2x2 == 0] = nodata
 
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, nodata=nodata)
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, nodata=nodata)
 
-    assert numpy.array_equal(masked[0], basic_image_2x2)
+    assert np.array_equal(masked[0], basic_image_2x2)
 
 
-def test_all_touched(basic_image, basic_image_file, basic_geometry):
+def test_mask_all_touched(basic_image, basic_image_file, basic_geometry):
     """All pixels touched by geometry should be masked out as 3"""
 
     nodata = 3
     geometries = [basic_geometry]
 
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, nodata=nodata,
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, nodata=nodata,
                                       invert=True, all_touched=True)
 
-    assert numpy.array_equal(masked[0], basic_image * nodata)
+    assert np.array_equal(masked[0], basic_image * nodata)
 
 
-def test_crop(basic_image_2x2, basic_image_file, basic_geometry):
+def test_mask_crop(basic_image_2x2, basic_image_file, basic_geometry):
     """Output should be cropped to extent of geometry"""
 
     geometries = [basic_geometry]
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, crop=True)
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, crop=True)
 
     assert masked.shape == (1, 3, 3)
-    assert numpy.array_equal(masked[0], basic_image_2x2[2:5, 2:5])
+    assert np.array_equal(masked[0], basic_image_2x2[2:5, 2:5])
 
 
-def test_crop_all_touched(basic_image, basic_image_file, basic_geometry):
+def test_mask_crop_all_touched(basic_image, basic_image_file, basic_geometry):
     """Output should be cropped to extent of data"""
 
     geometries = [basic_geometry]
 
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, crop=True,
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, crop=True,
                                       all_touched=True)
 
     assert masked.shape == (1, 3, 3)
-    assert numpy.array_equal(masked[0], basic_image[2:5, 2:5])
+    assert np.array_equal(masked[0], basic_image[2:5, 2:5])
 
 
-@pytest.mark.xfail()
-# TODO: This pad funcionality is not working properly
-def test_pad(basic_image_2x2, basic_image_file, basic_geometry):
+def test_mask_pad(basic_image_2x2, basic_image_file, basic_geometry):
     """Output should be cropped to extent of data"""
 
     geometries = [basic_geometry]
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, crop=True, pad=True)
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, crop=True, pad=True)
 
     assert masked.shape == (1, 4, 4)
-    assert numpy.array_equal(masked[0], basic_image_2x2[2:5, 2:5])
+    assert np.array_equal(masked[0], basic_image_2x2[1:5, 1:5])
 
 
-def test_return_type(basic_image_file, basic_geometry):
-    """Output array should be an ndarray, not MaskedArray"""
+def test_mask_filled(basic_image, basic_image_2x2, basic_image_file,
+                     basic_geometry):
+    """Should be returned as numpy.ma.MaskedArray if filled is False"""
 
     geometries = [basic_geometry]
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries)
-    assert(type(masked) == numpy.ndarray)
+
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, filled=False)
+
+    image = np.ma.MaskedArray(basic_image, mask=basic_image_2x2==0)
+
+    assert (type(masked) == np.ma.MaskedArray)
+    assert np.array_equal(masked[0].mask, image.mask)
+    assert np.array_equal(masked[0], image)
+

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -6,12 +6,18 @@ import pytest
 import rasterio
 from rasterio.mask import mask as mask_tool
 
+import numpy
 
 # Custom markers.
 xfail_pixel_sensitive_gdal22 = pytest.mark.xfail(
     parse(rasterio.__gdal_version__) < parse('2.2'),
     reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 
+def test_return_type(basic_image_file, basic_geometry):
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries)
+    assert(type(masked) == numpy.ndarray)
 
 def test_nodata(basic_image_file, basic_geometry):
     nodata_val = 0

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,69 +1,104 @@
 """Unittests for rasterio.mask"""
 
-from packaging.version import parse
-import pytest
 
 import rasterio
 from rasterio.mask import mask as mask_tool
 
 import numpy
+import pytest
 
-# Custom markers.
-xfail_pixel_sensitive_gdal22 = pytest.mark.xfail(
-    parse(rasterio.__gdal_version__) < parse('2.2'),
-    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 
-def test_return_type(basic_image_file, basic_geometry):
+def test_mask(basic_image_2x2, basic_image_file, basic_geometry):
+    """Pixels outside the geometry are masked to nodata (0)"""
+
     geometries = [basic_geometry]
+
     with rasterio.open(basic_image_file, "r") as src:
         masked, transform = mask_tool(src, geometries)
-    assert(type(masked) == numpy.ndarray)
 
-def test_nodata(basic_image_file, basic_geometry):
-    nodata_val = 0
+    assert numpy.array_equal(masked[0], basic_image_2x2)
+
+
+def test_mask_invert(basic_image, basic_image_file, basic_geometry):
+    """Pixels inside the geometry are masked to nodata (0)"""
+
+    geometries = [basic_geometry]
+    basic_image[2:4, 2:4] = 0
+
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, invert=True)
+
+    assert numpy.array_equal(masked[0], basic_image)
+
+
+def test_nodata(basic_image_2x2, basic_image_file, basic_geometry):
+    """All pixels outside geometry should be masked out as 3"""
+
+    nodata = 3
+    geometries = [basic_geometry]
+
+    basic_image_2x2[basic_image_2x2 == 0] = nodata
+
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, nodata=nodata)
+
+    assert numpy.array_equal(masked[0], basic_image_2x2)
+
+
+def test_all_touched(basic_image, basic_image_file, basic_geometry):
+    """All pixels touched by geometry should be masked out as 3"""
+
+    nodata = 3
+    geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, nodata=nodata,
+                                      invert=True, all_touched=True)
+
+    assert numpy.array_equal(masked[0], basic_image * nodata)
+
+
+def test_crop(basic_image_2x2, basic_image_file, basic_geometry):
+    """Output should be cropped to extent of geometry"""
+
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, crop=False,
-                                      nodata=nodata_val, invert=True)
-    assert(masked.data.all() == nodata_val)
-
-
-def test_no_nodata(basic_image_file, basic_geometry):
-    default_nodata_val = 0
-    geometries = [basic_geometry]
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, crop=False, invert=True)
-    assert(masked.data.all() == default_nodata_val)
-
-
-@xfail_pixel_sensitive_gdal22
-def test_crop(basic_image, basic_image_file, basic_geometry):
-    geometries = [basic_geometry]
-    with rasterio.open(basic_image_file, "r") as src:
-        masked, transform = mask_tool(src, geometries, crop=True, pad=False)
-
-    image = basic_image
-    image[4, :] = 0
-    image[:, 4] = 0
+        masked, transform = mask_tool(src, geometries, crop=True)
 
     assert masked.shape == (1, 3, 3)
-    assert (masked[0] == image[2:5, 2:5]).all()
+    assert numpy.array_equal(masked[0], basic_image_2x2[2:5, 2:5])
 
 
-@xfail_pixel_sensitive_gdal22
 def test_crop_all_touched(basic_image, basic_image_file, basic_geometry):
+    """Output should be cropped to extent of data"""
+
     geometries = [basic_geometry]
+
     with rasterio.open(basic_image_file, "r") as src:
         masked, transform = mask_tool(src, geometries, crop=True,
                                       all_touched=True)
 
     assert masked.shape == (1, 3, 3)
-    assert (masked[0] == basic_image[2:5, 2:5]).all()
+    assert numpy.array_equal(masked[0], basic_image[2:5, 2:5])
 
 
-def test_crop_and_invert(basic_image_file, basic_geometry):
+@pytest.mark.xfail()
+# TODO: This pad funcionality is not working properly
+def test_pad(basic_image_2x2, basic_image_file, basic_geometry):
+    """Output should be cropped to extent of data"""
+
     geometries = [basic_geometry]
-    with rasterio.open(basic_image_file) as src:
-        with pytest.raises(ValueError):
-            masked, transform = mask_tool(src, geometries,
-                                          crop=True, invert=True)
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries, crop=True, pad=True)
+
+    assert masked.shape == (1, 4, 4)
+    assert numpy.array_equal(masked[0], basic_image_2x2[2:5, 2:5])
+
+
+def test_return_type(basic_image_file, basic_geometry):
+    """Output array should be an ndarray, not MaskedArray"""
+
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file, "r") as src:
+        masked, transform = mask_tool(src, geometries)
+    assert(type(masked) == numpy.ndarray)

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -254,7 +254,7 @@ def test_mask_crop_out_of_bounds(runner, tmpdir, basic_feature,
             '--geojson-mask', '-'],
         input=json.dumps(basic_feature))
     assert result.exit_code == 2
-    assert 'not allowed' in result.output
+    assert 'GeoJSON outside the extent' in result.output
 
 
 def test_mask_crop_and_invert(runner, tmpdir, basic_feature, pixelated_image,

--- a/tests/test_rio_features.py
+++ b/tests/test_rio_features.py
@@ -127,7 +127,6 @@ def test_mask_out_of_bounds(runner, tmpdir, basic_feature,
             ['mask', pixelated_image_file, output, '--geojson-mask', '-'],
             input=json.dumps(basic_feature))
     assert result.exit_code == 0
-    assert any(['outside bounds' in w.message.args[0] for w in rec])
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:


### PR DESCRIPTION
Mask function now returns an `numpy.ndarray` instead of `numpy.ma.MaskedArray`.

I overhauled logic flow in `mask()` so that masked bounds, etc were only evaluated if `clip` is `True`; it was unnecessary otherwise.

I overhauled the tests to make really sure that they were working properly, and to only test a single option at a time.

I also updated the docstring to better match what the function was doing.

`pad` option functionality does not seem to be working properly, and the prior test case did not appear to catch that.  I made one fix, but it looks like our new functionality around windows may be introducing a bug here.  Since that is out of scope of this particular fix, I left that test as an `xfail` instead.

I'd appreciate it if someone more familiar with what the `pad` option is supposed to do could review the test for that option to make sure that the test is now correct, and thus whether or not the bug that I think I'm seeing is indeed present.  I could just be misunderstanding expected behavior.