### PR TITLE
Switch to warped vrt internally for boundless reads

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,9 @@ Bug fixes:
 
 - We always reacquire the GIL when GDAL calls the rasterio logging error
   handler (#1103, #1104).
+- Rasterio's boundless reading has had a compositing bug. We are resolving
+  it by using a VRT internally and relying upon the VRT's windowing and
+  compositing logic (#1161).
 
 1.0a9 (2017-06-02)
 ------------------

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -55,7 +55,7 @@ def window_index(*args, **kwargs):
 
 __all__ = [
     'band', 'open', 'copy', 'pad']
-__version__ = "1.0a10"
+__version__ = "1.0a9"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -326,11 +326,11 @@ cdef class DatasetReaderBase(DatasetBase):
                     self,
                     dst_nodata=ndv,
                     dst_crs=self.crs,
-                    dst_width=window.num_cols,
-                    dst_height=window.num_rows,
+                    dst_width=max(self.width, window.num_cols),
+                    dst_height=max(self.height, window.num_rows),
                     dst_transform=self.window_transform(window),
                     resampling=resampling) as vrt:
-                out = vrt._read(indexes, out, None, None)
+                out = vrt._read(indexes, out, Window(0, 0, window.num_cols, window.num_rows), None)
 
                 if masked:
                     if all_valid:
@@ -338,7 +338,7 @@ cdef class DatasetReaderBase(DatasetBase):
                     else:
                         mask = np.zeros(out.shape, 'uint8')
                         mask = ~vrt._read(
-                            indexes, mask, None, None, masks=True).astype('bool')
+                            indexes, mask, Window(0, 0, window.num_cols, window.num_rows), None, masks=True).astype('bool')
 
                     kwds = {'mask': mask}
                     # Set a fill value only if the read bands share a
@@ -470,11 +470,11 @@ cdef class DatasetReaderBase(DatasetBase):
             with WarpedVRT(
                     self,
                     dst_crs=self.crs,
-                    dst_width=window.num_cols,
-                    dst_height=window.num_rows,
+                    dst_width=max(self.width, window.num_cols),
+                    dst_height=max(self.height, window.num_rows),
                     dst_transform=self.window_transform(window),
                     resampling=resampling) as vrt:
-                out = vrt._read(indexes, out, None, None, masks=True)
+                out = vrt._read(indexes, out, Window(0, 0, window.num_cols, window.num_rows), None, masks=True)
 
         if return2d:
             out.shape = out.shape[1:]

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -28,6 +28,7 @@ from rasterio.errors import NodataShadowWarning, WindowError
 from rasterio.sample import sample_gen
 from rasterio.transform import Affine
 from rasterio.vfs import parse_path, vsi_path
+from rasterio.vrt import WarpedVRT
 from rasterio.windows import Window, intersection
 
 from libc.stdio cimport FILE
@@ -318,72 +319,34 @@ cdef class DatasetReaderBase(DatasetBase):
                         kwds['fill_value'] = nodatavals[0]
                 out = np.ma.array(out, **kwds)
 
+        # If boundless.
+        # Create a WarpedVRT to use its window and compositing logic.
         else:
-            # Compute the overlap between the dataset and the boundless window.
-            try:
-                overlap = intersection(
-                    window, Window(0, 0, self.width, self.height))
-            except WindowError:
-                log.info("Dataset and window do not overlap")
-                data = None
+            with WarpedVRT(
+                    self,
+                    dst_nodata=ndv,
+                    dst_crs=self.crs,
+                    dst_width=window.num_cols,
+                    dst_height=window.num_rows,
+                    dst_transform=self.window_transform(window),
+                    resampling=resampling) as vrt:
+                out = vrt._read(indexes, out, None, None)
+
                 if masked:
-                    kwds = {'mask': True}
+                    if all_valid:
+                        mask = np.ma.nomask
+                    else:
+                        mask = np.zeros(out.shape, 'uint8')
+                        mask = ~vrt._read(
+                            indexes, mask, None, None, masks=True).astype('bool')
+
+                    kwds = {'mask': mask}
+                    # Set a fill value only if the read bands share a
+                    # single nodata value.
                     if len(set(nodatavals)) == 1:
                         if nodatavals[0] is not None:
                             kwds['fill_value'] = nodatavals[0]
                     out = np.ma.array(out, **kwds)
