### PR TITLE
WarpedVRT and reproject nodata alignment

### DIFF
--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -774,6 +774,11 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
         self._set_attrs_from_dataset_handle()
 
+        # This attribute will be used by read().
+        if self.src_nodata is not None:
+            self._nodatavals = [
+                self.src_nodata for i in self.src_dataset.indexes]
+
     def start(self):
         """Starts the VRT's life cycle."""
         log.debug("Dataset %r is started.", self)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -105,21 +105,11 @@ cdef GDALWarpOptions * create_warp_options(
     # First, we make sure we have consistent source and destination
     # nodata values. TODO: alpha bands.
 
-    # We require source nodata if destination nodata is passed.
-    if src_nodata is None and dst_nodata is not None:
-        raise ValueError("src_nodata must be provided because dst_nodata "
-                         "is not None")
-
     if dst_nodata is None:
         if src_nodata is not None:
             dst_nodata = src_nodata
         else:
             dst_nodata = 0
-            src_nodata = 0
-
-    # Convert to float to validate.
-    dst_nodata = float(dst_nodata)
-    src_nodata = float(src_nodata)
 
     cdef GDALWarpOptions *psWOptions = GDALCreateWarpOptions()
 
@@ -140,15 +130,30 @@ cdef GDALWarpOptions * create_warp_options(
 
     psWOptions.eResampleAlg = <GDALResampleAlg>resampling
 
+    # Assign nodata values.
+    # We don't currently support an imaginary component.
+
     psWOptions.padfSrcNoDataReal = <double*>CPLMalloc(src_count * sizeof(double))
     psWOptions.padfSrcNoDataImag = <double*>CPLMalloc(src_count * sizeof(double))
+
+    for i in range(src_count):
+        if src_nodata is not None:
+            psWOptions.padfSrcNoDataReal[i] = float(src_nodata)
+            psWOptions.padfSrcNoDataImag[i] = 0.0
+        else:
+            psWOptions.padfSrcNoDataReal[i] = -123456.789  # as in gdalwarp.
+            psWOptions.padfSrcNoDataImag[i] = 0.0
+
     psWOptions.padfDstNoDataReal = <double*>CPLMalloc(src_count * sizeof(double))
     psWOptions.padfDstNoDataImag = <double*>CPLMalloc(src_count * sizeof(double))
+
     for i in range(src_count):
-        psWOptions.padfSrcNoDataReal[i] = src_nodata
-        psWOptions.padfSrcNoDataImag[i] = 0.0
-        psWOptions.padfDstNoDataReal[i] = dst_nodata
-        psWOptions.padfDstNoDataImag[i] = 0.0
+        if dst_nodata is not None:
+            psWOptions.padfDstNoDataReal[i] = float(dst_nodata)
+            psWOptions.padfDstNoDataImag[i] = 0.0
+        else:
+            psWOptions.padfDstNoDataReal[i] = -123456.789  # as in gdalwarp.
+            psWOptions.padfDstNoDataImag[i] = 0.0
 
     # Important: set back into struct or values set above are lost
     # This is because CSLSetNameValue returns a new list each time
@@ -213,7 +218,7 @@ def _reproject(
         The source nodata value.  Pixels with this value will not be used
         for interpolation.  If not set, it will be default to the
         nodata value of the source image if a masked ndarray or rasterio band,
-        if available.  Must be provided if dst_nodata is not None.
+        if available.
     dst_transform: affine.Affine(), optional
         Target affine transformation.  Required if source and destination
         are ndarrays.  Will be derived from target if it is a rasterio Band.
@@ -654,8 +659,8 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self.resampling = resampling
         self.tolerance = tolerance
 
-        self.src_nodata = (self.src_dataset.nodata or 0.0) if src_nodata is None else src_nodata
-        self.dst_nodata = (self.src_nodata or 0.0) if dst_nodata is None else dst_nodata
+        self.src_nodata = self.src_dataset.nodata if src_nodata is None else src_nodata
+        self.dst_nodata = self.src_nodata if dst_nodata is None else dst_nodata
         self.dst_width = dst_width
         self.dst_height = dst_height
         self.dst_transform = dst_transform

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -781,9 +781,8 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self._set_attrs_from_dataset_handle()
 
         # This attribute will be used by read().
-        if self.src_nodata is not None:
-            self._nodatavals = [
-                self.src_nodata for i in self.src_dataset.indexes]
+        self._nodatavals = [
+            self.src_nodata for i in self.src_dataset.indexes]
 
     def start(self):
         """Starts the VRT's life cycle."""

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -653,8 +653,9 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self.dst_crs = dst_crs
         self.resampling = resampling
         self.tolerance = tolerance
-        self.src_nodata = src_nodata
-        self.dst_nodata = dst_nodata
+
+        self.src_nodata = self.src_dataset.nodata if src_nodata is None else src_nodata
+        self.dst_nodata = (self.src_nodata or 0.0) if dst_nodata is None else dst_nodata
         self.dst_width = dst_width
         self.dst_height = dst_height
         self.dst_transform = dst_transform

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -654,7 +654,7 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self.resampling = resampling
         self.tolerance = tolerance
 
-        self.src_nodata = self.src_dataset.nodata if src_nodata is None else src_nodata
+        self.src_nodata = (self.src_dataset.nodata or 0.0) if src_nodata is None else src_nodata
         self.dst_nodata = (self.src_nodata or 0.0) if dst_nodata is None else dst_nodata
         self.dst_width = dst_width
         self.dst_height = dst_height

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -29,8 +29,7 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
     src_nodata: int or float, optional
         The source nodata value.  Pixels with this value will not be
         used for interpolation. If not set, it will be default to the
-        nodata value of the source image, if available. Must be provided
-        if dst_nodata is not None.
+        nodata value of the source image, if available.
     dst_nodata: int or float, optional
         The nodata value used to initialize the destination; it will
         remain in all areas not covered by the reprojected source.

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -26,15 +26,21 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
     tolerance : float
         The maximum error tolerance in input pixels when approximating
         the warp transformation. The default is 0.125.
-    src_nodata : float
-        A nodata value for the source data. It may be a value other
-        than the nodata value of src_dataset.
-    dst_nodata : float, int
-        The nodata value for the virtually warped dataset.
+    src_nodata: int or float, optional
+        The source nodata value.  Pixels with this value will not be
+        used for interpolation. If not set, it will be default to the
+        nodata value of the source image, if available. Must be provided
+        if dst_nodata is not None.
+    dst_nodata: int or float, optional
+        The nodata value used to initialize the destination; it will
+        remain in all areas not covered by the reprojected source.
+        Defaults to the value of src_nodata, or 0 (gdal default).
     dst_width : int, optional
-        Target width. dst_height and dst_transform must also be provided.
+        Target width in pixels. dst_height and dst_transform must also be
+        provided.
     dst_height : int, optional
-        Target height. dst_width and dst_transform must also be provided.
+        Target height in pixels. dst_width and dst_transform must also be
+        provided.
     dst_transform: affine.Affine(), optional
         Target affine transformation.  Required if width and height are
         provided.

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -70,7 +70,7 @@ def transform_geom(
         Target coordinate reference system.
     geom: GeoJSON like dict object
     antimeridian_cutting: bool, optional
-        If True, cut geometries at the antimeridian, otherwise geometries 
+        If True, cut geometries at the antimeridian, otherwise geometries
         will not be cut (default).  If False and GDAL is 2.2.0 or newer
         an exception is raised.  Antimeridian cutting is always on as of
         GDAL 2.2.0 but this could produce an unexpected geometry.
@@ -212,8 +212,7 @@ def reproject(source, destination, src_transform=None, gcps=None,
         The source nodata value.Pixels with this value will not be
         used for interpolation. If not set, it will be default to the
         nodata value of the source image if a masked ndarray or
-        rasterio band, if available. Must be provided if dst_nodata is
-        not None.
+        rasterio band, if available.
     dst_transform: affine.Affine(), optional
         Target affine transformation. Required if source and
         destination are ndarrays. Will be derived from target if it is

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ snuggs>=1.4.1
 setuptools>=0.9.8
 
 # development specific requirements
-cython>=0.23.4
+cython==0.26.1
 delocate
 enum34
 ghp-import

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -470,25 +470,6 @@ def test_reproject_invalid_dst_nodata():
         )
 
 
-def test_reproject_missing_src_nodata():
-    """src_nodata is required if dst_nodata is not None."""
-    params = default_reproject_params()
-
-    source = np.ones((params.width, params.height), dtype=np.uint8)
-    out = source.copy()
-
-    with pytest.raises(ValueError):
-        reproject(
-            source,
-            out,
-            src_transform=params.src_transform,
-            src_crs=params.src_crs,
-            dst_transform=params.dst_transform,
-            dst_crs=params.dst_crs,
-            dst_nodata=215
-        )
-
-
 def test_reproject_invalid_src_nodata():
     """src_nodata must be in range for data type."""
     params = default_reproject_params()

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -24,8 +24,8 @@ def test_warped_vrt(path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as src:
         vrt = WarpedVRT(src, dst_crs='EPSG:3857')
         assert vrt.dst_crs == 'EPSG:3857'
-        assert vrt.src_nodata is None
-        assert vrt.dst_nodata is None
+        assert vrt.src_nodata == 0.0
+        assert vrt.dst_nodata == 0.0
         assert vrt.tolerance == 0.125
         assert vrt.resampling == Resampling.nearest
         assert vrt.warp_extras == {'init_dest': 'NO_DATA'}
@@ -68,8 +68,8 @@ def test_warped_vrt_dimensions(path_rgb_byte_tif):
                         dst_width=size, dst_height=size,
                         dst_transform=dst_transform)
         assert vrt.dst_crs == 'EPSG:3857'
-        assert vrt.src_nodata is None
-        assert vrt.dst_nodata is None
+        assert vrt.src_nodata == 0.0
+        assert vrt.dst_nodata == 0.0
         assert vrt.resampling == Resampling.nearest
         assert vrt.width == size
         assert vrt.height == size


### PR DESCRIPTION
Resolves #1140 by making src/dst_nodata consistent across `WarpedVRT` and `reproject()`. When this PR is merged they will have the same sense, same defaults, same docstrings.