### PR TITLE
Remove potential circular import path

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -12,6 +12,69 @@ IDENTITY = Affine.identity()
 GDAL_IDENTITY = IDENTITY.to_gdal()
 
 
+class TransformMethodsMixin(object):
+    """Mixin providing methods for calculations related
+    to transforming between rows and columns of the raster
+    array and the coordinates.
+
+    These methods are wrappers for the functionality in
+    `rasterio.transform` module.
+
+    A subclass with this mixin MUST provide a `transform`
+    property.
+    """
+
+    def xy(self, row, col, offset="center"):
+        """Returns the coordinates ``(x, y)`` of a pixel at `row` and `col`.
+        The pixel's center is returned by default, but a corner can be returned
+        by setting `offset` to one of `ul, ur, ll, lr`.
+
+        Parameters
+        ----------
+        row : int
+            Pixel row.
+        col : int
+            Pixel column.
+        offset : str, optional
+            Determines if the returned coordinates are for the center of the
+            pixel or for a corner.
+
+        Returns
+        -------
+        tuple
+            ``(x, y)``
+        """
+        return xy(self.transform, row, col, offset=offset)
+
+    def index(self, x, y, op=math.floor, precision=6):
+        """
+        Returns the (row, col) index of the pixel containing (x, y) given a
+        coordinate reference system.
+
+        Use an epsilon, magnitude determined by the precision parameter
+        and sign determined by the op function:
+            positive for floor, negative for ceil.
+
+        Parameters
+        ----------
+        x : float
+            x value in coordinate reference system
+        y : float
+            y value in coordinate reference system
+        op : function, optional (default: math.floor)
+            Function to convert fractional pixels to whole numbers (floor,
+            ceiling, round)
+        precision : int, optional (default: 6)
+            Decimal places of precision in indexing, as in `round()`.
+
+        Returns
+        -------
+        tuple
+            (row index, col index)
+        """
+        return rowcol(self.transform, x, y, op=op, precision=precision)
+
+
 def tastes_like_gdal(seq):
     """Return True if `seq` matches the GDAL geotransform pattern."""
     return tuple(seq) == GDAL_IDENTITY or (

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -1,7 +1,8 @@
 """rasterio.vrt: a module concerned with GDAL VRTs"""
 
 from rasterio._warp import WarpedVRTReaderBase
-from rasterio.io import WindowMethodsMixin, TransformMethodsMixin
+from rasterio.windows import WindowMethodsMixin
+from rasterio.transform import TransformMethodsMixin
 
 
 class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,

--- a/tests/test_io_mixins.py
+++ b/tests/test_io_mixins.py
@@ -3,8 +3,7 @@ import pytest
 
 import rasterio
 from rasterio.errors import RasterioDeprecationWarning
-from rasterio.io import WindowMethodsMixin
-from rasterio.windows import Window
+from rasterio.windows import Window, WindowMethodsMixin
 
 
 EPS = 1.0e-8


### PR DESCRIPTION
The Mixin classes were in io, and imported within the vrt module,
but the io module also imported the vrt module (within _io). This
worked when copy was being imported before io in `__init__`, but removing
that import from `__init__` produced a circular import.

This addresses #1174, and should permit the necessary import removal for #1173 (at least I can remove the copy import from `__init__` without issue on this branch). cc @geowurster 