### PR TITLE
Make GDAL version checking more consistent

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -88,8 +88,7 @@ def transform_geom(
         Transformed geometry in GeoJSON dict format
     """
 
-    if (not antimeridian_cutting and
-            GDALVersion.runtime().at_least('2.2')):
+    if (GDALVersion.runtime().at_least('2.2') and not antimeridian_cutting):
         raise GDALBehaviorChangeException(
             "Antimeridian cutting is always enabled on GDAL 2.2.0 or "
             "newer, which could produce a different geometry than expected.")

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -14,7 +14,7 @@ from rasterio._base import _transform
 from rasterio._warp import (
     _transform_geom, _reproject, _calculate_default_transform)
 from rasterio.enums import Resampling
-from rasterio.env import ensure_env
+from rasterio.env import ensure_env, GDALVersion
 from rasterio.errors import GDALBehaviorChangeException
 from rasterio.transform import guard_transform
 
@@ -88,11 +88,8 @@ def transform_geom(
         Transformed geometry in GeoJSON dict format
     """
 
-    loose_gdal_version = filter(
-        lambda x: x.isdigit(),
-        rasterio.__gdal_version__.split('.'))
-    loose_gdal_version = tuple(map(int, loose_gdal_version))
-    if loose_gdal_version[:2] >= (2, 2) and not antimeridian_cutting:
+    if (not antimeridian_cutting and
+            GDALVersion.runtime().at_least('2.2')):
         raise GDALBehaviorChangeException(
             "Antimeridian cutting is always enabled on GDAL 2.2.0 or "
             "newer, which could produce a different geometry than expected.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import numpy as np
 import rasterio
 from rasterio.crs import CRS
 from rasterio.enums import ColorInterp
+from rasterio.env import GDALVersion
 
 
 DEFAULT_SHAPE = (10, 10)
@@ -494,3 +495,31 @@ def path_zip_file():
                              '389225main_sw_1965_1024.jpg']:
                 zip.write(os.path.join(data_dir(), filename), filename)
     return path
+
+
+# Define helpers to skip tests based on GDAL version
+gdal_version = GDALVersion.runtime()
+
+requires_only_gdal1 = pytest.mark.skipif(
+    gdal_version.major != 1,
+    reason="Only relevant for GDAL 1.x")
+
+requires_less_than_gdal110 = pytest.mark.skipif(
+    gdal_version.at_least('1.10'),
+    reason="Requires GDAL 1.9.x or earlier")
+
+requires_gdal110 = pytest.mark.skipif(
+    not gdal_version.at_least('1.10'),
+    reason="Requires GDAL 1.10.x")
+
+requires_gdal2 = pytest.mark.skipif(
+    not gdal_version.major >= 2,
+    reason="Requires GDAL 2.x")
+
+requires_gdal21 = pytest.mark.skipif(
+    not gdal_version.at_least('2.1'),
+    reason="Requires GDAL 2.1.x")
+
+requires_gdal22 = pytest.mark.skipif(
+    not gdal_version.at_least('2.2'),
+    reason="Requires GDAL 2.2.x")

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -168,7 +168,7 @@ def test_block_windows_filtered_none(path_rgb_byte_tif):
             next(itr)
 
 
-@requires_gdal2  # TIFF block size access requires GDAL 2.0
+@requires_gdal2(reason="TIFF block size access requires GDAL 2.0")
 def test_block_size_tiff(path_rgb_byte_tif):
     """Without compression a TIFF's blocks are all the same size"""
     with rasterio.open(path_rgb_byte_tif) as src:
@@ -178,7 +178,7 @@ def test_block_size_tiff(path_rgb_byte_tif):
         assert sizes.count(7119) == len(block_windows) - 1
 
 
-@requires_gdal2  # TIFF block size access requires GDAL 2.0
+@requires_gdal2(reason="TIFF block size access requires GDAL 2.0")
 def test_block_size_exception():
     """A JPEG has no TIFF metadata and no API for block size"""
     with pytest.raises(RasterBlockError):

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,19 +1,18 @@
 from functools import partial
-import logging
 import os.path
 import shutil
 import subprocess
-import sys
 import tempfile
 import unittest
 
 import numpy as np
-from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio import windows
 from rasterio.errors import RasterBlockError
+
+from .conftest import requires_gdal2
 
 
 class WindowTest(unittest.TestCase):
@@ -169,9 +168,7 @@ def test_block_windows_filtered_none(path_rgb_byte_tif):
             next(itr)
 
 
-@pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.0.0'),
-    reason="TIFF block size access requires GDAL 2.0")
+@requires_gdal2  # TIFF block size access requires GDAL 2.0
 def test_block_size_tiff(path_rgb_byte_tif):
     """Without compression a TIFF's blocks are all the same size"""
     with rasterio.open(path_rgb_byte_tif) as src:
