### PR TITLE
Add GDAL 2.2.3 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - GDALVERSION="2.1.4"
     - GDALVERSION="2.2.1"
     - GDALVERSION="2.2.2"
+    - GDALVERSION="2.2.3"
     - GDALVERSION="trunk"
 
 matrix:


### PR DESCRIPTION
Released a [few days ago](https://trac.osgeo.org/gdal/wiki/Release/2.2.3-News).