### PR TITLE
Refactor Window.from_slices

### DIFF
--- a/docs/topics/windowed-rw.rst
+++ b/docs/topics/windowed-rw.rst
@@ -98,7 +98,7 @@ Writing
 =======
 
 Writing works similarly. The following creates a blank 500 column x 300 row
-GeoTIFF and plops 37500 pixels with value 127 into a window 30 pixels down from
+GeoTIFF and plops 37,500 pixels with value 127 into a window 30 pixels down from
 and 50 pixels to the right of the upper left corner of the GeoTIFF.
 
 .. code-block:: python
@@ -127,8 +127,10 @@ Below, the window is scaled to one third of the source image.
 
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         b, g, r = (src.read(k) for k in (1, 2, 3))
+    # src.height = 718, src.width = 791
 
     write_window = Window.from_slices((30, 269), (50, 313))
+    # write_window.height = 239, write_window.width = 263
 
     with rasterio.open(
             '/tmp/example.tif', 'w',

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -379,7 +379,7 @@ def evaluate(window, height, width, boundless=False):
 
     Parameters
     ----------
-    window: Window.
+    window: Window or tuple of (rows, cols).
         The input window.
     height, width: int
         The number of rows or columns in the array that the window
@@ -393,8 +393,9 @@ def evaluate(window, height, width, boundless=False):
     if isinstance(window, Window):
         return window
     else:
-        return Window.from_slices(window[0], window[1], height=height, width=width,
-                                  boundless=boundless)
+        rows, cols = window
+        return Window.from_slices(rows=rows, cols=cols, height=height,
+                                  width=width, boundless=boundless)
 
 
 def shape(window, height=-1, width=-1):
@@ -583,71 +584,93 @@ class Window(object):
 
     @classmethod
     def from_slices(cls, rows, cols, height=-1, width=-1, boundless=False):
-        """Construct a Window from row and column slices or tuples.
+        """Construct a Window from row and column slices or tuples / lists of
+        start and stop indexes. Converts the rows and cols to offsets, height,
+        and width.
+
+        In general, indexes are defined relative to the upper left corner of
+        the dataset: rows=(0, 10), cols=(0, 4) defines a window that is 4
+        columns wide and 10 rows high starting from the upper left.
+
+        Start indexes may be `None` and will default to 0.
+        Stop indexes may be `None` and will default to width or height, which
+        must be provided in this case.
+
+        Negative start indexes are evaluated relative to the lower right of the
+        dataset: rows=(-2, None), cols=(-2, None) defines a window that is 2
+        rows high and 2 columns wide starting from the bottom right.
 
         Parameters
         ----------
-        rows, cols: slice or tuple
-            Slices or 2-tuples containing start, stop indexes.
+        rows, cols: slice, tuple, or list
+            Slices or 2 element tuples/lists containing start, stop indexes.
         height, width: float
-            A shape to resolve relative values against.
+            A shape to resolve relative values against. Only used when a start
+            or stop index is negative or a stop index is None.
         boundless: bool, optional
-            Whether the inputs are bounded or bot.
+            Whether the inputs are bounded (default) or not.
 
         Returns
         -------
         Window
         """
-        # Convert the rows indexing obj to offset and height.
+
         # Normalize to slices
-        if not isinstance(rows, (tuple, slice)):
-            raise WindowError("rows must be a tuple or slice")
-        else:
-            rows = slice(*rows) if isinstance(rows, tuple) else rows
+        if isinstance(rows, (tuple, list)):
+            if len(rows) != 2:
+                raise WindowError("rows must have a start and stop index")
+            rows = slice(*rows)
 
-        # Resolve the window height.
-        # Fail if the stop value is relative or implicit and there
-        # is no height context.
-        if not boundless and (
-                (rows.start is not None and rows.start < 0) or
-                rows.stop is None or rows.stop < 0) and height < 0:
-            raise WindowError(
-                "A non-negative height is required")
+        elif not isinstance(rows, slice):
+            raise WindowError("rows must be a slice, tuple, or list")
 
-        row_off = rows.start or 0.0
-        if not boundless and row_off < 0:
-            row_off += height
+        if isinstance(cols, (tuple, list)):
+            if len(cols) != 2:
+                raise WindowError("cols must have a start and stop index")
+            cols = slice(*cols)
 
+        elif not isinstance(cols, slice):
+            raise WindowError("cols must be a slice, tuple, or list")
+
+        # Height and width are required if stop indices are implicit
+        if rows.stop is None and height < 0:
+            raise WindowError("height is required if row stop index is None")
+
+        if cols.stop is None and width < 0:
+            raise WindowError("width is required if col stop index is None")
+
+        # Convert implicit indices to offsets, height, and width
+        row_off = 0.0 if rows.start is None else rows.start
         row_stop = height if rows.stop is None else rows.stop
-        if not boundless and row_stop < 0:
-            row_stop += height
 
-        num_rows = row_stop - row_off
-
-        # Number of rows is never less than 0.
-        num_rows = max(num_rows, 0.0)
-
-        # Do the same for the cols indexing object.
-        if not isinstance(cols, (tuple, slice)):
-            raise WindowError("cols must be a tuple or slice")
-        else:
-            cols = slice(*cols) if isinstance(cols, tuple) else cols
-
-        if not boundless and (
-                (cols.start is not None and cols.start < 0) or
-                cols.stop is None or cols.stop < 0) and width < 0:
-            raise WindowError("A non-negative width is required")
-
-        col_off = cols.start or 0.0
-        if not boundless and col_off < 0:
-            col_off += width
-
+        col_off = 0.0 if cols.start is None else cols.start
         col_stop = width if cols.stop is None else cols.stop
-        if not boundless and col_stop < 0:
-            col_stop += width
 
-        num_cols = col_stop - col_off
-        num_cols = max(num_cols, 0.0)
+        if not boundless:
+            if (row_off < 0 or row_stop < 0):
+                if height < 0:
+                    raise WindowError("height is required when providing "
+                                      "negative indexes")
+
+                if row_off < 0:
+                    row_off += height
+
+                if row_stop < 0:
+                    row_stop += height
+
+            if (col_off < 0 or col_stop < 0):
+                if width < 0:
+                    raise WindowError("width is required when providing "
+                                      "negative indexes")
+
+                if col_off < 0:
+                    col_off += width
+
+                if col_stop < 0:
+                    col_stop += width
+
+        num_cols = max(col_stop - col_off, 0.0)
+        num_rows = max(row_stop - row_off, 0.0)
 
         return cls(col_off=col_off, row_off=row_off, width=num_cols,
                    height=num_rows)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -464,6 +464,11 @@ def path_float_tif(data_dir):
 
 
 @pytest.fixture(scope='session')
+def path_alpha_tif(data_dir):
+    return os.path.join(data_dir, 'alpha.tif')
+
+
+@pytest.fixture(scope='session')
 def path_zip_file():
     """Creates ``coutwildrnp.zip`` if it does not exist and returns
     the absolute file path."""

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,23 +1,30 @@
-from copy import copy
 import logging
-import math
 import sys
-import warnings
 
+import numpy as np
+import pytest
 from affine import Affine
 from hypothesis import given
 from hypothesis.strategies import floats, integers
-import numpy as np
-import pytest
 
 import rasterio
 from rasterio.errors import RasterioDeprecationWarning, WindowError
 from rasterio.windows import (
     crop, from_bounds, bounds, transform, evaluate, window_index, shape,
     Window, intersect, intersection, get_data_window, union,
-    round_window_to_full_blocks, toranges)
+    round_window_to_full_blocks)
 
 EPS = 1.0e-8
+
+#col_off, row_off
+FLOAT_OFFSETS = floats(min_value=-1.0e+7, max_value=1.0e+7)
+INT_OFFSETS = floats(min_value=-10000000, max_value=10000000)
+
+# width, height
+FLOAT_LENGTHS = floats(min_value=0, max_value=1.0e+7)
+INT_LENGTHS = integers(min_value=0, max_value=1.0e+7)
+
+
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
@@ -26,23 +33,67 @@ def assert_window_almost_equals(a, b):
     assert np.allclose(a.flatten(), b.flatten(), rtol=1e-3, atol=1e-4)
 
 
-@given(col_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       row_off=floats(min_value=-1.0e+7, max_value=1.0e+7),
-       num_cols=floats(min_value=0.0, max_value=1.0e+7),
-       num_rows=floats(min_value=0.0, max_value=1.0e+7),
-       height=integers(min_value=0, max_value=10000000),
-       width=integers(min_value=0, max_value=10000000))
+
+def test_window_repr():
+    assert str(Window(0, 1, 4, 2)) == ('Window(col_off=0, row_off=1, width=4, '
+                                       'height=2)')
+
+
+@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, width=FLOAT_LENGTHS,
+       height=FLOAT_LENGTHS)
+def test_window_class(col_off, row_off, width, height):
+    """Floating point inputs should not be rounded, and 0 values should not 
+    raise errors"""
+
+    window = Window(col_off, row_off, width, height)
+
+    assert np.allclose(window.col_off, col_off)
+    assert np.allclose(window.row_off, row_off)
+    assert np.allclose(window.width, width)
+    assert np.allclose(window.height, height)
+
+
+@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, width=FLOAT_LENGTHS,
+       height=FLOAT_LENGTHS)
+def test_window_flatten(col_off, row_off, width, height):
+    """Flattened window should match inputs"""
+
+    assert np.allclose(
+        Window(col_off, row_off, width, height).flatten(),
+        (col_off, row_off, width, height))
+
+
+@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, width=FLOAT_LENGTHS,
+       height=FLOAT_LENGTHS)
+def test_window_todict(col_off, row_off, width, height):
+    """Dictionary of window should match inputs"""
+
+    d = Window(col_off, row_off, width, height).todict()
+
+    assert np.allclose(
+        (d['col_off'], d['row_off'], d['width'], d['height']),
+        (col_off, row_off, width, height))
+
+
+
+
+
+@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, num_cols=FLOAT_LENGTHS,
+       num_rows=FLOAT_LENGTHS, height=INT_LENGTHS, width=INT_LENGTHS)
 def test_crop(col_off, row_off, num_cols, num_rows, height, width):
-    window = crop(Window(col_off, row_off, num_cols, num_rows), height, width)
-    assert 0.0 <= round(window.col_off, 3) <= width
-    assert 0.0 <= round(window.row_off, 3) <= height
-    assert round(window.width, 3) <= round(width - window.col_off, 3)
-    assert round(window.height, 3) <= round(height - window.row_off, 3)
+
+    window = Window(col_off, row_off, num_cols, num_rows)
+    cropped_window = crop(window, height, width)
+
+    assert 0.0 <= round(cropped_window.col_off, 3) <= width
+    assert 0.0 <= round(cropped_window.row_off, 3) <= height
+    assert round(cropped_window.width, 3) <= round(width - cropped_window.col_off, 3)
+    assert round(cropped_window.height, 3) <= round(height - cropped_window.row_off, 3)
 
 
-def test_window_function():
+def test_window_from_bounds(path_rgb_byte_tif):
     # TODO: break this test up.
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+    with rasterio.open(path_rgb_byte_tif) as src:
         left, bottom, right, top = src.bounds
         dx, dy = src.res
         height = src.height
@@ -65,9 +116,9 @@ def test_window_function():
                                width=width))
 
 
-def test_window_float():
+def test_window_float(path_rgb_byte_tif):
     """Test window float values"""
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+    with rasterio.open(path_rgb_byte_tif) as src:
         left, bottom, right, top = src.bounds
         dx, dy = src.res
         height = src.height
@@ -92,8 +143,8 @@ def test_window_bounds_north_up():
         Window(0, 0, 10, 10))
 
 
-def test_window_transform_function():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_window_transform_function(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as src:
         assert transform(((0, None), (0, None)), src.transform) == src.transform
         assert transform(((None, None), (None, None)), src.transform) == src.transform
         assert transform(
@@ -109,8 +160,8 @@ def test_window_transform_function():
             src.transform).f == src.bounds.top + src.res[1]
 
 
-def test_window_bounds_function():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_window_bounds_function(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as src:
         rows = src.height
         cols = src.width
         assert bounds(((0, rows), (0, cols)), src.transform) == src.bounds
@@ -192,9 +243,9 @@ def test_window_from_offlen():
         assert Window.from_offlen(2, 0, 1, 1) == Window.from_slices((0, 1), (2, 3))
 
 
-def test_read_with_window_class():
+def test_read_with_window_class(path_rgb_byte_tif):
     """Reading subset with Window class works"""
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+    with rasterio.open(path_rgb_byte_tif) as src:
         subset = src.read(1, window=Window(0, 0, 10, 10))
         assert subset.shape == (10, 10)
 
@@ -264,8 +315,8 @@ def test_intersection():
     assert window == Window.from_slices((8, 10), (8, 10))
 
 
-def test_round_window_to_full_blocks():
-    with rasterio.open('tests/data/alpha.tif') as src:
+def test_round_window_to_full_blocks(path_alpha_tif):
+    with rasterio.open(path_alpha_tif) as src:
         block_shapes = src.block_shapes
         test_window = ((321, 548), (432, 765))
         rounded_window = round_window_to_full_blocks(test_window, block_shapes)
@@ -284,16 +335,16 @@ def test_round_window_to_full_blocks_error():
             Window(0, 0, 10, 10), block_shapes=[(1, 1), (2, 2)])
 
 
-def test_round_window_already_at_edge():
-    with rasterio.open('tests/data/alpha.tif') as src:
+def test_round_window_already_at_edge(path_alpha_tif):
+    with rasterio.open(path_alpha_tif) as src:
         block_shapes = src.block_shapes
         test_window = ((256, 512), (512, 768))
         rounded_window = round_window_to_full_blocks(test_window, block_shapes)
         assert rounded_window == Window.from_slices(*test_window)
 
 
-def test_round_window_boundless():
-    with rasterio.open('tests/data/alpha.tif') as src:
+def test_round_window_boundless(path_alpha_tif):
+    with rasterio.open(path_alpha_tif) as src:
         block_shapes = src.block_shapes
         test_window = ((256, 512), (1000, 1500))
         rounded_window = round_window_to_full_blocks(test_window, block_shapes)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -16,13 +16,13 @@ from rasterio.windows import (
 
 EPS = 1.0e-8
 
-#col_off, row_off
-FLOAT_OFFSETS = floats(min_value=-1.0e+7, max_value=1.0e+7)
-INT_OFFSETS = floats(min_value=-10000000, max_value=10000000)
+# hypothesis inputs: col_off, row_off
+F_OFF = floats(min_value=-1.0e+7, max_value=1.0e+7)
+I_OFF = floats(min_value=-10000000, max_value=10000000)
 
-# width, height
-FLOAT_LENGTHS = floats(min_value=0, max_value=1.0e+7)
-INT_LENGTHS = integers(min_value=0, max_value=1.0e+7)
+# hypothesis inputs: width, height
+F_LEN = floats(min_value=0, max_value=1.0e+7)
+I_LEN = integers(min_value=0, max_value=1.0e+7)
 
 
 
@@ -39,8 +39,7 @@ def test_window_repr():
                                        'height=2)')
 
 
-@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, width=FLOAT_LENGTHS,
-       height=FLOAT_LENGTHS)
+@given(col_off=F_OFF, row_off=F_OFF, width=F_LEN, height=F_LEN)
 def test_window_class(col_off, row_off, width, height):
     """Floating point inputs should not be rounded, and 0 values should not 
     raise errors"""
@@ -53,8 +52,7 @@ def test_window_class(col_off, row_off, width, height):
     assert np.allclose(window.height, height)
 
 
-@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, width=FLOAT_LENGTHS,
-       height=FLOAT_LENGTHS)
+@given(col_off=F_OFF, row_off=F_OFF, width=F_LEN, height=F_LEN)
 def test_window_flatten(col_off, row_off, width, height):
     """Flattened window should match inputs"""
 
@@ -63,8 +61,7 @@ def test_window_flatten(col_off, row_off, width, height):
         (col_off, row_off, width, height))
 
 
-@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, width=FLOAT_LENGTHS,
-       height=FLOAT_LENGTHS)
+@given(col_off=F_OFF, row_off=F_OFF, width=F_LEN, height=F_LEN)
 def test_window_todict(col_off, row_off, width, height):
     """Dictionary of window should match inputs"""
 
@@ -75,11 +72,32 @@ def test_window_todict(col_off, row_off, width, height):
         (col_off, row_off, width, height))
 
 
+@given(col_off=F_OFF, row_off=F_OFF, width=F_LEN, height=F_LEN)
+def test_window_toranges(col_off, row_off, width, height):
+    """window.toranges() should match inputs"""
+
+    assert np.allclose(
+        Window(col_off, row_off, width, height).toranges(),
+        ((row_off, row_off + height), (col_off, col_off + width)))
 
 
+@given(col_off=F_OFF, row_off=F_OFF, width=F_LEN, height=F_LEN)
+def test_window_toslices(col_off, row_off, width, height):
+    """window.toslices() should match inputs"""
 
-@given(col_off=FLOAT_OFFSETS, row_off=FLOAT_OFFSETS, num_cols=FLOAT_LENGTHS,
-       num_rows=FLOAT_LENGTHS, height=INT_LENGTHS, width=INT_LENGTHS)
+    expected_slices = (slice(row_off, row_off + height),
+                       slice(col_off, col_off + width))
+
+    slices = Window(col_off, row_off, width, height).toslices()
+
+    assert np.allclose(
+        [(s.start, s.stop) for s in slices],
+        [(s.start, s.stop) for s in expected_slices]
+    )
+
+
+@given(col_off=F_OFF, row_off=F_OFF, num_cols=F_LEN, num_rows=F_LEN,
+       height=I_LEN, width=I_LEN)
 def test_crop(col_off, row_off, num_cols, num_rows, height, width):
 
     window = Window(col_off, row_off, num_cols, num_rows)


### PR DESCRIPTION
So far, this has mostly added more extensive tests of `Window` class.

This includes a moderate refactor of `Window.from_slices` to add support for `list` as input type, expand validation of inputs, and restructure logic so that it is easier to follow.

Writing good tests for `boundless=True` is still proving difficult; we could probably use a bit more documentation on how to use `boundless` correctly.

The goal of this eventually is to have a solid enough test suite that we are comfortable removing use of epsilon as per #1139