### PR TITLE
Merging option ADD to the rasterize feature

### DIFF
--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -284,8 +284,8 @@ def _rasterize(shapes, image, transform, all_touched, merge_alg):
     try:
         if all_touched:
             options = CSLSetNameValue(options, "ALL_TOUCHED", "TRUE")
-        options = CSLSetNameValue(
-            options, "MERGE_ALG", MergeAlg[merge_alg].value)
+        merge_algorithm = MergeAlg[merge_alg].value.encode('utf-8')
+        options = CSLSetNameValue(options, "MERGE_ALG", merge_algorithm)
 
         # GDAL needs an array of geometries.
         # For now, we'll build a Python list on the way to building that

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -250,7 +250,7 @@ def _sieve(image, size, out, mask, connectivity):
         mask_mem_ds.close()
 
 
-def _rasterize(shapes, image, transform, all_touched):
+def _rasterize(shapes, image, transform, all_touched, merge_alg_add):
     """
     Burns input geometries into `image`.
 
@@ -269,6 +269,9 @@ def _rasterize(shapes, image, transform, all_touched):
         If false, only pixels whose center is within the polygon or
         that are selected by Bresenham's line algorithm will be burned
         in.
+    merge_alg_add : boolean, optional
+        If True, the new value will be added to the existing raster. If
+        False, the new value will overwrite the existing value.
     """
     cdef int retval
     cdef size_t i
@@ -281,6 +284,8 @@ def _rasterize(shapes, image, transform, all_touched):
     try:
         if all_touched:
             options = CSLSetNameValue(options, "ALL_TOUCHED", "TRUE")
+        if merge_alg_add:
+            options = CSLSetNameValue(options, "MERGE_ALG", "ADD")
 
         # GDAL needs an array of geometries.
         # For now, we'll build a Python list on the way to building that

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -83,3 +83,8 @@ class PhotometricInterp(Enum):
     cielab = 'CIELAB'
     icclab = 'ICCLAB'
     itulab = 'ITULAB'
+
+class MergeAlg(Enum):
+    """Available rasterization algorithms"""
+    replace = 'REPLACE'
+    add = 'ADD'

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -155,7 +155,7 @@ def rasterize(
         out=None,
         transform=IDENTITY,
         all_touched=False,
-        merge_alg_add=False,
+        merge_alg='replace',
         default_value=1,
         dtype=None):
     """Return an image array with input geometries burned in.
@@ -181,9 +181,9 @@ def rasterize(
         If True, all pixels touched by geometries will be burned in.  If
         false, only pixels whose center is within the polygon or that
         are selected by Bresenham's line algorithm will be burned in.
-    merge_alg_add : boolean, optional
-        If True, the new value will be added to the existing raster. If
-        False, the new value will overwrite the existing value.
+    merge_alg : str, optional
+        If `replace` (default), the new value will overwrite the existing value.
+        If `add`, the new value will be added to the existing raster.
     default_value : int or float, optional
         Used as value for all geometries, if not provided in `shapes`.
     dtype : rasterio or numpy data type, optional
@@ -288,7 +288,7 @@ def rasterize(
         raise ValueError("width and height must be > 0")
 
     transform = guard_transform(transform)
-    _rasterize(valid_shapes, out, transform.to_gdal(), all_touched, merge_alg_add)
+    _rasterize(valid_shapes, out, transform.to_gdal(), all_touched, merge_alg)
     return out
 
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -155,6 +155,7 @@ def rasterize(
         out=None,
         transform=IDENTITY,
         all_touched=False,
+        merge_alg_add=False,
         default_value=1,
         dtype=None):
     """Return an image array with input geometries burned in.
@@ -180,6 +181,9 @@ def rasterize(
         If True, all pixels touched by geometries will be burned in.  If
         false, only pixels whose center is within the polygon or that
         are selected by Bresenham's line algorithm will be burned in.
+    merge_alg_add : boolean, optional
+        If True, the new value will be added to the existing raster. If
+        False, the new value will overwrite the existing value.
     default_value : int or float, optional
         Used as value for all geometries, if not provided in `shapes`.
     dtype : rasterio or numpy data type, optional
@@ -284,7 +288,7 @@ def rasterize(
         raise ValueError("width and height must be > 0")
 
     transform = guard_transform(transform)
-    _rasterize(valid_shapes, out, transform.to_gdal(), all_touched)
+    _rasterize(valid_shapes, out, transform.to_gdal(), all_touched, merge_alg_add)
     return out
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,6 +267,26 @@ def basic_image_2x2():
 
 
 @pytest.fixture
+def basic_image_2x2x2():
+    """
+    A basic 10x10 array for testing sieve and shapes functions.
+    Contains a square feature 2x2 (size 4).
+    Equivalent to results of rasterizing two times the basic_geometry with
+    merge_alg_add=True.
+
+    Returns
+    -------
+
+    np ndarray
+    """
+
+    image = np.zeros(DEFAULT_SHAPE, dtype=np.uint8)
+    image[2:4, 2:4] = 2
+
+    return image
+
+
+@pytest.fixture
 def pixelated_image(basic_image):
     """
     A basic 10x10 array for testing sieve functions.  Contains a square feature

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,7 +272,7 @@ def basic_image_2x2x2():
     A basic 10x10 array for testing sieve and shapes functions.
     Contains a square feature 2x2 (size 4).
     Equivalent to results of rasterizing two times the basic_geometry with
-    merge_alg_add=True.
+    merge_alg='add'.
 
     Returns
     -------

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -547,6 +547,19 @@ def test_rasterize_all_touched(basic_geometry, basic_image):
         )
     )
 
+def test_rasterize_merge_alg_add(basic_geometry, basic_image_2x2x2):
+    """
+    Rasterizing two times the basic_geometry with the ADD merging
+    option should output the shape with the value 2
+    """
+    with rasterio.Env():
+        assert np.array_equal(
+            basic_image_2x2x2,
+            rasterize(
+                [basic_geometry, basic_geometry], merge_alg_add=True,
+                out_shape=DEFAULT_SHAPE)
+        )
+
 
 def test_rasterize_value(basic_geometry, basic_image_2x2):
     """

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -547,16 +547,16 @@ def test_rasterize_all_touched(basic_geometry, basic_image):
         )
     )
 
-def test_rasterize_merge_alg_add(basic_geometry, basic_image_2x2x2):
+def test_rasterize_merge_alg(basic_geometry, basic_image_2x2x2):
     """
-    Rasterizing two times the basic_geometry with the ADD merging
+    Rasterizing two times the basic_geometry with the "add" merging
     option should output the shape with the value 2
     """
     with rasterio.Env():
         assert np.array_equal(
             basic_image_2x2x2,
             rasterize(
-                [basic_geometry, basic_geometry], merge_alg_add=True,
+                [basic_geometry, basic_geometry], merge_alg='add',
                 out_shape=DEFAULT_SHAPE)
         )
 


### PR DESCRIPTION
This PR exposes the `MERGE_ALG=ADD` option of GDALRasterizeGeometries instead of the default `MERGE_ALG=REPLACE`.