### PR TITLE
Shush test warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ rasterio/_env.c
 rasterio/_shim.c
 rasterio/_shim.pyx
 tests/data/white-gemini-iv.zip
+.hypothesis/
 
 # vim
 .*.swp

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore::UserWarning

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -20,7 +20,7 @@ from rasterio.dtypes import (
     bool_, ubyte, uint8, uint16, int16, uint32, int32, float32, float64,
     complex_, check_dtype)
 from rasterio.env import ensure_env, Env
-from rasterio.errors import RasterioIOError
+from rasterio.errors import RasterioIOError, RasterioDeprecationWarning
 from rasterio.compat import string_types
 from rasterio.io import (
     DatasetReader, get_writer_for_path, get_writer_for_driver, MemoryFile)
@@ -37,19 +37,22 @@ from rasterio import _err, coords, enums, vfs
 # TODO deprecate or remove in factor of rasterio.windows.___
 def eval_window(*args, **kwargs):
     from rasterio.windows import evaluate
-    warnings.warn("Deprecated; Use rasterio.windows instead", FutureWarning)
+    warnings.warn(
+        "Deprecated; Use rasterio.windows instead", RasterioDeprecationWarning)
     return evaluate(*args, **kwargs)
 
 
 def window_shape(*args, **kwargs):
     from rasterio.windows import shape
-    warnings.warn("Deprecated; Use rasterio.windows instead", FutureWarning)
+    warnings.warn(
+        "Deprecated; Use rasterio.windows instead", RasterioDeprecationWarning)
     return shape(*args, **kwargs)
 
 
 def window_index(*args, **kwargs):
     from rasterio.windows import window_index
-    warnings.warn("Deprecated; Use rasterio.windows instead", FutureWarning)
+    warnings.warn(
+        "Deprecated; Use rasterio.windows instead", RasterioDeprecationWarning)
     return window_index(*args, **kwargs)
 
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -23,7 +23,7 @@ from rasterio.compat import text_type, string_types
 from rasterio import dtypes
 from rasterio.enums import ColorInterp, MaskFlags, Resampling
 from rasterio.errors import CRSError, DriverRegistrationError
-from rasterio.errors import RasterioIOError
+from rasterio.errors import RasterioIOError, NotGeoreferencedWarning
 from rasterio.errors import NodataShadowWarning, WindowError
 from rasterio.sample import sample_gen
 from rasterio.transform import Affine
@@ -1107,7 +1107,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             warnings.warn(
                 "Dataset uses default geotransform (Affine.identity). "
                 "No transform will be written to the output by GDAL.",
-                UserWarning
+                NotGeoreferencedWarning
             )
 
         cdef double gt[6]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [tool:pytest]
 testpaths = tests
+filterwarnings =
+    ignore::rasterio.errors.NotGeoreferencedWarning
+    ignore::rasterio.errors.RasterioDeprecationWarning


### PR DESCRIPTION
`pytest` logs can get pretty noisy.  This PR migrates some `UserWarnings` to Rasterio warnings so we can safely ignore _only_ the Rasterio warnings and still be alerted of any other warnings.