### PR TITLE
Fix fillnodata docs, intent, and tests

### DIFF
--- a/rasterio/_fill.pyx
+++ b/rasterio/_fill.pyx
@@ -3,57 +3,32 @@
 
 include "gdal.pxi"
 
-import uuid
-
-import numpy as np
-
-from rasterio import dtypes
-
-cimport numpy as np
-
-from rasterio._err cimport exc_wrap_int, exc_wrap_pointer
-from rasterio._io cimport DatasetReaderBase, InMemoryRaster, io_auto
+from rasterio._err cimport exc_wrap_int
+from rasterio._io cimport InMemoryRaster
 
 
 def _fillnodata(image, mask, double max_search_distance=100.0,
                 int smoothing_iterations=0):
-    cdef GDALDriverH driver = NULL
-    cdef GDALDatasetH image_dataset = NULL
     cdef GDALRasterBandH image_band = NULL
-    cdef GDALDatasetH mask_dataset = NULL
     cdef GDALRasterBandH mask_band = NULL
     cdef char **alg_options = NULL
 
-    driver = GDALGetDriverByName("MEM")
-
     # copy numpy ndarray into an in-memory dataset.
-    datasetname = str(uuid.uuid4()).encode('utf-8')
-    image_dataset = GDALCreate(
-        driver, <const char *>datasetname, image.shape[1], image.shape[0],
-        1, <GDALDataType>dtypes.dtype_rev[image.dtype.name], NULL)
-    image_band = GDALGetRasterBand(image_dataset, 1)
-    io_auto(image, image_band, True)
+    image_dataset = InMemoryRaster(image)
+    image_band = image_dataset.band(1)
 
     if mask is not None:
         mask_cast = mask.astype('uint8')
-        datasetname = str(uuid.uuid4()).encode('utf-8')
-        mask_dataset = GDALCreate(
-            driver, <const char *>datasetname, mask.shape[1], mask.shape[0], 1,
-            <GDALDataType>dtypes.dtype_rev['uint8'], NULL)
-        mask_band = GDALGetRasterBand(mask_dataset, 1)
-        io_auto(mask_cast, mask_band, True)
+        mask_dataset = InMemoryRaster(mask_cast)
+        mask_band = mask_dataset.band(1)
 
     try:
         alg_options = CSLSetNameValue(alg_options, "TEMP_FILE_DRIVER", "MEM")
         exc_wrap_int(
             GDALFillNodata(image_band, mask_band, max_search_distance, 0,
                            smoothing_iterations, alg_options, NULL, NULL))
-        result = np.empty(image.shape, dtype=image.dtype)
-        io_auto(result, image_band, False)
-        return result
+        return image_dataset.read()
     finally:
-        if image_dataset != NULL:
-            GDALClose(image_dataset)
-        if mask_dataset != NULL:
-            GDALClose(mask_dataset)
+        image_dataset.close()
+        mask_dataset.close()
         CSLDestroy(alg_options)

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -5,6 +5,8 @@ from rasterio._fill import _fillnodata
 from rasterio.env import ensure_env
 from rasterio import dtypes
 
