### PR TITLE
merge: treat nodata=None and np.nan in data

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -106,6 +106,10 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         nodataval = nodata
         logger.debug("Set nodataval: %r", nodataval)
 
+    if np.dtype(dtype).kind == 'f':
+        if nodataval is None:
+            nodataval = np.nan
+
     if nodataval is not None:
         # Only fill if the nodataval is within dtype's range.
         inrange = False
@@ -114,7 +118,10 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
             inrange = (info.min <= nodataval <= info.max)
         elif np.dtype(dtype).kind == 'f':
             info = np.finfo(dtype)
-            inrange = (info.min <= nodataval <= info.max)
+            if np.isnan(nodataval):
+                inrange = True
+            else:
+                inrange = (info.min <= nodataval <= info.max)
         if inrange:
             dest.fill(nodataval)
         else:
@@ -165,10 +172,13 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
             int(round(dst_window.row_off)), int(round(dst_window.col_off)))
 
         region = dest[:, roff:roff + trows, coff:coff + tcols]
-
-        np.copyto(
-            region, temp,
-            where=np.logical_and(region == nodataval,
-                                 np.logical_not(temp.mask)))
+        if np.isnan(nodataval):
+            region_nodata = np.isnan(region)
+            temp_nodata = np.isnan(temp)
+        else:
+            region_nodata = region == nodataval
+            temp_nodata = temp.mask
+        mask = np.logical_and(region_nodata, ~temp_nodata)
+        np.copyto(region, temp, where=mask)
 
     return dest, output_transform

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -106,10 +106,6 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         nodataval = nodata
         logger.debug("Set nodataval: %r", nodataval)
 
-    if np.dtype(dtype).kind == 'f':
-        if nodataval is None:
-            nodataval = np.nan
-
     if nodataval is not None:
         # Only fill if the nodataval is within dtype's range.
         inrange = False

--- a/rasterio/rio/edit_info.py
+++ b/rasterio/rio/edit_info.py
@@ -131,9 +131,12 @@ def edit(ctx, input, bidx, nodata, unset_nodata, crs, unset_crs, transform,
     import numpy as np
 
     def in_dtype_range(value, dtype):
+        kind = np.dtype(dtype).kind
+        if kind == 'f' and np.isnan(value):
+            return True
         infos = {'c': np.finfo, 'f': np.finfo, 'i': np.iinfo,
                  'u': np.iinfo}
-        rng = infos[np.dtype(dtype).kind](dtype)
+        rng = infos[kind](dtype)
         return rng.min <= value <= rng.max
 
     with ctx.obj['env'], rasterio.open(input, 'r+') as dst:

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -94,11 +94,6 @@ def test_edit_nodata_nan(data):
     runner = CliRunner()
     inputfile = str(data.join('float_nan.tif'))
     result = runner.invoke(
-        main_group, ['edit-info', inputfile, '--unset-nodata'])
-    assert result.exit_code == 0
-    with rasterio.open(inputfile) as src:
-        assert src.nodata is None
-    result = runner.invoke(
         main_group, ['edit-info', inputfile, '--nodata', 'NaN'])
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -96,6 +96,8 @@ def test_edit_nodata_nan(data):
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--unset-nodata'])
     assert result.exit_code == 0
+    with rasterio.open(inputfile) as src:
+        assert src.nodata is None
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--nodata', 'NaN'])
     assert result.exit_code == 0

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -90,6 +90,19 @@ def test_edit_nodata(data):
         assert src.nodata == 255.0
 
 
+def test_edit_nodata_nan(data):
+    runner = CliRunner()
+    inputfile = str(data.join('float_nan.tif'))
+    result = runner.invoke(
+        main_group, ['edit-info', inputfile, '--unset-nodata'])
+    assert result.exit_code == 0
+    result = runner.invoke(
+        main_group, ['edit-info', inputfile, '--nodata', 'NaN'])
+    assert result.exit_code == 0
+    with rasterio.open(inputfile) as src:
+        assert src.nodata != src.nodata
+
+
 def test_edit_crs_err(data):
     runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))


### PR DESCRIPTION
## The issue

I want to merge some `float32` files that have `nodata=None` and contain `NaN` for missing values.

However, `merge` does not support `np.nan` as a nodata flag, because it uses comparison to validate the nodata value:
https://github.com/mapbox/rasterio/blob/89538636ff92112848a888e314bea8f457e3a30b/rasterio/merge.py#L117

and to test whether the existing data (`region`) is empty:
https://github.com/mapbox/rasterio/blob/89538636ff92112848a888e314bea8f457e3a30b/rasterio/merge.py#L171

## Proposed solution

If the `nodata` value is `np.nan`, accept it as valid for floating point data and use `np.isnan` to check whether the `region` is empty.

Also, for floating point data, if `nodata` is `None`, set it to `np.nan` per default. This part is perhaps too auto-magic, one could also leave it up to the user to specify `nodata=np.nan` in the function call.

## Relevance

I do not know how common it is to use `np.nan` as implicit or explicit nodata value in floating point data. But QGIS, for example, handles this case out of the box.