@@ -181,9 +178,7 @@ def test_block_size_tiff(path_rgb_byte_tif):
         assert sizes.count(7119) == len(block_windows) - 1
 
 
-@pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.0.0'),
-    reason="TIFF block size access requires GDAL 2.0")
+@requires_gdal2  # TIFF block size access requires GDAL 2.0
 def test_block_size_exception():
     """A JPEG has no TIFF metadata and no API for block size"""
     with pytest.raises(RasterBlockError):

--- a/tests/test_colorinterp.py
+++ b/tests/test_colorinterp.py
@@ -24,7 +24,8 @@ def test_cmyk_interp(tmpdir):
             ColorInterp.black)
 
 
-@requires_gdal22  # Some versions prior to 2.2.2 segfault on a Mac OSX Homebrew GDAL
+@requires_gdal22(reason="Some versions prior to 2.2.2 segfault on a Mac OSX "
+                        "Homebrew GDAL")
 def test_ycbcr_interp(tmpdir):
     """A YCbCr TIFF has red, green, blue bands."""
     with rasterio.open('tests/data/RGB.byte.tif') as src:

--- a/tests/test_colorinterp.py
+++ b/tests/test_colorinterp.py
@@ -1,11 +1,11 @@
 """Tests for interacting with color interpretation."""
 
-
-from packaging.version import Version
 import pytest
 
 import rasterio
 from rasterio.enums import ColorInterp
+
+from .conftest import requires_gdal22
 
 
 def test_cmyk_interp(tmpdir):
@@ -24,9 +24,7 @@ def test_cmyk_interp(tmpdir):
             ColorInterp.black)
 
 
-@pytest.mark.skipif(
-    Version(rasterio.__gdal_version__) < Version('2.2.2'),
-    reason="Some prior versions segfault on a Mac OSX Homebrew GDAL install.")
+@requires_gdal22  # Some versions prior to 2.2.2 segfault on a Mac OSX Homebrew GDAL
 def test_ycbcr_interp(tmpdir):
     """A YCbCr TIFF has red, green, blue bands."""
     with rasterio.open('tests/data/RGB.byte.tif') as src:

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -1,16 +1,15 @@
 import logging
 import subprocess
-import sys
 import json
 
-from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio._base import _can_create_osr
 from rasterio.crs import CRS
 from rasterio.errors import CRSError
-from rasterio.io import DatasetWriter
+
+from .conftest import requires_gdal21
 
 
 @pytest.fixture(scope='session')
@@ -243,7 +242,7 @@ def test_safe_osr_release(tmpdir):
     assert "Pointer 'hSRS' is NULL in 'OSRRelease'" not in log
 
 
-@pytest.mark.xfail(parse(rasterio.__gdal_version__) < parse('2.1'), reason="CRS equality is buggy pre-2.1")
+@requires_gdal21  # CRS equality is buggy pre-2.1
 def test_from_wkt():
     wgs84 = CRS.from_string('+proj=longlat +datum=WGS84 +no_defs')
     from_wkt = CRS.from_wkt(wgs84.wkt)

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -242,7 +242,7 @@ def test_safe_osr_release(tmpdir):
     assert "Pointer 'hSRS' is NULL in 'OSRRelease'" not in log
 
 
-@requires_gdal21  # CRS equality is buggy pre-2.1
+@requires_gdal21(reason="CRS equality is buggy pre-2.1")
 def test_from_wkt():
     wgs84 = CRS.from_string('+proj=longlat +datum=WGS84 +no_defs')
     from_wkt = CRS.from_wkt(wgs84.wkt)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -206,7 +206,7 @@ def test_skip_gtiff(gdalenv):
             rasterio.open('tests/data/RGB.byte.tif')
 
 
-@requires_gdal21  # S3 access requires 2.1.x
+@requires_gdal21(reason="S3 access requires 2.1+")
 @credentials
 @pytest.mark.network
 def test_s3_open_with_env(gdalenv):