-            else:
-                # Prepare a buffer.
-                window_h, window_w = win_shape[-2:]
-                overlap_h = overlap.height
-                overlap_w = overlap.width
-                scaling_h = float(out.shape[-2:][0])/window_h
-                scaling_w = float(out.shape[-2:][1])/window_w
-                buffer_shape = (
-                        int(round(overlap_h*scaling_h)),
-                        int(round(overlap_w*scaling_w)))
-                data = np.zeros(win_shape[:-2] + buffer_shape, dtype)
-                data = self._read(indexes, data, overlap, dtype,
-                                  resampling=resampling)
-
-                if masked:
-                    mask = np.zeros(win_shape[:-2] + buffer_shape, 'uint8')
-                    mask = ~self._read(
-                        indexes, mask, overlap, 'uint8', masks=True,
-                        resampling=resampling).astype('bool')
-                    kwds = {'mask': mask}
-                    if len(set(nodatavals)) == 1:
-                        if nodatavals[0] is not None:
-                            kwds['fill_value'] = nodatavals[0]
-                    data = np.ma.array(data, **kwds)
-
-            if data is not None:
-                # Determine where to put the data in the output window.
-                data_h, data_w = buffer_shape
-                roff = 0
-                coff = 0
-                if window.row_off < 0:
-                    roff = int(-window.row_off * scaling_h)
-                if window.col_off < 0:
-                    coff = int(-window.col_off * scaling_w)
-
-                for dst, src in zip(
-                        out if len(out.shape) == 3 else [out],
-                        data if len(data.shape) == 3 else [data]):
-                    dst[roff:roff+data_h, coff:coff+data_w] = src
-
-                if masked:
-                    if not hasattr(out, 'mask'):
-                        kwds = {'mask': True}
-                        if len(set(nodatavals)) == 1:
-                            if nodatavals[0] is not None:
-                                kwds['fill_value'] = nodatavals[0]
-                        out = np.ma.array(out, **kwds)
-
-                    for dst, src in zip(
-                            out.mask if len(out.shape) == 3 else [out.mask],
-                            data.mask if len(data.shape) == 3 else [data.mask]):
-                        dst[roff:roff+data_h, coff:coff+data_w] = src
 
         if return2d:
             out.shape = out.shape[1:]
@@ -500,39 +463,18 @@ cdef class DatasetReaderBase(DatasetBase):
             out = self._read(indexes, out, window, dtype, masks=True,
                              resampling=resampling)
 
+        # If boundless is True.
+        # Create a temporary VRT to use its source/dest windowing
+        # and compositing logic.
         else:
-            # Compute the overlap between the dataset and the boundless window.
-            try:
-                overlap = intersection(
-                    window, Window(0, 0, self.width, self.height))
-            except WindowError:
-                log.info("Window and dataset do not overlap")
-                data = None
-            else:
-                # Prepare a buffer.
-                window_h, window_w = win_shape[-2:]
-                overlap_h = overlap.height
-                overlap_w = overlap.width
-                scaling_h = float(out.shape[-2:][0])/window_h
-                scaling_w = float(out.shape[-2:][1])/window_w
-                buffer_shape = (int(overlap_h*scaling_h), int(overlap_w*scaling_w))
-                data = np.zeros(win_shape[:-2] + buffer_shape, 'uint8')
-                data = self._read(indexes, data, overlap, dtype, masks=True,
-                                  resampling=resampling)
-
-            if data is not None:
-                # Determine where to put the data in the output window.
-                data_h, data_w = data.shape[-2:]
-                roff = 0
-                coff = 0
-                if window[0][0] < 0:
-                    roff = int(window_h*scaling_h) - data_h
-                if window[1][0] < 0:
-                    coff = int(window_w*scaling_w) - data_w
-                for dst, src in zip(
-                        out if len(out.shape) == 3 else [out],
-                        data if len(data.shape) == 3 else [data]):
-                    dst[roff:roff+data_h, coff:coff+data_w] = src
+            with WarpedVRT(
+                    self,
+                    dst_crs=self.crs,
+                    dst_width=window.num_cols,
+                    dst_height=window.num_rows,
+                    dst_transform=self.window_transform(window),
+                    resampling=resampling) as vrt:
+                out = vrt._read(indexes, out, None, None, masks=True)
 
         if return2d:
             out.shape = out.shape[1:]

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -712,11 +712,12 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
                 OSRRelease(osr)
             osr = NULL
 
