### PR TITLE
Fix Travis builds on Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-dist: precise
-sudo: required
+sudo: false
 cache:
   directories:
     - $GDALINST
@@ -23,7 +22,6 @@ addons:
     - gdal-bin
     - libproj-dev
     - libhdf5-serial-dev
-    - libpng12-dev
     - libgdal-dev
     - libatlas-dev
     - libatlas-base-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: precise
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 dist: precise
-sudo: false
+sudo: required
 cache:
   directories:
     - $GDALINST

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -17,7 +17,7 @@ GDALOPTS="  --with-ogr \
             --without-cfitsio \
             --without-pcraster \
             --without-netcdf \
-            --with-png=/usr \
+            --with-png=internal \
             --with-jpeg=internal \
             --without-gif \
             --without-ogdi \


### PR DESCRIPTION
resolves #1146 

Travis-CI recently moved to Ubuntu 14.04 as the default image, instead of 12.04 (https://blog.travis-ci.com/2017-08-31-trusty-as-default-status)

Unfortunately, this caused negative interactions between `libpng` and the `zlib` that it depends on.

I tried lots of alternatives, like forcing use of 12.04, installing `zlib`, etc.  The most expedient fix ended up being to use GDAL's internal PNG support.

Someone with more experience building GDAL on Ubuntu 14.04 may be able to come up with a better long term solution.