+from numpy.ma import MaskedArray
+
 
 @ensure_env
 def fillnodata(
@@ -12,7 +14,7 @@ def fillnodata(
         mask=None,
         max_search_distance=100.0,
         smoothing_iterations=0):
-    """Fill holes in a raster dataset by interpolation from the edges.
+    """Fill holes in raster data by interpolation
 
     This algorithm will interpolate values for all designated nodata
     pixels (marked by zeros in `mask`). For each pixel a four direction
@@ -31,7 +33,8 @@ def fillnodata(
     Parameters
     ----------
     image : numpy ndarray
-        The source containing nodata holes.
+        The source image with holes to be filled. If a MaskedArray, the
+        inverse of its mask will define the pixels to be filled.
     mask : numpy ndarray or None
         A mask band indicating which pixels to interpolate. Pixels to
         interpolate into are indicated by the value 0. Values > 0
@@ -50,12 +53,12 @@ def fillnodata(
     out : numpy ndarray
         The filled raster array.
     """
-    if mask is None and hasattr(image, 'mask'):  # pragma: no cover
+    if mask is None and isinstance(image, MaskedArray):
         mask = ~image.mask
     if not dtypes.is_ndarray(mask):
         raise ValueError("An mask array is required")
 
-    if hasattr(image, 'mask'):  # pragma: no cover
+    if isinstance(image, MaskedArray):
         image = image.data
     if not dtypes.is_ndarray(image):
         raise ValueError("An image array is required")

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -34,13 +34,15 @@ def fillnodata(
     ----------
     image : numpy ndarray
         The source image with holes to be filled. If a MaskedArray, the
-        inverse of its mask will define the pixels to be filled.
+        inverse of its mask will define the pixels to be filled --
+        unless the ``mask`` argument is not None (see below).`
     mask : numpy ndarray or None
         A mask band indicating which pixels to interpolate. Pixels to
-        interpolate into are indicated by the value 0. Values > 0
-        indicate areas to use during interpolation. Must be same shape
-        as image. If None, the inverse of the image's mask will be used
-        if available.
+        interpolate into are indicated by the value 0. Values
+        > 0 indicate areas to use during interpolation. Must be same
+        shape as image. This array always takes precedence over the
+        image's mask (see above). If None, the inverse of the image's
+        mask will be used if available.
     max_search_distance : float, optional
         The maxmimum number of pixels to search in all directions to
         find values to interpolate from. The default is 100.

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -36,7 +36,8 @@ def fillnodata(
         A mask band indicating which pixels to interpolate. Pixels to
         interpolate into are indicated by the value 0. Values > 0
         indicate areas to use during interpolation. Must be same shape
-        as image.
+        as image. If None, the inverse of the image's mask will be used
+        if available.
     max_search_distance : float, optional
         The maxmimum number of pixels to search in all directions to
         find values to interpolate from. The default is 100.
@@ -49,17 +50,15 @@ def fillnodata(
     out : numpy ndarray
         The filled raster array.
     """
-    if mask is None:
-        if hasattr(image, 'mask'):  # pragma: no cover
-            mask = ~image.mask
-    else:
-        if not dtypes.is_ndarray(mask):
-            raise ValueError("mask is not an array")
+    if mask is None and hasattr(image, 'mask'):  # pragma: no cover
+        mask = ~image.mask
+    if not dtypes.is_ndarray(mask):
+        raise ValueError("An mask array is required")
 
     if hasattr(image, 'mask'):  # pragma: no cover
         image = image.data
     if not dtypes.is_ndarray(image):
-        raise ValueError("image is not an array")
+        raise ValueError("An image array is required")
 
     max_search_distance = float(max_search_distance)
     smoothing_iterations = int(smoothing_iterations)

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -3,6 +3,7 @@
 import rasterio
 from rasterio._fill import _fillnodata
 from rasterio.env import ensure_env
+from rasterio import dtypes
 
 
 @ensure_env
@@ -35,8 +36,7 @@ def fillnodata(
         A mask band indicating which pixels to interpolate. Pixels to
         interpolate into are indicated by the value 0. Values > 0
         indicate areas to use during interpolation. Must be same shape
-        as image. If `None`, a mask will be diagnosed from the source
-        data.
+        as image.
     max_search_distance : float, optional
         The maxmimum number of pixels to search in all directions to
         find values to interpolate from. The default is 100.
@@ -49,6 +49,18 @@ def fillnodata(
     out : numpy ndarray
         The filled raster array.
     """
+    if mask is None:
+        if hasattr(image, 'mask'):  # pragma: no cover
+            mask = ~image.mask
+    else:
+        if not dtypes.is_ndarray(mask):
+            raise ValueError("mask is not an array")
+
+    if hasattr(image, 'mask'):  # pragma: no cover
+        image = image.data
+    if not dtypes.is_ndarray(image):
+        raise ValueError("image is not an array")
+
     max_search_distance = float(max_search_distance)
     smoothing_iterations = int(smoothing_iterations)
     return _fillnodata(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ snuggs>=1.4.1
 setuptools>=0.9.8
 
 # development specific requirements
-cython>=0.23.4
+cython==0.26.1
 delocate
 enum34
 ghp-import

--- a/tests/test_fillnodata.py
+++ b/tests/test_fillnodata.py
@@ -6,7 +6,9 @@ import pytest
 import rasterio
 from rasterio.fill import fillnodata
 
+
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
 
 def test_fillnodata():
     """Test filling nodata values in an ndarray"""
@@ -19,12 +21,26 @@ def test_fillnodata():
     result = fillnodata(a, mask)
     assert(np.all((np.ones([3, 3]) * 42) == result))
 
+
+def test_fillnodata_masked_array():
+    """Test filling nodata values in a masked ndarray"""
+    # create a 5x5 array, with some missing data
+    a = np.ones([3, 3]) * 42
+    a[1][1] = 0
+    # find the missing data
+    a = np.ma.masked_array(a, (a == 0))
+    # fill the missing data using interpolation from the edges
+    result = fillnodata(a)
+    assert(np.all((np.ones([3, 3]) * 42) == result))
+
+
 def test_fillnodata_invalid_types():
     a = np.ones([3, 3])
     with pytest.raises(ValueError):
         fillnodata(None, a)
     with pytest.raises(ValueError):
         fillnodata(a, 42)
+
 
 def test_fillnodata_mask_ones():
     # when mask is all ones, image should be unmodified

--- a/tests/test_fillnodata.py
+++ b/tests/test_fillnodata.py
@@ -1,10 +1,8 @@
-import logging
-import sys
+"""Tests of nodata filling"""
 
 import numpy as np
 import pytest
 
-import rasterio
 from rasterio.fill import fillnodata
 
 
@@ -42,4 +40,4 @@ def test_fillnodata_mask_ones(hole_in_ones):
     """when mask is all ones, image should be unmodified"""
     mask = np.ones((5, 5))
     result = fillnodata(hole_in_ones, mask)
-    assert(np.all(hole_in_ones == result))
+    assert (hole_in_ones == result).all()

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -121,7 +121,7 @@ def test_fillnodata(tmpdir):
         assert src.count == 3
         assert src.meta['dtype'] == 'uint8'
         data = src.read(masked=True)
-        assert round(data.mean(), 1) == 60.6
+        assert round(data.mean(), 1) == 58.6
 
 
 def test_fillnodata_map(tmpdir):
@@ -135,8 +135,8 @@ def test_fillnodata_map(tmpdir):
         assert src.count == 3
         assert src.meta['dtype'] == 'uint8'
         data = src.read(masked=True)
-        assert round(data.mean(), 1) == 60.6
-
+        assert round(data.mean(), 1) == 58.6
+        assert data[0][60][60] > 0
 
 def test_sieve_band(tmpdir):
     outfile = str(tmpdir.join('out.tif'))


### PR DESCRIPTION
This PR resolves #1138.

It removes the advice that source nodata values are used, which was not true, and won't be implemented. It also removes support for filling dataset bands in-place, a feature which was not tested, not correctly implemented, and not in line with the rasterio philosophy (separation of raster data I/O from operations on arrays).

If we pass a `MaskedArray` as the sole argument to `fillnodata()`, the inverse of its mask will be filled.
