### PR TITLE
Switch to GDALOpenEx for fine driver control

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,8 @@ Bug fixes:
 - Pad boundless read VRTs so we don't overflow due to rounding (#1184).
 - Boundless reads of WarpedVRTs are enabled by setting an effective crs
   (#1188).
+- Raise ValueError when invalid width/height are passed to the
+  ``InMemoryRaster`` constructor (#1144, #1194).
 
 1.0a11 (2017-10-30)
 -------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Next
 New features:
 
 - ``rasterio.open()`` now accepts URLs with GET parameters (#1121).
+- Specific drivers and options can be used in ``rasterio.open()`` (#1000,
+  #1158, #1196).
 
 Bug fixes:
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -72,111 +72,87 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
          crs=None, transform=None, dtype=None, nodata=None, **kwargs):
     """Open a dataset for reading or writing.
 
-    The dataset may be located in a local file, in a resource located
-    by a URL, or contained within a stream of bytes.
+    The dataset may be located in a local file, in a resource located by
+    a URL, or contained within a stream of bytes.
 
-    To access a dataset within a zip file without unzipping the archive
-    use an Apache VFS style zip:// URL like
+    In read ('r') or read/write ('r+') mode, no keyword arguments are
+    required: these attributes are supplied by the opened dataset.
 
-      zip://path/to/archive.zip!path/to/example.tif
-
-    In read ('r') or read/write ('r+') mode, no other keyword arguments
-    are required: the attributes are supplied by the opened dataset.
-
-    In write mode, a driver name such as "GTiff" or "JPEG" (see GDAL
-    docs or ``gdal_translate --help`` on the command line), ``width``
-    (number of pixels per line) and ``height`` (number of lines), the
-    ``count`` number of bands in the new file must be specified.
-    Additionally, the data type for bands such as ``rasterio.ubyte`` for
-    8-bit bands or ``rasterio.uint16`` for 16-bit bands must be
-    specified using the ``dtype`` argument.
+    In write ('w') mode, the driver, width, height, count, and dtype
+    keywords are strictly required.
 
     Parameters
     ----------
-    fp: string or file
-        A filename or URL, or file object opened in binary mode.
-    mode: string
-        "r" (read), "r+" (read/write), or "w" (write)
-    driver: string
-        Driver code specifying the format name (e.g. "GTiff" or
-        "JPEG"). See GDAL docs at
-        http://www.gdal.org/formats_list.html (optional, required
-        for writing).
-    width: int
-        Number of pixels per line (optional, required for write).
-    height: int
-        Number of lines (optional, required for write).
-    count: int > 0
-        Count of bands (optional, required for write).
-    dtype: rasterio.dtype
-        the data type for bands such as ``rasterio.ubyte`` for
-        8-bit bands or ``rasterio.uint16`` for 16-bit bands
-        (optional, required for write)
-    crs: dict or string
-        Coordinate reference system (optional, recommended for write).
-    transform: Affine instance
+    fp : str or file object
+        A filename or URL, or file object opened in binary ('rb') mode
+    mode : str, optional
+        'r' (read, the default), 'r+' (read/write), or 'w' (write)
+    driver : str, optional
+        A short format driver name (e.g. "GTiff" or "JPEG") or a list of
+        such names (see GDAL docs at
+        http://www.gdal.org/formats_list.html). In 'w' mode a single
+        name is required. In 'r' or 'r+' mode the driver can usually be
+        omitted. Registered drivers will be tried sequentially until a
+        match is found. When multiple drivers are available for a format
+        such as JPEG2000, one of them can be selected by using this
+        keyword argument.
+    width, height : int, optional
+        The numbers of rows and columns of the raster dataset. Required
+        in 'w' mode, they are ignored in 'r' or 'r+' mode.
+    count : int, optional
+        The count of dataset bands. Required in 'w' mode, it is ignored
+        in 'r' or 'r+' mode.
+    dtype : str or numpy dtype
+        The data type for bands. For example: 'uint8' or
+        ``rasterio.uint16``. Required in 'w' mode, it is ignored in
+        'r' or 'r+' mode.
+    crs : str, dict, or CRS; optional
+        The coordinate reference system. Required in 'w' mode, it is
+        ignored in 'r' or 'r+' mode.
+    transform : Affine instance, optional
         Affine transformation mapping the pixel space to geographic
-        space (optional, recommended for writing).
-    nodata: number
-        Defines pixel value to be interpreted as null/nodata
-        (optional, recommended for write, will be broadcast to all
-        bands).
+        space. Required in 'w' mode, it is ignored in 'r' or 'r+' mode.
+    nodata : int, float, or nan; optional
+        Defines the pixel value to be interpreted as not valid data.
+        Required in 'w' mode, it is ignored in 'r' or 'r+' mode.
+    kwargs : optional
+        These are passed to format drivers as directives for creating
+        or interpreting datasets. For example: in 'w' a `tiled=True`
+        keyword argument will direct the GeoTIFF format driver to
+        create a tiled, rather than striped, TIFF.
 
     Returns
     -------
     A ``DatasetReader`` or ``DatasetUpdater`` object.
 
-    Notes
-    -----
-    In write mode, you must specify at least ``width``, ``height``,
-    ``count`` and ``dtype``.
+    Examples
+    --------
 
-    A coordinate reference system for raster datasets in write mode
-    can be defined by the ``crs`` argument. It takes Proj4 style
-    mappings like
+    To open a GeoTIFF for reading using standard driver discovery and
+    no directives:
 
-    .. code::
+    >>> import rasterio
+    >>> with rasterio.open('example.tif') as dataset:
+    ...     print(dataset.profile)
 
-      {'proj': 'longlat', 'ellps': 'WGS84', 'datum': 'WGS84',
-       'no_defs': True}
+    To open a JPEG2000 using only the JP2OpenJPEG driver:
 
-    An affine transformation that maps ``col,row`` pixel coordinates
-    to ``x,y`` coordinates in the coordinate reference system can be
-    specified using the ``transform`` argument. The value should be
-    an instance of ``affine.Affine``
+    >>> with rasterio.open(
+    ...         'example.jp2', driver='JP2OpenJPEG') as dataset:
+    ...     print(dataset.profile)
 
-    .. code:: python
+    To create a new 8-band, 16-bit unsigned, tiled, and LZW-compressed
+    GeoTIFF with a global extent and 0.5 degree resolution:
 
-        >>> from affine import Affine
-        >>> transform = Affine(0.5, 0.0, -180.0, 0.0, -0.5, 90.0)
-
-    These coefficients are shown in the figure below.
-
-    .. code::
-
-      | x |   | a  b  c | | c |
-      | y | = | d  e  f | | r |
-      | 1 |   | 0  0  1 | | 1 |
-
-      a: rate of change of X with respect to increasing column,
-         i.e. pixel width
-      b: rotation, 0 if the raster is oriented "north up"
-      c: X coordinate of the top left corner of the top left pixel
-      d: rotation, 0 if the raster is oriented "north up"
-      e: rate of change of Y with respect to increasing row,
-         usually a negative number (i.e. -1 * pixel height) if
-         north-up.
-      f: Y coordinate of the top left corner of the top left pixel
-
-    A 6-element sequence of the affine transformation matrix
-    coefficients in ``c, a, b, f, d, e`` order, (i.e. GDAL
-    geotransform order) will be accepted until 1.0 (deprecated).
-
-    A virtual filesystem can be specified. The ``vfs`` parameter may
-    be an Apache Commons VFS style string beginning with "zip://" or
-    "tar://"". In this case, the ``path`` must be an absolute path
-    within that container.
+    >>> from rasterio.transform import from_origin
+    >>> with rasterio.open(
+    ...         'example.tif', 'w', driver='GTiff', dtype='uint16',
+    ...         width=720, height=360, count=8, crs='EPSG:4326',
+    ...         transform=from_origin(-180.0, 90.0, 0.5, 0.5),
+    ...         nodata=0, tiled=True, compress='lzw') as dataset:
+    ...     dataset.write(...)
     """
+
     if not isinstance(fp, string_types):
         if not (hasattr(fp, 'read') or hasattr(fp, 'write')):
             raise TypeError("invalid path or file: {0!r}".format(fp))

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -261,13 +261,13 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
             # be taken over by the dataset's context manager if it is not
             # None.
             if mode == 'r':
-                s = DatasetReader(fp)
+                s = DatasetReader(fp, driver=driver, **kwargs)
             elif mode == 'r-':
                 warnings.warn("'r-' mode is deprecated, use 'r'",
                               DeprecationWarning)
                 s = DatasetReader(fp)
             elif mode == 'r+':
-                s = get_writer_for_path(fp)(fp, mode)
+                s = get_writer_for_path(fp)(fp, mode, driver=driver, **kwargs)
             elif mode == 'w':
                 s = get_writer_for_driver(driver)(fp, mode, driver=driver,
                                                   width=width, height=height,

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -112,12 +112,6 @@ cdef class DatasetBase(object):
 
     def __init__(self, path=None, driver=None, **kwargs):
         cdef GDALDatasetH hds = NULL
-        cdef const char *path_c = NULL
-        cdef const char *driver_c = NULL
-        cdef const char *key_c = NULL
-        cdef const char *val_c = NULL
-        cdef char **allowed_drivers = NULL
-        cdef char **options = NULL
         cdef int flags = 0
 
         self._hds = NULL

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -125,6 +125,13 @@ cdef class DatasetBase(object):
             path_b = vsi_path(*parse_path(path)).encode('utf-8')
             path_c = path_b
 
+            # driver may be a string or list of strings. If the
+            # former, we put it into a list.
+            if isinstance(driver, string_types):
+                driver = [driver]
+
+            # Construct a null terminated C list of driver
+            # names for GDALOpenEx.
             for name in (driver or []):
                 name_b = name.encode('utf-8')
                 name_c = name_b
@@ -137,7 +144,7 @@ cdef class DatasetBase(object):
                 val_c = val_b
                 options = CSLAddNameValue(options, key_c, val_c)
 
-            # Read-only + Raster + Sharing
+            # GDALOpenEx flags: Read-only + Raster + Sharing + Errors
             flags = 0x00 | 0x02 | 0x20 | 0x40
 
             try:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -993,12 +993,19 @@ cdef class DatasetWriterBase(DatasetReaderBase):
 
         elif mode == 'r+':
 
+            # driver may be a string or list of strings. If the
+            # former, put it into a list.
+            if isinstance(driver, string_types):
+                driver = [driver]
+
+            # Construct a null terminated C list of driver names
+            # for GDALOpenEx.
             for name in (driver or []):
                 name_b = name.encode('utf-8')
                 name_c = name_b
                 allowed_drivers = CSLAddString(allowed_drivers, name_c)
 
-            # Read-only + Raster
+            # GDALOpenEx flags: Update + Raster + Errors
             flags = 0x01 | 0x02 | 0x40
 
             try:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -872,8 +872,6 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                  count=None, crs=None, transform=None, dtype=None, nodata=None,
                  gcps=None, **kwargs):
         """Initialize a DatasetWriterBase instance."""
-
-        cdef char **allowed_drivers = NULL
         cdef char **options = NULL
         cdef char *key_c = NULL
         cdef char *val_c = NULL

--- a/rasterio/_shim.pxd
+++ b/rasterio/_shim.pxd
@@ -1,5 +1,8 @@
 include "gdal.pxi"
 
+cdef GDALDatasetH open_dataset(object filename, int mode,
+                               object allowed_drivers, object open_options,
+                               object siblings) except NULL
 cdef int delete_nodata_value(GDALRasterBandH hBand) except 3
 cdef int io_band(GDALRasterBandH band, int mode, float xoff, float yoff,
                  float width, float height, object data, int resampling=*)

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -32,10 +32,10 @@ cdef GDALDatasetH open_dataset(
     # are not supported by GDAL versions < 2.0.
     if flags & 0x20:
         with nogil:
-            GDALOpenShared(fname, <int>(flags & 0x01))
+            hds = GDALOpenShared(fname, <GDALAccess>(flags & 0x01))
     else:
         with nogil:
-            hds = GDALOpen(fname, <int>(flags & 0x01))
+            hds = GDALOpen(fname, <GDALAccess>(flags & 0x01))
 
     return exc_wrap_pointer(hds)
 

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -12,10 +12,12 @@ from rasterio.enums import Resampling
 cimport numpy as np
 from rasterio._err cimport exc_wrap_pointer
 
+from rasterio.errors import GDALOptionNotImplementedError
+
 
 cdef GDALDatasetH open_dataset(
-        object filename, int flags, object allowed_drivers, object open_options,
-        object siblings) except NULL:
+        object filename, int flags, object allowed_drivers,
+        object open_options, object siblings) except NULL:
     """Wrapper for GDALOpen and GDALOpenShared"""
     cdef const char *fname = NULL
     cdef GDALDatasetH hds = NULL
@@ -25,6 +27,19 @@ cdef GDALDatasetH open_dataset(
 
     # Note well: driver choice, open options, and sibling files
     # are not supported by GDAL versions < 2.0.
+
+    if allowed_drivers:
+        raise GDALOptionNotImplementedError(
+            "Driver selection is not implemented in GDAL 1.x")
+
+    if open_options:
+        raise GDALOptionNotImplementedError(
+            "Dataset opening options are not implemented in GDAL 1.x")
+
+    if siblings:
+        raise GDALOptionNotImplementedError(
+            "Sibling files are not implemented in GDAL 1.x")
+
     if flags & 0x20:
         with nogil:
             hds = GDALOpenShared(fname, <GDALAccess>(flags & 0x01))

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -18,11 +18,6 @@ cdef GDALDatasetH open_dataset(
         object siblings) except NULL:
     """Wrapper for GDALOpen and GDALOpenShared"""
     cdef const char *fname = NULL
-    cdef const char **drivers = NULL
-    cdef const char **options = NULL
-    cdef const char *key = NULL
-    cdef const char *val = NULL
-    cdef const char *driver = NULL
     cdef GDALDatasetH hds = NULL
 
     filename = filename.encode('utf-8')

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -32,10 +32,10 @@ cdef GDALDatasetH open_dataset(
     # are not supported by GDAL versions < 2.0.
     if flags & 0x20:
         with nogil:
-            GDALOpenShared(fname, flags & 0x01)
+            GDALOpenShared(fname, <int>(flags & 0x01))
     else:
         with nogil:
-            hds = GDALOpen(fname, flags & 0x01)
+            hds = GDALOpen(fname, <int>(flags & 0x01))
 
     return exc_wrap_pointer(hds)
 

--- a/rasterio/_shim20.pyx
+++ b/rasterio/_shim20.pyx
@@ -1,3 +1,5 @@
+"""Rasterio shims for GDAL 2.0"""
+
 # cython: boundscheck=False
 
 # The baseline GDAL API.
@@ -7,7 +9,59 @@ include "gdal.pxi"
 include "shim_rasterioex.pxi"
 
 
+# Declarations and implementations specific for GDAL = 2.0
+cdef extern from "gdal.h" nogil:
+
+    GDALDatasetH GDALOpenEx(const char *filename, int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
+
+from rasterio._err cimport exc_wrap_pointer
+
+
 # Declarations and implementations specific for GDAL==2.0
+cdef GDALDatasetH open_dataset(
+        object filename, int flags, object allowed_drivers, object open_options,
+        object siblings) except NULL:
+    """Wrapper for GDALOpen and GDALOpenShared"""
+    cdef const char *fname = NULL
+    cdef const char **drivers = NULL
+    cdef const char **options = NULL
+    cdef const char *key = NULL
+    cdef const char *val = NULL
+    cdef const char *driver = NULL
+    cdef GDALDatasetH hds = NULL
+
+    filename = filename.encode('utf-8')
+    fname = filename
+
+    # Construct a null terminated C list of driver
+    # names for GDALOpenEx.
+    if allowed_drivers:
+        for name in allowed_drivers:
+            name = name.encode('utf-8')
+            driver = name
+            drivers = CSLAddString(drivers, driver)
+
+    for k, v in open_options.items():
+        k = k.upper().encode('utf-8')
+        key = k
+
+        # Normalize values consistent with code in _env module.
+        if isinstance(v, bool):
+            v = ('ON' if v else 'OFF').encode('utf-8')
+        else:
+            v = str(v).encode('utf-8')
+        val = v
+        options = CSLAddNameValue(options, key, val)
+
+    with nogil:
+        hds = GDALOpenEx(fname, flags, drivers, options, NULL)
+    try:
+        return exc_wrap_pointer(hds)
+    finally:
+        CSLDestroy(drivers)
+        CSLDestroy(options)
+
+
 cdef int delete_nodata_value(GDALRasterBandH hBand) except 3:
     raise NotImplementedError(
         "GDAL versions < 2.1 do not support nodata deletion")

--- a/rasterio/_shim21.pyx
+++ b/rasterio/_shim21.pyx
@@ -1,3 +1,7 @@
+"""Rasterio shims for GDAL 2.1"""
+
+# cython: boundscheck=False
+
 include "directives.pxi"
 
 # The baseline GDAL API.
@@ -11,6 +15,53 @@ include "shim_rasterioex.pxi"
 cdef extern from "gdal.h" nogil:
 
     cdef CPLErr GDALDeleteRasterNoDataValue(GDALRasterBandH hBand)
+    GDALDatasetH GDALOpenEx(const char *filename, int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
+
+from rasterio._err cimport exc_wrap_pointer
+
+
+cdef GDALDatasetH open_dataset(
+        object filename, int flags, object allowed_drivers, object open_options,
+        object siblings) except NULL:
+    """Wrapper for GDALOpen and GDALOpenShared"""
+    cdef const char *fname = NULL
+    cdef const char **drivers = NULL
+    cdef const char **options = NULL
+    cdef const char *key = NULL
+    cdef const char *val = NULL
+    cdef const char *driver = NULL
+    cdef GDALDatasetH hds = NULL
+
+    filename = filename.encode('utf-8')
+    fname = filename
+
+    # Construct a null terminated C list of driver
+    # names for GDALOpenEx.
+    if allowed_drivers:
+        for name in allowed_drivers:
+            name = name.encode('utf-8')
+            driver = name
+            drivers = CSLAddString(drivers, driver)
+
+    for k, v in open_options.items():
+        k = k.upper().encode('utf-8')
+        key = k
+
+        # Normalize values consistent with code in _env module.
+        if isinstance(v, bool):
+            v = ('ON' if v else 'OFF').encode('utf-8')
+        else:
+            v = str(v).encode('utf-8')
+        val = v
+        options = CSLAddNameValue(options, key, val)
+
+    with nogil:
+        hds = GDALOpenEx(fname, flags, drivers, options, NULL)
+    try:
+        return exc_wrap_pointer(hds)
+    finally:
+        CSLDestroy(drivers)
+        CSLDestroy(options)
 
 
 cdef int delete_nodata_value(GDALRasterBandH hBand) except 3:

--- a/rasterio/_shim21.pyx
+++ b/rasterio/_shim21.pyx
@@ -24,13 +24,10 @@ cdef GDALDatasetH open_dataset(
         object filename, int flags, object allowed_drivers, object open_options,
         object siblings) except NULL:
     """Wrapper for GDALOpen and GDALOpenShared"""
-    cdef const char *fname = NULL
-    cdef const char **drivers = NULL
-    cdef const char **options = NULL
-    cdef const char *key = NULL
-    cdef const char *val = NULL
-    cdef const char *driver = NULL
+    cdef char **drivers = NULL
+    cdef char **options = NULL
     cdef GDALDatasetH hds = NULL
+    cdef const char *fname = NULL
 
     filename = filename.encode('utf-8')
     fname = filename
@@ -40,20 +37,21 @@ cdef GDALDatasetH open_dataset(
     if allowed_drivers:
         for name in allowed_drivers:
             name = name.encode('utf-8')
-            driver = name
-            drivers = CSLAddString(drivers, driver)
+            drivers = CSLAddString(drivers, <const char *>name)
 
     for k, v in open_options.items():
         k = k.upper().encode('utf-8')
-        key = k
 
         # Normalize values consistent with code in _env module.
         if isinstance(v, bool):
             v = ('ON' if v else 'OFF').encode('utf-8')
         else:
             v = str(v).encode('utf-8')
-        val = v
-        options = CSLAddNameValue(options, key, val)
+
+        options = CSLAddNameValue(options, <const char *>k, <const char *>v)
+
+    # Ensure raster flags
+    flags = flags | 0x02
 
     with nogil:
         hds = GDALOpenEx(fname, flags, drivers, options, NULL)

--- a/rasterio/_shim21.pyx
+++ b/rasterio/_shim21.pyx
@@ -21,8 +21,8 @@ from rasterio._err cimport exc_wrap_pointer
 
 
 cdef GDALDatasetH open_dataset(
-        object filename, int flags, object allowed_drivers, object open_options,
-        object siblings) except NULL:
+        object filename, int flags, object allowed_drivers,
+        object open_options, object siblings) except NULL:
     """Wrapper for GDALOpen and GDALOpenShared"""
     cdef char **drivers = NULL
     cdef char **options = NULL
@@ -49,6 +49,11 @@ cdef GDALDatasetH open_dataset(
             v = str(v).encode('utf-8')
 
         options = CSLAddNameValue(options, <const char *>k, <const char *>v)
+
+    # Support for sibling files is not yet implemented.
+    if siblings:
+        raise NotImplementedError(
+            "Sibling files are not implemented")
 
     # Ensure raster flags
     flags = flags | 0x02

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -62,6 +62,16 @@ class GDALBehaviorChangeException(RuntimeError):
             src_crs, dst_crs, antimeridian_cutting=False)
     """
 
+
+class GDALOptionNotImplementedError(RasterioError):
+    """A dataset opening or dataset creation option can't be supported
+
+    This will be raised from Rasterio's shim modules. For example, when
+    a user passes arguments to open_dataset() that can't be evaluated
+    by GDAL 1.x.
+    """
+
+
 class WindowEvaluationError(ValueError):
     """Raised when window evaluation fails"""
 

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -171,7 +171,6 @@ cdef extern from "gdal.h" nogil:
     void GDALSetDescription(GDALMajorObjectH obj, const char *text)
     GDALDriverH GDALGetDriverByName(const char *name)
     GDALDatasetH GDALOpen(const char *filename, GDALAccess access) # except -1
-    GDALDatasetH GDALOpenEx(const char *filename, int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
     GDALDatasetH GDALOpenShared(const char *filename, GDALAccess access) # except -1
     void GDALFlushCache(GDALDatasetH hds)
     void GDALClose(GDALDatasetH hds)

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -36,6 +36,7 @@ cdef extern from "cpl_error.h" nogil:
 cdef extern from "cpl_string.h" nogil:
 
     int CSLCount(char **papszStrList)
+    char **CSLAddString(char **strlist, const char *string)
     char **CSLAddNameValue(char **papszStrList, const char *pszName,
                            const char *pszValue)
     char **CSLDuplicate(char **papszStrList)
@@ -170,6 +171,7 @@ cdef extern from "gdal.h" nogil:
     void GDALSetDescription(GDALMajorObjectH obj, const char *text)
     GDALDriverH GDALGetDriverByName(const char *name)
     GDALDatasetH GDALOpen(const char *filename, GDALAccess access) # except -1
+    GDALDatasetH GDALOpenEx(const char *filename, int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
     GDALDatasetH GDALOpenShared(const char *filename, GDALAccess access) # except -1
     void GDALFlushCache(GDALDatasetH hds)
     void GDALClose(GDALDatasetH hds)

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -94,7 +94,7 @@ class MemoryFile(MemoryFileBase):
              transform=None, dtype=None, nodata=None, **kwargs):
         """Open the file and return a Rasterio dataset object.
 
-        If data has already been written, the file is opened in 'r+'
+        If data has already been written, the file is opened in 'r'
         mode. Otherwise, the file is opened in 'w' mode.
 
         Parameters
@@ -111,7 +111,7 @@ class MemoryFile(MemoryFileBase):
         if self.closed:
             raise IOError("I/O operation on closed file.")
         if self.exists():
-            return DatasetReader(vsi_path, 'r+')
+            return DatasetReader(vsi_path, driver=driver, **kwargs)
         else:
             writer = get_writer_for_driver(driver)
             return writer(vsi_path, 'w', driver=driver, width=width,
@@ -137,7 +137,7 @@ class ZipMemoryFile(MemoryFile):
         super(ZipMemoryFile, self).__init__(file_or_bytes, ext='zip')
 
     @ensure_env
-    def open(self, path):
+    def open(self, path, driver=None, **kwargs):
         """Open a dataset within the zipped stream.
 
         Parameters
@@ -154,7 +154,7 @@ class ZipMemoryFile(MemoryFile):
 
         if self.closed:
             raise IOError("I/O operation on closed file.")
-        return DatasetReader(vsi_path, 'r')
+        return DatasetReader(vsi_path, driver=driver, **kwargs)
 
 
 def get_writer_for_driver(driver):

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -8,24 +8,6 @@ import rasterio
 from rasterio.errors import RasterioDeprecationWarning
 
 
-def test_open_affine_and_transform(path_rgb_byte_tif):
-    """Passsing both 'affine' and 'transform' to rasterio.open() should issue
-    some helpful warnings.
-
-    By settings the 'affine' kwarg to a wacky value we ensure that the
-    'transform' kwarg is used while ignoring the 'affine' kwarg.
-    """
-    with pytest.warns(None) as record:
-        with rasterio.open(
-                path_rgb_byte_tif,
-                affine=rasterio,
-                transform=affine.Affine.identity()):
-            pass
-        assert len(record) == 2
-        assert "The 'affine' kwarg in rasterio.open() is deprecated" in str(record[0].message)
-        assert "choosing 'transform'" in str(record[1].message)
-
-
 def test_open_transform_gdal_geotransform(path_rgb_byte_tif):
     """Passing a GDAL geotransform to rasterio.open(transform=...) should raise
     an exception.

--- a/tests/test_open_options.py
+++ b/tests/test_open_options.py
@@ -7,6 +7,22 @@ import rasterio
 from rasterio.transform import Affine
 
 
+@pytest.mark.skipif(parse(rasterio.__gdal_version__) >= parse('2.0'),
+                    reason="Only relevant for GDAL 1.x")
+def test_driver_option_not_implemented():
+    """Driver selection is not supported by GDAL 1.x"""
+    with pytest.raises(rasterio.errors.GDALOptionNotImplementedError):
+        rasterio.open('tests/data/RGB.byte.tif', driver='BMP')
+
+
+@pytest.mark.skipif(parse(rasterio.__gdal_version__) >= parse('2.0'),
+                    reason="Only relevant for GDAL 1.x")
+def test_open_options_not_implemented():
+    """Open options are not supported by GDAL 1.x"""
+    with pytest.raises(rasterio.errors.GDALOptionNotImplementedError):
+        rasterio.open('tests/data/RGB.byte.tif', NUM_THREADS=42)
+
+
 @pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.0'),
                     reason="Requires a GDAL 2.0 feature")
 def test_fail_with_missing_driver():

--- a/tests/test_open_options.py
+++ b/tests/test_open_options.py
@@ -7,16 +7,21 @@ import rasterio
 from rasterio.transform import Affine
 
 
+@pytest.mark.xfail(parse(rasterio.__gdal_version__) < parse('2.0'),
+                   reason="Requires a GDAL 2.0 feature")
 def test_fail_with_missing_driver():
     """Fail to open a GeoTIFF without the GTiff driver"""
     with pytest.raises(rasterio.errors.RasterioIOError):
         rasterio.open('tests/data/RGB.byte.tif', driver='BMP')
 
 
+@pytest.mark.xfail(parse(rasterio.__gdal_version__) < parse('2.0'),
+                   reason="Requires a GDAL 2.0 feature")
 def test_open_specific_driver():
     """Open a GeoTIFF with the GTiff driver"""
     with rasterio.open('tests/data/RGB.byte.tif', driver='GTiff') as src:
         assert src.count == 3
+
 
 @pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.2'),
                     reason="Requires a GDAL 2.2 feature")

--- a/tests/test_open_options.py
+++ b/tests/test_open_options.py
@@ -7,16 +7,16 @@ import rasterio
 from rasterio.transform import Affine
 
 
-@pytest.mark.xfail(parse(rasterio.__gdal_version__) < parse('2.0'),
-                   reason="Requires a GDAL 2.0 feature")
+@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.0'),
+                    reason="Requires a GDAL 2.0 feature")
 def test_fail_with_missing_driver():
     """Fail to open a GeoTIFF without the GTiff driver"""
     with pytest.raises(rasterio.errors.RasterioIOError):
         rasterio.open('tests/data/RGB.byte.tif', driver='BMP')
 
 
-@pytest.mark.xfail(parse(rasterio.__gdal_version__) < parse('2.0'),
-                   reason="Requires a GDAL 2.0 feature")
+@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.0'),
+                    reason="Requires a GDAL 2.0 feature")
 def test_open_specific_driver():
     """Open a GeoTIFF with the GTiff driver"""
     with rasterio.open('tests/data/RGB.byte.tif', driver='GTiff') as src:

--- a/tests/test_open_options.py
+++ b/tests/test_open_options.py
@@ -1,0 +1,27 @@
+"""Tests of dataset opening options and driver choice"""
+
+from packaging.version import parse
+import pytest
+
+import rasterio
+from rasterio.transform import Affine
+
+
+def test_fail_with_missing_driver():
+    """Fail to open a GeoTIFF without the GTiff driver"""
+    with pytest.raises(rasterio.errors.RasterioIOError):
+        rasterio.open('tests/data/RGB.byte.tif', driver='BMP')
+
+
+def test_open_specific_driver():
+    """Open a GeoTIFF with the GTiff driver"""
+    with rasterio.open('tests/data/RGB.byte.tif', driver='GTiff') as src:
+        assert src.count == 3
+
+@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.2'),
+                    reason="Requires a GDAL 2.2 feature")
+def test_open_specific_driver_with_options():
+    """Open a GeoTIFF with the GTiff driver and GEOREF_SOURCES option"""
+    with rasterio.open(
+            'tests/data/RGB.byte.tif', driver='GTiff', GEOREF_SOURCES='NONE') as src:
+        assert src.transform == Affine.identity()


### PR DESCRIPTION
A WIP toward resolving #1000 and #1158.

TODO: 

- [x] correction for the string as sequence bug here: `driver='GTiff'` becomes `allowed_drivers=['G', 'T', 'i', 'f', 'f']`.
- [x] tests
- [x] `GDALOpenEx` shims for older GDAL versions