### PR TITLE
Raise error on invalid shape for InMemoryRaster

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1588,6 +1588,12 @@ cdef class InMemoryRaster:
                 height, width = image.shape
             dtype = image.dtype.name
 
+        if height is None or height == 0:
+            raise ValueError("height must be > 0")
+
+        if width is None or width == 0:
+            raise ValueError("width must be > 0")
+
         self.band_ids[0] = 1
 
         memdriver = exc_wrap_pointer(GDALGetDriverByName("MEM"))

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -280,6 +280,9 @@ def rasterize(
     else:
         raise ValueError('Either an out_shape or image must be provided')
 
+    if min(out.shape) == 0:
+        raise ValueError("width and height must be > 0")
+
     transform = guard_transform(transform)
     _rasterize(valid_shapes, out, transform.to_gdal(), all_touched)
     return out

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -480,6 +480,11 @@ def test_rasterize_invalid_out_shape(basic_geometry):
         rasterize([basic_geometry], out_shape=(10,))
     assert 'Invalid out_shape' in str(ex.value)
 
+    for shape in [(0, 0), (1, 0), (0, 1)]:
+        with pytest.raises(ValueError) as ex:
+            rasterize([basic_geometry], out_shape=shape)
+        assert 'must be > 0' in str(ex.value)
+
 
 def test_rasterize_default_value(basic_geometry, basic_image_2x2):
     """All shapes should rasterize to the default value."""


### PR DESCRIPTION
Added checks for height and width > 0 for `InMemoryRaster`.  Resolves #1144.

Turns out this extension class is fairly difficult to test directly.  However, I added additional tests of invalid inputs for `geometry_mask` which test the underlying fix.  

Will look for other places where we should add validation of image shape in the python layer, perhaps in `rasterize`.