@@ -216,7 +216,7 @@ def test_s3_open_with_env(gdalenv):
             assert dataset.count == 1
 
 
-@requires_gdal21
+@requires_gdal21(reason="S3 access requires 2.1+")
 @credentials
 @pytest.mark.network
 def test_s3_open_with_implicit_env(gdalenv):
@@ -225,7 +225,7 @@ def test_s3_open_with_implicit_env(gdalenv):
         assert dataset.count == 1
 
 
-@requires_gdal21
+@requires_gdal21(reason="S3 access requires 2.1+")
 @credentials
 @pytest.mark.network
 def test_env_open_s3(gdalenv):
@@ -237,7 +237,7 @@ def test_env_open_s3(gdalenv):
             assert dataset.count == 1
 
 
-@requires_gdal21
+@requires_gdal21(reason="S3 access requires 2.1+")
 @credentials
 @pytest.mark.network
 def test_env_open_s3_credentials(gdalenv):
@@ -248,7 +248,7 @@ def test_env_open_s3_credentials(gdalenv):
             assert dataset.count == 1
 
 
-@requires_gdal21
+@requires_gdal21(reason="S3 access requires 2.1+")
 @credentials
 @pytest.mark.network
 def test_ensured_env_no_credentializing(gdalenv):
@@ -259,7 +259,7 @@ def test_ensured_env_no_credentializing(gdalenv):
             rasterio.open(L8TIFB2)
 
 
-@requires_gdal21
+@requires_gdal21(reason="S3 access requires 2.1+")
 @pytest.mark.network
 def test_open_https_vsicurl(gdalenv):
     """Read from HTTPS URL."""
@@ -269,7 +269,7 @@ def test_open_https_vsicurl(gdalenv):
 
 # CLI tests.
 
-@requires_gdal21
+@requires_gdal21(reason="S3 access requires 2.1+")
 @credentials
 @pytest.mark.network
 def test_s3_rio_info(runner):
@@ -279,7 +279,7 @@ def test_s3_rio_info(runner):
     assert '"crs": "EPSG:32645"' in result.output
 
 
-@requires_gdal21
+@requires_gdal21(reason="S3 access requires 2.1+")
 @credentials
 @pytest.mark.network
 def test_https_rio_info(runner):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,23 +5,19 @@ import logging
 import sys
 
 import boto3
-from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio._env import del_gdal_config, get_gdal_config, set_gdal_config
-from rasterio._err import CPLE_BaseError
 from rasterio.env import defenv, delenv, getenv, setenv, ensure_env
 from rasterio.env import default_options, GDALVersion
 from rasterio.errors import EnvError, RasterioIOError
 from rasterio.rio.main import main_group
 
+from .conftest import requires_gdal21
+
 
 # Custom markers.
-mingdalversion = pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.1.0dev'),
-    reason="S3 raster access requires GDAL 2.1")
-
 credentials = pytest.mark.skipif(
     not(boto3.Session()._session.get_credentials()),
     reason="S3 raster access requires credentials")
@@ -210,7 +206,7 @@ def test_skip_gtiff(gdalenv):
             rasterio.open('tests/data/RGB.byte.tif')
 
 
-@mingdalversion
+@requires_gdal21  # S3 access requires 2.1.x
 @credentials
 @pytest.mark.network
 def test_s3_open_with_env(gdalenv):
@@ -220,7 +216,7 @@ def test_s3_open_with_env(gdalenv):
             assert dataset.count == 1
 
 
-@mingdalversion
+@requires_gdal21
 @credentials
 @pytest.mark.network
 def test_s3_open_with_implicit_env(gdalenv):
@@ -229,7 +225,7 @@ def test_s3_open_with_implicit_env(gdalenv):
         assert dataset.count == 1
 
 
-@mingdalversion
+@requires_gdal21
 @credentials
 @pytest.mark.network
 def test_env_open_s3(gdalenv):
@@ -241,7 +237,7 @@ def test_env_open_s3(gdalenv):
             assert dataset.count == 1
 
 
-@mingdalversion
+@requires_gdal21
 @credentials
 @pytest.mark.network
 def test_env_open_s3_credentials(gdalenv):
@@ -252,7 +248,7 @@ def test_env_open_s3_credentials(gdalenv):
             assert dataset.count == 1
 
 
-@mingdalversion
+@requires_gdal21
 @credentials
 @pytest.mark.network
 def test_ensured_env_no_credentializing(gdalenv):
