### PR TITLE
Reduce xfailing tests

### DIFF
--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -9,7 +9,7 @@ from rasterio._base import _can_create_osr
 from rasterio.crs import CRS
 from rasterio.errors import CRSError
 
-from .conftest import requires_gdal21
+from .conftest import requires_gdal21, requires_gdal22
 
 
 @pytest.fixture(scope='session')
@@ -195,9 +195,9 @@ def test_can_create_osr_invalid(arg):
     assert not _can_create_osr(arg)
 
 
-@pytest.mark.xfail()
+@requires_gdal22(
+    reason="GDAL bug resolved in 2.2+ allowed invalid CRS to be created")
 def test_can_create_osr_invalid_epsg_0():
-    """this invalid CRS should fail, but doesn't because of a GDAL bug"""
     assert not _can_create_osr('EPSG:')
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -130,7 +130,7 @@ def test_geometry_window(basic_image_file, basic_geometry):
         assert window.flatten() == (2, 2, 3, 3)
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(reason="https://github.com/mapbox/rasterio/issues/1139")
 # This test is failing due to https://github.com/mapbox/rasterio/issues/1139
 def test_geometry_window_pixel_precision(basic_image_file):
     """Window offsets should be floor, width and height ceiling"""

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -197,8 +197,6 @@ def test_test_file_object_write(tmpdir, rgb_data_and_profile):
         assert src.read().shape == (3, 718, 791)
 
 
-@pytest.mark.xfail(reason="in-memory files created within open() "
-                          "are not persistent")
 def test_nonpersistemt_memfile_fail_example(rgb_data_and_profile):
     """An example of writing to a file object"""
     data, profile = rgb_data_and_profile

--- a/tests/test_rio_mask.py
+++ b/tests/test_rio_mask.py
@@ -11,13 +11,8 @@ import pytest
 import rasterio
 from rasterio.crs import CRS
 from rasterio.rio.main import main_group
-from rasterio.env import GDALVersion
 
-
-# Custom markers.
-xfail_pixel_sensitive_gdal22 = pytest.mark.xfail(
-    not GDALVersion.runtime().at_least('2.2'),
-    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
+from .conftest import requires_gdal22
 
 
 def test_mask(runner, tmpdir, basic_feature, basic_image_2x2,
@@ -166,7 +161,8 @@ def test_mask_invalid_geojson(runner, tmpdir, pixelated_image_file):
 
 
 
-@xfail_pixel_sensitive_gdal22
+@requires_gdal22(
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
     """
     In order to test --crop option, we need to use a transform more similar to
@@ -204,7 +200,8 @@ def test_mask_crop(runner, tmpdir, basic_feature, pixelated_image):
             out.read(1, masked=True).filled(0))
 
 
-@xfail_pixel_sensitive_gdal22
+@requires_gdal22(
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 def test_mask_crop_inverted_y(runner, tmpdir, basic_feature, pixelated_image_file):
     """
     --crop option should also work if raster has a positive y pixel size

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -16,14 +16,7 @@ from rasterio.merge import merge
 from rasterio.rio.main import main_group
 from rasterio.transform import Affine
 
-from rasterio.env import GDALVersion
-
-
-# Custom markers.
-xfail_pixel_sensitive_gdal2 = pytest.mark.xfail(
-    not GDALVersion.runtime().at_least('2.0'),
-    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
-
+from .conftest import requires_gdal22
 
 # Fixture to create test datasets within temporary directory
 @fixture(scope='function')
@@ -100,7 +93,8 @@ def test_merge_with_colormap(test_data_dir_1):
         assert cmap[255] == (0, 0, 0, 255)
 
 
-@xfail_pixel_sensitive_gdal2
+@requires_gdal22(
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 def test_merge_with_nodata(test_data_dir_1):
     outputname = str(test_data_dir_1.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_1.listdir()]
@@ -131,7 +125,8 @@ def test_merge_warn(test_data_dir_1):
     assert os.path.exists(outputname)
 
 
-@xfail_pixel_sensitive_gdal2
+@requires_gdal22(
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 def test_merge_without_nodata(test_data_dir_2):
     outputname = str(test_data_dir_2.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_2.listdir()]
@@ -275,10 +270,8 @@ def test_data_dir_float(tmpdir):
     return tmpdir
 
 
-@xfail_pixel_sensitive_gdal2
-@pytest.mark.xfail(
-    os.environ.get('GDALVERSION', 'a.b.c').startswith('1.9'),
-    reason="GDAL 1.9 doesn't catch this error")
+@requires_gdal22(
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 def test_merge_float(test_data_dir_float):
     outputname = str(test_data_dir_float.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_float.listdir()]
@@ -382,7 +375,8 @@ def test_merge_tiny_output_opt(tiffs):
         assert data[0][3][0] == 40
 
 
-@xfail_pixel_sensitive_gdal2
+@requires_gdal22(
+    reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 @pytest.mark.xfail(sys.version_info < (3,),
                    reason="Test is sensitive to rounding behavior")
 def test_merge_tiny_res_bounds(tiffs):

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -915,7 +915,6 @@ def test_resample_default_invert_proj(method):
     assert out.mean() > 0
 
 
-@pytest.mark.xfail()
 @pytest.mark.parametrize("method", Resampling)
 def test_resample_no_invert_proj(method):
     """Nearest and bilinear should produce valid results with
@@ -923,6 +922,12 @@ def test_resample_no_invert_proj(method):
     """
     if not supported_resampling(method):
         pytest.skip()
+
+    if method in (Resampling.bilinear, Resampling.cubic,
+                  Resampling.cubic_spline, Resampling.lanczos):
+        pytest.xfail(
+            reason="Some resampling methods succeed but produce blank images. "
+                   "See https://github.com/mapbox/rasterio/issues/614")
 
     with rasterio.Env(CHECK_WITH_INVERT_PROJ=False):
         with rasterio.open('tests/data/world.rgb.tif') as src:
@@ -940,7 +945,7 @@ def test_resample_no_invert_proj(method):
 
         out = np.empty(shape=(dst_height, dst_width), dtype=np.uint8)
 
-        # see #614, some resamplin methods succeed but produce blank images
+        # see #614, some resampling methods succeed but produce blank images
         out = np.empty(src.shape, dtype=np.uint8)
         reproject(
             source,


### PR DESCRIPTION
This skips GDAL version dependent tests instead of xfailing them.

It also removes `xfail` marks from tests that were not failing on any of our Travis builds.

I slightly refactored the testing of the xfailing resampling tests to only xfail those specific methods that were failing.