### PR TITLE
Override get_crs() in WarpedVRT to return dst_crs

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -350,6 +350,7 @@ cdef class DatasetReaderBase(DatasetBase):
             with WarpedVRT(
                     self,
                     dst_nodata=ndv,
+                    src_crs=self.crs,
                     dst_crs=self.crs,
                     dst_width=max(self.width, window.width) + 10,
                     dst_height=max(self.height, window.height) + 10,

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -772,6 +772,9 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self._nodatavals = [
             self.src_nodata for i in self.src_dataset.indexes]
 
+    def get_crs(self):
+        return self.dst_crs
+
     def start(self):
         """Starts the VRT's life cycle."""
         log.debug("Dataset %r is started.", self)


### PR DESCRIPTION
This way, `WarpedVRT` has an effective CRS of `dst_crs` rather than `None`, enabling boundless reads.

Fixes #1186