@@ -263,7 +259,7 @@ def test_ensured_env_no_credentializing(gdalenv):
             rasterio.open(L8TIFB2)
 
 
-@mingdalversion
+@requires_gdal21
 @pytest.mark.network
 def test_open_https_vsicurl(gdalenv):
     """Read from HTTPS URL."""
@@ -273,7 +269,7 @@ def test_open_https_vsicurl(gdalenv):
 
 # CLI tests.
 
-@mingdalversion
+@requires_gdal21
 @credentials
 @pytest.mark.network
 def test_s3_rio_info(runner):
@@ -283,7 +279,7 @@ def test_s3_rio_info(runner):
     assert '"crs": "EPSG:32645"' in result.output
 
 
-@mingdalversion
+@requires_gdal21
 @credentials
 @pytest.mark.network
 def test_https_rio_info(runner):

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -2,21 +2,14 @@
 
 from io import BytesIO
 import logging
-
-from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio.io import MemoryFile, ZipMemoryFile
 
+from .conftest import requires_gdal2
 
 logging.basicConfig(level=logging.DEBUG)
-
-
-# Custom markers.
-mingdalversion = pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.0dev'),
-    reason="MemoryFile requires GDAL 2.0")
 
 
 @pytest.fixture(scope='session')
@@ -45,14 +38,14 @@ def rgb_data_and_profile(path_rgb_byte_tif):
     return data, profile
 
 
-@mingdalversion
+@requires_gdal2  # MemoryFile requires GDAL 2.0
 def test_initial_not_bytes():
     """Creating a MemoryFile from not bytes fails."""
     with pytest.raises(TypeError):
         MemoryFile(u'lolwut')
 
 
-@mingdalversion
+@requires_gdal2
 def test_initial_bytes(rgb_file_bytes):
     """MemoryFile contents can initialized from bytes and opened."""
     with MemoryFile(rgb_file_bytes) as memfile:
@@ -63,7 +56,7 @@ def test_initial_bytes(rgb_file_bytes):
             assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_initial_lzw_bytes(rgb_lzw_file_bytes):
     """MemoryFile contents can initialized from bytes and opened."""
     with MemoryFile(rgb_lzw_file_bytes) as memfile:
@@ -74,7 +67,7 @@ def test_initial_lzw_bytes(rgb_lzw_file_bytes):
             assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_initial_file_object(rgb_file_object):
     """MemoryFile contents can initialized from bytes and opened."""
     with MemoryFile(rgb_file_object) as memfile:
@@ -85,7 +78,7 @@ def test_initial_file_object(rgb_file_object):
             assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_closed():
     """A closed MemoryFile can not be opened"""
     with MemoryFile() as memfile:
@@ -94,7 +87,7 @@ def test_closed():
         memfile.open()
 
 
-@mingdalversion
+@requires_gdal2
 def test_non_initial_bytes(rgb_file_bytes):
     """MemoryFile contents can be read from bytes and opened."""
     with MemoryFile() as memfile:
@@ -106,7 +99,7 @@ def test_non_initial_bytes(rgb_file_bytes):
             assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_non_initial_bytes_in_two(rgb_file_bytes):
     """MemoryFile contents can be read from bytes in two steps and opened."""
     with MemoryFile() as memfile:
@@ -119,7 +112,7 @@ def test_non_initial_bytes_in_two(rgb_file_bytes):
             assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_non_initial_bytearray(rgb_file_bytes):
     """MemoryFile contents can be read from bytearray and opened."""
     with MemoryFile() as memfile:
@@ -131,7 +124,7 @@ def test_non_initial_bytearray(rgb_file_bytes):
             assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_no_initial_bytes(rgb_data_and_profile):
     """An empty MemoryFile can be opened and written into."""
     data, profile = rgb_data_and_profile
@@ -150,7 +143,7 @@ def test_no_initial_bytes(rgb_data_and_profile):
             assert sorted(src.profile.items()) == sorted(profile.items())
 
 
-@mingdalversion
+@requires_gdal2
 def test_read(tmpdir, rgb_file_bytes):
     """Reading from a MemoryFile works"""
     with MemoryFile(rgb_file_bytes) as memfile:
@@ -166,7 +159,7 @@ def test_read(tmpdir, rgb_file_bytes):
         assert src.count == 3
 
 
