### PR TITLE
Add Libraries.io link to README to show projects that depend on rasterio

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,3 +310,8 @@ Changes
 -------
 
 See `CHANGES.txt <CHANGES.txt>`__.
+
+Who is Using Rasterio?
+----------------------
+
+See `here <https://libraries.io/pypi/rasterio/usage>`__.


### PR DESCRIPTION
Added a link to bottom of README that links to rasterio page on Libraries.io, which shows the projects that depend on rasterio.

https://libraries.io/pypi/rasterio/usage