-        try:
-            osr = _osr_from_crs(self.dst_crs)
-            OSRExportToWkt(osr, &dst_crs_wkt)
-        finally:
-            _safe_osr_release(osr)
+        if self.dst_crs is not None:
+            try:
+                osr = _osr_from_crs(self.dst_crs)
+                OSRExportToWkt(osr, &dst_crs_wkt)
+            finally:
+                _safe_osr_release(osr)
 
         log.debug("Exported CRS to WKT.")
 

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -126,6 +126,7 @@ class WindowMethodsMixin(object):
                           RasterioDeprecationWarning)
 
         transform = guard_transform(self.transform)
+
         return windows.from_bounds(
             left, bottom, right, top, transform=transform,
             height=self.height, width=self.width, precision=precision)

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -406,6 +406,7 @@ def validate_length_value(instance, attribute, value):
     if value and value < 0:
         raise ValueError("Number of columns or rows must be non-negative")
 
+
 _default = attr.Factory(lambda x: 0.0 if x is None else float(x))
 
 
@@ -498,7 +499,8 @@ class Window(object):
         """For backwards compatibility only"""
         warnings.warn("Use the class constructor instead of this method",
                       RasterioDeprecationWarning)
-        return cls(col_off, row_off, num_cols, num_rows)
+        return cls(col_off=col_off, row_off=row_off, width=num_cols,
+                   height=num_rows)
 
     @classmethod
     def from_slices(cls, rows, cols, height=-1, width=-1, boundless=False):
@@ -568,7 +570,8 @@ class Window(object):
         num_cols = col_stop - col_off
         num_cols = max(num_cols, 0.0)
 
-        return cls(col_off, row_off, num_cols, num_rows)
+        return cls(col_off=col_off, row_off=row_off, width=num_cols,
+                   height=num_rows)
 
     @classmethod
     def from_ranges(cls, rows, cols):

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -47,7 +47,7 @@ def test_read_boundless_beyond(rgb_byte_tif_reader):
 def test_read_boundless_beyond_fill_value(rgb_byte_tif_reader):
     """Reading entirely outside the dataset returns the fill value"""
     with rgb_byte_tif_reader as src:
-        data = src.read(window=((-200, -100), (-200, -100)), boundless=True,
+        data = src.read(window=Window(-200, -200, 100, 100), boundless=True,
                         fill_value=1)
         assert data.shape == (3, 100, 100)
         assert (data == 1).all()
@@ -103,7 +103,7 @@ def test_read_boundless_masked_overlap(rgb_byte_tif_reader):
 def test_read_boundless_zero_stop(rgb_byte_tif_reader):
     with rgb_byte_tif_reader as src:
         data = src.read(
-            window=((-200, 0), (-200, 0)), boundless=True, masked=True)
+            window=Window(-200, -200, 200, 200), boundless=True, masked=True)
         assert data.shape == (3, 200, 200)
         assert data.mask.all()
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -104,6 +104,9 @@ def test_window_transform_function():
             ((-1, None), (-1, None)), src.transform).c == src.bounds.left - src.res[0]
         assert transform(
             ((-1, None), (-1, None)), src.transform).f == src.bounds.top + src.res[1]
+        assert transform(
+            Window(-1, -1, src.width + 1, src.height + 1),
+            src.transform).f == src.bounds.top + src.res[1]
 
 
 def test_window_bounds_function():


### PR DESCRIPTION
Rasterio has offered "boundless reads" as a feature – you can read an image window (in pixel space) that goes beyond the source raster's rows and columns and rasterio performs VRT-like source reading and compositing. The math has been buggy: at best it doesn't exactly match GDAL's math and, at worst, can drop a line or row of data.

This PR fixes the bug by switching from an approximation of GDAL's VRT logic to the use of a temporary VRT that represents the boundless window. It provides more accurate and reliable results and eliminates 2 chunks of brittle code in _io.pyx.

I'm using a warped VRT because GDAL doesn't surface a non-warped VRT constructor in its C API. As far as I can tell, reprojection is short-circuited when the input and output crs are the same. I think this is good enough for 1.0 and we could look at a more optimal implementation after that.

I'm concerned that source overviews will be skipped when we use the VRT like this. Notice that we read from the VRT at its full resolution. It seems that the test at https://github.com/OSGeo/gdal/blob/8372431040f2b17bb5f6b643c2bfdfcec8d6f630/gdal/frmts/vrt/vrtsourcedrasterband.cpp#L169 will thus fail and source overviews would be skipped. I'm going to ask GDAL developers for confirmation and guidance on this point.