-@mingdalversion
+@requires_gdal2
 def test_file_object_read(rgb_file_object):
     """An example of reading from a file object"""
     with rasterio.open(rgb_file_object) as src:
@@ -176,7 +169,7 @@ def test_file_object_read(rgb_file_object):
         assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_file_object_read_variant(rgb_file_bytes):
     """An example of reading from a MemoryFile object"""
     with rasterio.open(MemoryFile(rgb_file_bytes)) as src:
@@ -186,7 +179,7 @@ def test_file_object_read_variant(rgb_file_bytes):
         assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_file_object_read_variant2(rgb_file_bytes):
     """An example of reading from a BytesIO object"""
     with rasterio.open(BytesIO(rgb_file_bytes)) as src:
@@ -196,7 +189,7 @@ def test_file_object_read_variant2(rgb_file_bytes):
         assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 def test_test_file_object_write(tmpdir, rgb_data_and_profile):
     """An example of writing to a file object"""
     data, profile = rgb_data_and_profile
@@ -211,7 +204,7 @@ def test_test_file_object_write(tmpdir, rgb_data_and_profile):
         assert src.read().shape == (3, 718, 791)
 
 
-@mingdalversion
+@requires_gdal2
 @pytest.mark.xfail(reason="in-memory files created within open() "
                           "are not persistent")
 def test_nonpersistemt_memfile_fail_example(rgb_data_and_profile):
@@ -226,7 +219,7 @@ def test_nonpersistemt_memfile_fail_example(rgb_data_and_profile):
         rasterio.open(fout)
 
 
-@mingdalversion
+@requires_gdal2
 def test_zip_closed():
     """A closed ZipMemoryFile can not be opened"""
     with ZipMemoryFile() as zipmemfile:
@@ -235,7 +228,7 @@ def test_zip_closed():
         zipmemfile.open('foo')
 
 
-@mingdalversion
+@requires_gdal2
 def test_zip_file_object_read(path_zip_file):
     """An example of reading from a zip file object"""
     with open(path_zip_file, 'rb') as zip_file_object:

--- a/tests/test_open_options.py
+++ b/tests/test_open_options.py
@@ -1,46 +1,42 @@
 """Tests of dataset opening options and driver choice"""
 
-from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio.transform import Affine
 
+from .conftest import requires_only_gdal1, requires_gdal2, requires_gdal22
 
-@pytest.mark.skipif(parse(rasterio.__gdal_version__) >= parse('2.0'),
-                    reason="Only relevant for GDAL 1.x")
+
+@requires_only_gdal1
 def test_driver_option_not_implemented():
     """Driver selection is not supported by GDAL 1.x"""
     with pytest.raises(rasterio.errors.GDALOptionNotImplementedError):
         rasterio.open('tests/data/RGB.byte.tif', driver='BMP')
 
 
-@pytest.mark.skipif(parse(rasterio.__gdal_version__) >= parse('2.0'),
-                    reason="Only relevant for GDAL 1.x")
+@requires_only_gdal1
 def test_open_options_not_implemented():
     """Open options are not supported by GDAL 1.x"""
     with pytest.raises(rasterio.errors.GDALOptionNotImplementedError):
         rasterio.open('tests/data/RGB.byte.tif', NUM_THREADS=42)
 
 
-@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.0'),
-                    reason="Requires a GDAL 2.0 feature")
+@requires_gdal2
 def test_fail_with_missing_driver():
     """Fail to open a GeoTIFF without the GTiff driver"""
     with pytest.raises(rasterio.errors.RasterioIOError):
         rasterio.open('tests/data/RGB.byte.tif', driver='BMP')
 
 
-@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.0'),
-                    reason="Requires a GDAL 2.0 feature")
+@requires_gdal2
 def test_open_specific_driver():
     """Open a GeoTIFF with the GTiff driver"""
     with rasterio.open('tests/data/RGB.byte.tif', driver='GTiff') as src:
         assert src.count == 3
 
 
