### PR TITLE
Removed spurious line creating NOCI.tif from test

### DIFF
--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -437,7 +437,6 @@ def test_colorinterp_like_all(
     """Test setting colorinterp via '--like template --all'."""
     noci = str(tmpdir.join('test_colorinterp_like_all.tif'))
     rasterio.shutil.copy(path_4band_no_colorinterp, noci)
-    rasterio.shutil.copy(path_4band_no_colorinterp, 'NOCI.tif')
     result = runner.invoke(main_group, [
         'edit-info', noci, '--like', path_rgba_byte_tif, '--all'])
     assert result.exit_code == 0


### PR DESCRIPTION
This removes the line creating "NOCI.tif" from `test_rio_edit_info.py`.  This line had no apparent side-effects, and was creating an unversioned, unignored file.