### PR TITLE
.travis.yml: remove GDAL 1.9 builds, and add GDAL trunk builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,16 @@ env:
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
   matrix:
-    - GDALVERSION="1.9.2"
     - GDALVERSION="1.11.5"
     - GDALVERSION="2.0.3"
     - GDALVERSION="2.1.1"
     - GDALVERSION="2.2.0"
+    - GDALVERSION="trunk"
+
+matrix:
+  allow_failures:
+    - env: GDALVERSION="trunk"
+
 addons:
   apt:
     packages:
@@ -40,7 +45,7 @@ before_install:
   - export PATH=$GDALINST/gdal-$GDALVERSION/bin:$PATH
   - export LD_LIBRARY_PATH=$GDALINST/gdal-$GDALVERSION/lib:$LD_LIBRARY_PATH
 install:
-  - "if [ $(gdal-config --version) == \"$GDALVERSION\" ]; then echo \"Using gdal $GDALVERSION\"; else echo \"NOT using gdal $GDALVERSION as expected; aborting\"; exit 1; fi"
+  - "if [ \"$GDALVERSION\" == \"trunk\" -o $(gdal-config --version) == \"$GDALVERSION\" ]; then echo \"Using gdal $GDALVERSION\"; else echo \"NOT using gdal $GDALVERSION as expected; aborting\"; exit 1; fi"
   - "pip wheel -r requirements-dev.txt"
   - "pip install -r requirements-dev.txt"
   - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config pip install --upgrade --force-reinstall -e .[test,plot]"

--- a/scripts/travis_gdal_install.sh
+++ b/scripts/travis_gdal_install.sh
@@ -57,17 +57,28 @@ fi
 
 ls -l $GDALINST
 
-if [ "$GDALVERSION" = "1.9.2" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
+if [ "$GDALVERSION" = "trunk" ]; then
   cd $GDALBUILD
-  wget http://download.osgeo.org/gdal/gdal-$GDALVERSION.tar.gz
-  tar -xzf gdal-$GDALVERSION.tar.gz
-  cd gdal-$GDALVERSION
-  ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
-  make -s -j 2
-  make install
+  git clone --depth 1 https://github.com/OSGeo/gdal gdal-$GDALVERSION
+  cd gdal-$GDALVERSION/gdal
+  git rev-parse HEAD > newrev.txt
+  BUILD=no
+  # Only build if nothing cached or if the GDAL revision changed
+  if test ! -f $GDALINST/gdal-$GDALVERSION/rev.txt; then
+    BUILD=yes
+  elif ! diff newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt >/dev/null; then
+    BUILD=yes
+  fi
+  if test "$BUILD" = "yes"; then
+    mkdir -p $GDALINST/gdal-$GDALVERSION
+    cp newrev.txt $GDALINST/gdal-$GDALVERSION/rev.txt
+    ./configure --prefix=$GDALINST/gdal-$GDALVERSION $GDALOPTS
+    make -s -j 2
+    make install
+  fi
 fi
 
-if [ "$GDALVERSION" != "1.9.2" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
+if [ "$GDALVERSION" != "trunk" -a ! -d "$GDALINST/gdal-$GDALVERSION" ]; then
   cd $GDALBUILD
   wget http://download.osgeo.org/gdal/$GDALVERSION/gdal-$GDALVERSION.tar.gz
   tar -xzf gdal-$GDALVERSION.tar.gz


### PR DESCRIPTION
- I doubt compat with GDAL 1.9 is needed nowadays
- Addition of test against GDAL trunk (with a allow_failures), to detect
  either GDAL bugs or integration issues at earliest stage. GDAL is rebuilt
  if the revision changed, otherwise the cached build is used