-@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.2'),
-                    reason="Requires a GDAL 2.2 feature")
+@requires_gdal22
 def test_open_specific_driver_with_options():
     """Open a GeoTIFF with the GTiff driver and GEOREF_SOURCES option"""
     with rasterio.open(

--- a/tests/test_read_resample.py
+++ b/tests/test_read_resample.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from packaging.version import parse
-import pytest
-
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.windows import Window
+
+from .conftest import requires_gdal2
+
 
 # Rasterio exposes GDAL's resampling/decimation on I/O. These are the tests
 # that it does this correctly.
@@ -50,9 +50,7 @@ def test_read_downsample_alpha():
             src.read(4, out=out, masked=False)
 
 
-@pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.0dev'),
-    reason="Extra resampling algorithms require GDAL>2.0")
+@requires_gdal2
 def test_resample_alg():
     """default (nearest) and cubic produce different results"""
     with rasterio.open('tests/data/RGB.byte.tif') as s:
@@ -62,9 +60,7 @@ def test_resample_alg():
         assert np.any(nearest != cubic)
 
 
-@pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.0dev'),
-    reason="Floating point windows require GDAL>2.0")
+@requires_gdal2
 def test_float_window():
     """floating point windows work"""
     with rasterio.open('tests/data/RGB.byte.tif') as s:

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -5,16 +5,18 @@ import json
 
 import click
 from click.testing import CliRunner
-from packaging.version import Version, parse
 import pytest
 
 import rasterio
 from rasterio.enums import ColorInterp
+from rasterio.env import GDALVersion
 from rasterio.rio.edit_info import (
     all_handler, crs_handler, tags_handler, transform_handler,
     colorinterp_handler)
 from rasterio.rio.main import main_group
 import rasterio.shutil
+
+from .conftest import requires_gdal110, requires_less_than_gdal110, requires_gdal21
 
 
 PARAM_HANDLER = {
@@ -55,9 +57,7 @@ def test_delete_crs_exclusive_opts(data):
     assert result.exit_code == 2
 
 
-@pytest.mark.skip(
-    parse(rasterio.__gdal_version__) < parse('1.10'),
-    reason='GDAL version >= 1.10 required')
+@requires_gdal110
 def test_unset_crs(data):
     runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
@@ -67,10 +67,7 @@ def test_unset_crs(data):
     with rasterio.open(inputfile) as src:
         assert src.crs is None
 
-
-@pytest.mark.skip(
-    parse(rasterio.__gdal_version__) >= parse('1.10'),
-    reason='Test applies to GDAL version < 1.10')
+@requires_less_than_gdal110
 def test_unset_crs_gdal19(data):
     """unsetting crs doesn't work for geotiff and gdal 1.9
     and should emit an warning"""
@@ -94,9 +91,7 @@ def test_edit_nodata_err(data):
     assert result.exit_code == 2
 
 
-@pytest.mark.skipif(
-    Version(rasterio.__gdal_version__) < Version('2.1'),
-    reason='GDAL version >= 2.1 required')
+@requires_gdal21
 def test_delete_nodata(data):
     """Delete a dataset's nodata value"""
     runner = CliRunner()
@@ -429,9 +424,7 @@ def test_like_band_count_mismatch(runner, data):
     assert "When using '--like' for color interpretation" in result.output
 
 
-@pytest.mark.skipif(
-    Version(rasterio.__gdal_version__) < Version('2.1'),
-    reason='GDAL version >= 2.1 required')
+@requires_gdal21
 def test_colorinterp_like_all(
         runner, path_4band_no_colorinterp, path_rgba_byte_tif, tmpdir):
     """Test setting colorinterp via '--like template --all'."""

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -702,7 +702,7 @@ def test_info_checksums_only():
     assert result.output.strip() == '29131'
 
 
-@requires_gdal21  # netCDF requires GDAL 2.1+
+@requires_gdal21(reason="NetCDF requires GDAL 2.1+")
 @pytest.mark.skipif(not HAVE_NETCDF,
                     reason="GDAL not compiled with NetCDF driver.")
 def test_info_subdatasets():

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -1,12 +1,14 @@
 import json
 
 from click.testing import CliRunner
-from packaging.version import Version, parse
 import pytest
 
 import numpy as np
 import rasterio
 from rasterio.rio.main import main_group
+from rasterio.env import GDALVersion
+
+from .conftest import requires_gdal110, requires_less_than_gdal110, requires_gdal21
 
 
 with rasterio.Env() as env:
@@ -31,9 +33,7 @@ def test_delete_crs_exclusive_opts(data):
     assert result.exit_code == 2
 
 
-@pytest.mark.skip(
-    parse(rasterio.__gdal_version__) < parse('1.10'),
-    reason='GDAL version >= 1.10 required')
+@requires_gdal110
 def test_unset_crs(data):
     runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
@@ -44,9 +44,7 @@ def test_unset_crs(data):
         assert src.crs is None
 
 
-@pytest.mark.skip(
-    parse(rasterio.__gdal_version__) >= parse('1.10'),
-    reason='Test applies to GDAL version < 1.10')
+@requires_less_than_gdal110
 def test_unset_crs_gdal19(data):
     """unsetting crs doesn't work for geotiff and gdal 1.9
     and should emit an warning"""
@@ -70,9 +68,7 @@ def test_edit_nodata_err(data):
     assert result.exit_code == 2
 
 
-@pytest.mark.xfail(
-    Version(rasterio.__gdal_version__) < Version('2.1'),
-    reason='GDAL version >= 2.1 required')
+@requires_gdal21
 def test_delete_nodata(data):
     """Delete a dataset's nodata value"""
     runner = CliRunner()
@@ -706,8 +702,7 @@ def test_info_checksums_only():
     assert result.output.strip() == '29131'
 
 
-@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.1'),
-                    reason='netCDF requires GDAL 2.1+')
+@requires_gdal21  # netCDF requires GDAL 2.1+
 @pytest.mark.skipif(not HAVE_NETCDF,
                     reason="GDAL not compiled with NetCDF driver.")
 def test_info_subdatasets():

--- a/tests/test_rio_mask.py
+++ b/tests/test_rio_mask.py
@@ -6,17 +6,17 @@ import os
 
 import affine
 import numpy as np
-from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio.crs import CRS
 from rasterio.rio.main import main_group
+from rasterio.env import GDALVersion
 
 
 # Custom markers.
 xfail_pixel_sensitive_gdal22 = pytest.mark.xfail(
-    parse(rasterio.__gdal_version__) < parse('2.2'),
+    not GDALVersion.runtime().at_least('2.2'),
     reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 
 

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -8,7 +8,6 @@ import logging
 import affine
 from click.testing import CliRunner
 import numpy as np
-from packaging.version import parse
 from pytest import fixture
 import pytest
 
@@ -17,11 +16,13 @@ from rasterio.merge import merge
 from rasterio.rio.main import main_group
 from rasterio.transform import Affine
 
+from rasterio.env import GDALVersion
+
 
 # Custom markers.
 xfail_pixel_sensitive_gdal2 = pytest.mark.xfail(
-    parse(rasterio.__gdal_version__) < parse('2.0dev'),
-    reason="This test is sensitive to pixel values and requires GDAL 2.0+")
+    not GDALVersion.runtime().at_least('2.0'),
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 
 
 # Fixture to create test datasets within temporary directory

--- a/tests/test_subdatasets.py
+++ b/tests/test_subdatasets.py
@@ -1,15 +1,14 @@
-from packaging.version import parse
 import pytest
 
 import rasterio
 
+from .conftest import requires_gdal21
 
 with rasterio.Env() as env:
     HAVE_NETCDF = 'NetCDF' in env.drivers().keys()
 
 
-@pytest.mark.skipif(parse(rasterio.__gdal_version__) < parse('2.1'),
-                    reason="netcdf driver not available before GDAL 2.1")
+@requires_gdal21  # NetCDF requires 2.1.x
 @pytest.mark.skipif(not HAVE_NETCDF,
                     reason="GDAL not compiled with NetCDF driver.")
 def test_subdatasets():

--- a/tests/test_subdatasets.py
+++ b/tests/test_subdatasets.py
@@ -8,7 +8,7 @@ with rasterio.Env() as env:
     HAVE_NETCDF = 'NetCDF' in env.drivers().keys()
 
 
-@requires_gdal21  # NetCDF requires 2.1.x
+@requires_gdal21(reason="NetCDF requires GDAL 2.1+")
 @pytest.mark.skipif(not HAVE_NETCDF,
                     reason="GDAL not compiled with NetCDF driver.")
 def test_subdatasets():

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,13 +1,15 @@
-import shutil
 import subprocess
 import re
 
 import affine
 import numpy as np
-from packaging.version import Version
 import pytest
 
 import rasterio
+from rasterio.env import GDALVersion
+
+from .conftest import requires_gdal21
+
 
 def test_update_tags(data):
     tiffname = str(data.join('RGB.byte.tif'))
@@ -65,7 +67,7 @@ def test_update_nodatavals(data):
 
 
 @pytest.mark.skipif(
-    Version(rasterio.__gdal_version__) >= Version('2.1'),
+    GDALVersion.runtime().at_least('2.1'),
     reason='Tests behavior specific to GDAL versions < 2.1')
 def test_update_nodatavals_none_fails(data):
     """GDAL 2.0 doesn't support un-setting nodata values."""
@@ -75,9 +77,7 @@ def test_update_nodatavals_none_fails(data):
             f.nodata = None
 
 
-@pytest.mark.skipif(
-    Version(rasterio.__gdal_version__) < Version('2.1'),
-    reason='Tests behavior specific to GDAL versions >= 2.1')
+@requires_gdal21
 def test_update_nodatavals_none(data):
     """GDAL 2.1 does support un-setting nodata values."""
     tiffname = str(data.join('RGB.byte.tif'))

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -5,19 +5,18 @@ import sys
 import pytest
 from affine import Affine
 import numpy as np
-from packaging.version import parse
 
 import rasterio
 from rasterio.control import GroundControlPoint
-from rasterio.crs import CRS
 from rasterio.enums import Resampling
+from rasterio.env import GDALVersion
 from rasterio.errors import GDALBehaviorChangeException, CRSError
 from rasterio.warp import (
     reproject, transform_geom, transform, transform_bounds,
     calculate_default_transform)
 from rasterio import windows
 
-
+gdal_version = GDALVersion.runtime()
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
@@ -43,10 +42,9 @@ def supported_resampling(method):
     gdal2plus_only = (
         Resampling.max, Resampling.min, Resampling.med,
         Resampling.q1, Resampling.q3)
-    version = parse(rasterio.__gdal_version__)
-    if version < parse('1.10'):
+    if not gdal_version.at_least('1.10'):
         return method not in gdal2plus_only and method not in gdal110plus_only
-    if version < parse('2.0'):
+    if not gdal_version.at_least('2.0'):
         return method not in gdal2plus_only
     return True
 
@@ -1050,7 +1048,7 @@ def test_reproject_gcps(rgb_byte_profile):
 
 
 @pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.2.0'),
+    gdal_version.at_least('2.2'),
     reason="GDAL 2.2.0 and newer has different antimeridian cutting behavior.")
 def test_transform_geom_gdal22():
     """Enabling `antimeridian_cutting` has no effect on GDAL 2.2.0 or newer

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1048,7 +1048,7 @@ def test_reproject_gcps(rgb_byte_profile):
 
 
 @pytest.mark.skipif(
-    gdal_version.at_least('2.2'),
+    not gdal_version.at_least('2.2'),
     reason="GDAL 2.2.0 and newer has different antimeridian cutting behavior.")
 def test_transform_geom_gdal22():
     """Enabling `antimeridian_cutting` has no effect on GDAL 2.2.0 or newer

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -81,7 +81,7 @@ def test_warp_extras(path_rgb_byte_tif):
             assert (rgb[:, 0, 0] == 255).all()
 
 
-@requires_gdal21  # S3 raster access requires GDAL 2.1
+@requires_gdal21(reason="S3 raster access requires GDAL 2.1+")
 @credentials
 @pytest.mark.network
 def test_wrap_s3():

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -1,19 +1,15 @@
 import boto3
-from packaging.version import parse
 import pytest
 
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.transform import Affine
 from rasterio.vrt import WarpedVRT
-from rasterio.windows import Window
+
+from .conftest import requires_gdal21
 
 
 # Custom markers.
-mingdalversion = pytest.mark.skipif(
-    parse(rasterio.__gdal_version__) < parse('2.1.0dev'),
-    reason="S3 raster access requires GDAL 2.1")
-
 credentials = pytest.mark.skipif(
     not(boto3.Session()._session.get_credentials()),
     reason="S3 raster access requires credentials")
@@ -85,7 +81,7 @@ def test_warp_extras(path_rgb_byte_tif):
             assert (rgb[:, 0, 0] == 255).all()
 
 
-@mingdalversion
+@requires_gdal21  # S3 raster access requires GDAL 2.1
 @credentials
 @pytest.mark.network
 def test_wrap_s3():


### PR DESCRIPTION
Resolves #1209 

Opted for a very simplistic parsing of GDAL version number and a few helpers wrapped into a class.

Leveraged pytest test skipping using helpers in `conftest.py` to centralize and make more semantic tests that vary based on GDAL version.

There are a couple of `xfail` marked tests that maybe should be skipped instead, I flagged those for consideration.