### PR TITLE
Naming raster / source / dataset

### DIFF
--- a/docs/topics/plotting.rst
+++ b/docs/topics/plotting.rst
@@ -23,7 +23,7 @@ displaying multi-band images as RGB and labeling the axes with proper geo-refere
 
 The first argument to ``show`` represent the data source to be plotted. This can be one of
 
-   * A ``DatasetReader`` source instance
+   * A dataset object opened in 'r' mode
    * A single band of a source, represented by a ``(src, band_index)`` tuple
    * A numpy ndarray, 2D or 3D. If the array is 3D, ensure that it is in rasterio band order.
 

--- a/docs/topics/plotting.rst
+++ b/docs/topics/plotting.rst
@@ -23,7 +23,7 @@ displaying multi-band images as RGB and labeling the axes with proper geo-refere
 
 The first argument to ``show`` represent the data source to be plotted. This can be one of
 
-   * A ``RasterReader`` source instance
+   * A ``DatasetReader`` source instance
    * A single band of a source, represented by a ``(src, band_index)`` tuple
    * A numpy ndarray, 2D or 3D. If the array is 3D, ensure that it is in rasterio band order.
 

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -25,7 +25,7 @@ def _shapes(image, mask, connectivity, transform):
 
     Parameters
     ----------
-    image : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
+    image : array or dataset object opened in 'r' mode or Band or tuple(dataset, bidx)
         Data type must be one of rasterio.int16, rasterio.int32,
         rasterio.uint8, rasterio.uint16, or rasterio.float32.
     mask : numpy ndarray or rasterio Band object
@@ -151,7 +151,7 @@ def _sieve(image, size, out, mask, connectivity):
 
     Parameters
     ----------
-    image : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
+    image : array or dataset object opened in 'r' mode or Band or tuple(dataset, bidx)
         Must be of type rasterio.int16, rasterio.int32, rasterio.uint8,
         rasterio.uint16, or rasterio.float32.
     size : int

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -26,7 +26,7 @@ def _shapes(image, mask, connectivity, transform):
     Parameters
     ----------
     image : numpy ndarray or rasterio Band object
-        (RasterReader, bidx namedtuple).
+        (DatasetReader, bidx namedtuple).
         Data type must be one of rasterio.int16, rasterio.int32,
         rasterio.uint8, rasterio.uint16, or rasterio.float32.
     mask : numpy ndarray or rasterio Band object
@@ -153,7 +153,7 @@ def _sieve(image, size, out, mask, connectivity):
     Parameters
     ----------
     image : numpy ndarray or rasterio Band object
-        (RasterReader, bidx namedtuple)
+        (DatasetReader, bidx namedtuple)
         Must be of type rasterio.int16, rasterio.int32, rasterio.uint8,
         rasterio.uint16, or rasterio.float32.
     size : int

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -25,8 +25,7 @@ def _shapes(image, mask, connectivity, transform):
 
     Parameters
     ----------
-    image : numpy ndarray or rasterio Band object
-        (DatasetReader, bidx namedtuple).
+    image : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
         Data type must be one of rasterio.int16, rasterio.int32,
         rasterio.uint8, rasterio.uint16, or rasterio.float32.
     mask : numpy ndarray or rasterio Band object
@@ -152,8 +151,7 @@ def _sieve(image, size, out, mask, connectivity):
 
     Parameters
     ----------
-    image : numpy ndarray or rasterio Band object
-        (DatasetReader, bidx namedtuple)
+    image : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
         Must be of type rasterio.int16, rasterio.int32, rasterio.uint8,
         rasterio.uint16, or rasterio.float32.
     size : int

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -65,7 +65,7 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
 
     Parameters
     ----------
-    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
+    source : array or dataset object opened in 'r' mode or Band or tuple(dataset, bidx)
         Data type must be one of rasterio.int16, rasterio.int32,
         rasterio.uint8, rasterio.uint16, or rasterio.float32.
     mask : numpy ndarray or rasterio Band object, optional
@@ -108,7 +108,7 @@ def sieve(source, size, out=None, mask=None, connectivity=4):
 
     Parameters
     ----------
-    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
+    source : array or dataset object opened in 'r' mode or Band or tuple(dataset, bidx)
         Must be of type rasterio.int16, rasterio.int32, rasterio.uint8,
         rasterio.uint16, or rasterio.float32
     size : int

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -65,7 +65,7 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
 
     Parameters
     ----------
-    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
+    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
         Data type must be one of rasterio.int16, rasterio.int32,
         rasterio.uint8, rasterio.uint16, or rasterio.float32.
     mask : numpy ndarray or rasterio Band object, optional
@@ -108,7 +108,7 @@ def sieve(source, size, out=None, mask=None, connectivity=4):
 
     Parameters
     ----------
-    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
+    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
         Must be of type rasterio.int16, rasterio.int32, rasterio.uint8,
         rasterio.uint16, or rasterio.float32
     size : int
@@ -321,7 +321,7 @@ def geometry_window(dataset, shapes, pad_x=0, pad_y=0, north_up=True,
 
     Parameters
     ----------
-    dataset: rasterio DatasetReader object
+    dataset: dataset object opened in 'r' mode
         Raster for which the mask will be created.
     shapes: iterable over geometries.
         A geometry is a GeoJSON-like object or implements the geo interface.

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -32,7 +32,7 @@ def geometry_mask(
     out_shape : tuple or list
         Shape of output numpy ndarray.
     transform : Affine transformation object
-        Transformation from pixel coordinates of `image` to the
+        Transformation from pixel coordinates of `source` to the
         coordinate system of the input `shapes`. See the `transform`
         property of dataset objects.
     all_touched : boolean, optional
@@ -60,13 +60,12 @@ def geometry_mask(
 
 
 @ensure_env
-def shapes(image, mask=None, connectivity=4, transform=IDENTITY):
+def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
     """Yield (polygon, value for each set of adjacent pixels of the same value.
 
     Parameters
     ----------
-    image : numpy ndarray or rasterio Band object
-        (DatasetReader, bidx namedtuple).
+    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
         Data type must be one of rasterio.int16, rasterio.int32,
         rasterio.uint8, rasterio.uint16, or rasterio.float32.
     mask : numpy ndarray or rasterio Band object, optional
@@ -97,26 +96,25 @@ def shapes(image, mask=None, connectivity=4, transform=IDENTITY):
 
     """
     transform = guard_transform(transform)
-    for s, v in _shapes(image, mask, connectivity, transform.to_gdal()):
+    for s, v in _shapes(source, mask, connectivity, transform.to_gdal()):
         yield s, v
 
 
 @ensure_env
-def sieve(image, size, out=None, mask=None, connectivity=4):
-    """Replace small polygons in `image` with value of their largest neighbor.
+def sieve(source, size, out=None, mask=None, connectivity=4):
+    """Replace small polygons in `source` with value of their largest neighbor.
 
     Polygons are found for each set of neighboring pixels of the same value.
 
     Parameters
     ----------
-    image : numpy ndarray or rasterio Band object
-        (DatasetReader, bidx namedtuple)
+    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
         Must be of type rasterio.int16, rasterio.int32, rasterio.uint8,
         rasterio.uint16, or rasterio.float32
     size : int
         minimum polygon size (number of pixels) to retain.
     out : numpy ndarray, optional
-        Array of same shape and data type as `image` in which to store results.
+        Array of same shape and data type as `source` in which to store results.
     mask : numpy ndarray or rasterio Band object, optional
         Values of False or 0 will be excluded from feature generation
         Must evaluate to bool (rasterio.bool_ or rasterio.uint8)
@@ -142,8 +140,8 @@ def sieve(image, size, out=None, mask=None, connectivity=4):
     """
 
     if out is None:
-        out = np.zeros(image.shape, image.dtype)
-    _sieve(image, size, out, mask, connectivity)
+        out = np.zeros(source.shape, source.dtype)
+    _sieve(source, size, out, mask, connectivity)
     return out
 
 
@@ -171,10 +169,10 @@ def rasterize(
         Used as fill value for all areas not covered by input
         geometries.
     out : numpy ndarray, optional
-        Array of same shape and data type as `image` in which to store
+        Array of same shape and data type as `source` in which to store
         results.
     transform : Affine transformation object, optional
-        Transformation from pixel coordinates of `image` to the
+        Transformation from pixel coordinates of `source` to the
         coordinate system of the input `shapes`. See the `transform`
         property of dataset objects.
     all_touched : boolean, optional

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -26,7 +26,7 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
 
     Parameters
     ----------
-    dataset: rasterio DatasetReader object
+    dataset: a dataset object opened in 'r' mode
         Raster for which the mask will be created.
     shapes: list of polygons
         GeoJSON-like dict representation of polygons that will be used to
@@ -118,7 +118,7 @@ def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
 
     Parameters
     ----------
-    dataset: rasterio DatasetReader object
+    dataset: a dataset object opened in 'r' mode
         Raster to which the mask will be applied.
     shapes: list of polygons
         GeoJSON-like dict representation of polygons that will be used to

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -31,8 +31,8 @@ def merge(datasets, bounds=None, res=None, nodata=None, precision=7):
 
     Parameters
     ----------
-    datasets: list of source datasets
-        Open rasterio DatasetReader objects to be merged.
+    datasets: list of dataset objects opened in 'r' mode
+        source datasets to be merged.
     bounds: tuple, optional
         Bounds of the output image (left, bottom, right, top).
         If not set, bounds are determined from bounds of input rasters.

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -32,7 +32,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
     Parameters
     ----------
     sources: list of source datasets
-        Open rasterio RasterReader objects to be merged.
+        Open rasterio DatasetReader objects to be merged.
     bounds: tuple, optional
         Bounds of the output image (left, bottom, right, top).
         If not set, bounds are determined from bounds of input rasters.

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -15,7 +15,7 @@ from rasterio.transform import Affine
 logger = logging.getLogger(__name__)
 
 
-def merge(sources, bounds=None, res=None, nodata=None, precision=7):
+def merge(datasets, bounds=None, res=None, nodata=None, precision=7):
     """Copy valid pixels from input files to an output file.
 
     All files must have the same number of bands, data type, and
@@ -31,7 +31,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
 
     Parameters
     ----------
-    sources: list of source datasets
+    datasets: list of source datasets
         Open rasterio DatasetReader objects to be merged.
     bounds: tuple, optional
         Bounds of the output image (left, bottom, right, top).
@@ -57,7 +57,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
                 Information for mapping pixel coordinates in `dest` to another
                 coordinate system
     """
-    first = sources[0]
+    first = datasets[0]
     first_res = first.res
     nodataval = first.nodatavals[0]
     dtype = first.dtypes[0]
@@ -69,7 +69,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         # scan input files.
         xs = []
         ys = []
-        for src in sources:
+        for src in datasets:
             left, bottom, right, top = src.bounds
             xs.extend([left, right])
             ys.extend([bottom, top])
@@ -129,7 +129,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
     else:
         nodataval = 0
 
-    for src in sources:
+    for src in datasets:
         # Real World (tm) use of boundless reads.
         # This approach uses the maximum amount of memory to solve the
         # problem. Making it more efficient is a TODO.

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -40,9 +40,9 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
 
     Parameters
     ----------
-    source : np.ndarray or DatasetReader or rasterio.Band or tuple(DatasetReader, bidx)
-        If tuple (DatasetReader, bidx),
-        selects band `bidx` from raster.
+    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
+        If Band or tuple (DatasetReader, bidx),
+        display the selected band.
         If raster dataset display the rgb image
         as defined in the colorinterp metadata, or default to first band.
     with_bounds : bool (opt)
@@ -155,8 +155,8 @@ def plotting_extent(source, transform=None):
 
     Parameters
     ----------
-    source : array-like in image order (see reshape_as_image),
-        or RasterReader
+    source : array or DatasetReader
+        input data
     transform: Affine, required if source is array
         Defines the affine transform if source is an array
 
@@ -218,7 +218,7 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
 
     Parameters
     ----------
-    source : np.ndarray or DatasetReader or rasterio.Band or tuple(DatasetReader, bidx)
+    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
         Input data to display.
         The first three arrays in multi-dimensional
         arrays are plotted as red, green, and blue.

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -40,7 +40,7 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
 
     Parameters
     ----------
-    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
+    source : array or dataset object opened in 'r' mode or Band or tuple(dataset, bidx)
         If Band or tuple (dataset, bidx), display the selected band.
         If raster dataset display the rgb image
         as defined in the colorinterp metadata, or default to first band.
@@ -217,7 +217,7 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
 
     Parameters
     ----------
-    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
+    source : array or dataset object opened in 'r' mode or Band or tuple(dataset, bidx)
         Input data to display.
         The first three arrays in multi-dimensional
         arrays are plotted as red, green, and blue.

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -40,9 +40,8 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
 
     Parameters
     ----------
-    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
-        If Band or tuple (DatasetReader, bidx),
-        display the selected band.
+    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
+        If Band or tuple (dataset, bidx), display the selected band.
         If raster dataset display the rgb image
         as defined in the colorinterp metadata, or default to first band.
     with_bounds : bool (opt)
@@ -155,7 +154,7 @@ def plotting_extent(source, transform=None):
 
     Parameters
     ----------
-    source : array or DatasetReader
+    source : array or dataset object opened in 'r' mode
         input data
     transform: Affine, required if source is array
         Defines the affine transform if source is an array
@@ -218,7 +217,7 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
 
     Parameters
     ----------
-    source : array or DatasetReader or Band or tuple(DatasetReader, bidx)
+    source : array or dataset object in 'r' mode or Band or tuple(dataset, bidx)
         Input data to display.
         The first three arrays in multi-dimensional
         arrays are plotted as red, green, and blue.

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -40,11 +40,10 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
 
     Parameters
     ----------
-    source : array-like in raster axis order,
-        or (raster dataset, bidx) tuple,
-        or raster dataset,
-        If the tuple (raster dataset, bidx),
-        selects band `bidx` from raster.  If raster dataset display the rgb image
+    source : np.ndarray or DatasetReader or rasterio.Band or tuple(DatasetReader, bidx)
+        If tuple (DatasetReader, bidx),
+        selects band `bidx` from raster.
+        If raster dataset display the rgb image
         as defined in the colorinterp metadata, or default to first band.
     with_bounds : bool (opt)
         Whether to change the image extent to the spatial bounds of the image,
@@ -156,8 +155,15 @@ def plotting_extent(source, transform=None):
 
     Parameters
     ----------
-    source : raster dataset or array in image order (see reshape_as_image)
+    source : array-like in image order (see reshape_as_image),
+        or RasterReader
     transform: Affine, required if source is array
+        Defines the affine transform if source is an array
+
+    Returns
+    -------
+    tuple of float
+        left, right, bottom, top
     """
     if hasattr(source, 'bounds'):
         extent = (source.bounds.left, source.bounds.right,
@@ -184,7 +190,8 @@ def reshape_as_image(arr):
 
     Parameters
     ----------
-    source : array-like in a of format (bands, rows, columns)
+    arr : array-like of shape (bands, rows, columns)
+        image to reshape
     """
     # swap the axes order from (bands, rows, columns) to (rows, columns, bands)
     im = np.ma.transpose(arr, [1, 2, 0])
@@ -199,6 +206,7 @@ def reshape_as_raster(arr):
     Parameters
     ----------
     arr : array-like in the image form of (rows, columns, bands)
+        image to reshape
     """
     # swap the axes order from (rows, columns, bands) to (bands, rows, columns)
     im = np.transpose(arr, [2, 0, 1])
@@ -210,8 +218,9 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
 
     Parameters
     ----------
-    source : np.array or DatasetReader, rasterio.Band or tuple(dataset, bidx)
-        Input data to display.  The first three arrays in multi-dimensional
+    source : np.ndarray or DatasetReader or rasterio.Band or tuple(DatasetReader, bidx)
+        Input data to display.
+        The first three arrays in multi-dimensional
         arrays are plotted as red, green, and blue.
     bins : int, optional
         Compute histogram across N bins.

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -21,14 +21,14 @@ class _Collection(object):
 
     """For use with `rasterio.rio.helpers.write_features()`."""
 
-    def __init__(self, src, bidx, precision=6, geographic=True):
+    def __init__(self, dataset, bidx, precision=6, geographic=True):
 
         """Export raster dataset windows to GeoJSON polygon features.
 
         Parameters
         ----------
-        src : RasterReader
-            An open datasource.
+        dataset : DatasetReader
+            An open dataset.
         bidx : int
             Extract windows from this band.
         precision : int, optional
@@ -42,7 +42,7 @@ class _Collection(object):
             GeoJSON polygon feature.
         """
 
-        self._src = src
+        self._src = dataset
         self._bidx = bidx
         self._precision = precision
         self._geographic = geographic
@@ -130,7 +130,7 @@ def blocks(
     coordinate reference system.
 
     For more information on exactly what blocks and windows represent, see
-    'src.block_windows()'.
+    'dataset.block_windows()'.
     """
 
     dump_kwds = {'sort_keys': True}
@@ -149,7 +149,7 @@ def blocks(
             raise click.BadParameter("Not a valid band index")
 
         collection = _Collection(
-            src=src,
+            dataset=src,
             bidx=bidx,
             precision=precision,
             geographic=projection != 'projected')

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -27,19 +27,19 @@ class _Collection(object):
 
         Parameters
         ----------
-        dataset : DatasetReader
-            An open dataset.
+        dataset : a dataset object opened in 'r' mode
+            Source dataset
         bidx : int
-            Extract windows from this band.
+            Extract windows from this band
         precision : int, optional
-            Coordinate precision.
+            Coordinate precision
         geographic : bool, optional
-            Reproject geometries to ``EPSG:4326`` if ``True``.
+            Reproject geometries to ``EPSG:4326`` if ``True``
 
         Yields
         ------
         dict
-            GeoJSON polygon feature.
+            GeoJSON polygon feature
         """
 
         self._src = dataset

--- a/rasterio/rio/insp.py
+++ b/rasterio/rio/insp.py
@@ -36,12 +36,12 @@ Stats = collections.namedtuple('Stats', ['min', 'max', 'mean'])
 funcs = locals()
 
 
-def stats(source):
+def stats(dataset):
     """Return a tuple with raster min, max, and mean."""
-    if isinstance(source, tuple):
-        arr = source[0].read(source[1])
+    if isinstance(dataset, tuple):
+        arr = dataset[0].read(dataset[1])
     else:
-        arr = source
+        arr = dataset
     return Stats(np.min(arr), np.max(arr), np.mean(arr))
 
 

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -49,11 +49,11 @@ def merge(ctx, files, output, driver, bounds, res, nodata, force_overwrite,
         files=files, output=output, force_overwrite=force_overwrite)
 
     with ctx.obj['env']:
-        sources = [rasterio.open(f) for f in files]
-        dest, output_transform = merge_tool(sources, bounds=bounds, res=res,
+        datasets = [rasterio.open(f) for f in files]
+        dest, output_transform = merge_tool(datasets, bounds=bounds, res=res,
                                             nodata=nodata, precision=precision)
 
-        profile = sources[0].profile
+        profile = datasets[0].profile
         profile['transform'] = output_transform
         profile['height'] = dest.shape[1]
         profile['width'] = dest.shape[2]
@@ -66,7 +66,7 @@ def merge(ctx, files, output, driver, bounds, res, nodata, force_overwrite,
 
             # uses the colormap in the first input raster.
             try:
-                colormap = sources[0].colormap(1)
+                colormap = datasets[0].colormap(1)
                 dst.write_colormap(1, colormap)
             except ValueError:
                 pass

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -55,7 +55,7 @@ def sample(ctx, files, bidx):
     logger = logging.getLogger('rio')
 
     files = list(files)
-    source = files.pop(0)
+    source_path = files.pop(0)
     input = files.pop(0) if files else '-'
 
     # Handle the case of file, stream, or string input.
@@ -66,7 +66,7 @@ def sample(ctx, files, bidx):
 
     try:
         with ctx.obj['env']:
-            with rasterio.open(source) as src:
+            with rasterio.open(source_path) as src:
                 if bidx is None:
                     indexes = src.indexes
                 elif '..' in bidx:

--- a/rasterio/shutil.pyx
+++ b/rasterio/shutil.pyx
@@ -24,7 +24,7 @@ def exists(path):
     Parameters
     ----------
     path : str
-        Path to dataset.
+        Path to dataset
     """
 
     cdef GDALDatasetH h_dataset = NULL
@@ -54,17 +54,17 @@ def copy(src, dst, driver='GTiff', strict=True, **creation_options):
 
     Parameters
     ----------
-    src : str or rasterio.io.DatasetReader
-        Path to source dataset or open dataset handle.
+    src : str or dataset object opened in 'r' mode
+        Source dataset
     dst : str
-        Output dataset path.
+        Output dataset path
     driver : str, optional
-        Output driver name.
+        Output driver name
     strict : bool, optional.  Default: True
         Indicates if the output must be strictly equivalent or if the
-        driver may adapt as necessary.
+        driver may adapt as necessary
     creation_options : **kwargs, optional
-        Creation options for output dataset.
+        Creation options for output dataset
     """
 
     cdef bint c_strictness
@@ -125,9 +125,9 @@ def copyfiles(src, dst):
     Parameters
     ----------
     src : str
-        Source dataset.
+        Source dataset
     dst : str
-        Target dataset.
+        Target dataset
     """
 
     cdef GDALDatasetH h_dataset = NULL
@@ -161,15 +161,15 @@ def copyfiles(src, dst):
 @ensure_env
 def delete(path, driver=None):
 
-    """Delete a GDAL dataset.
+    """Delete a GDAL dataset
 
     Parameters
     ----------
     path : path
-        Path to dataset to delete.
+        Path to dataset to delete
     driver : str or None, optional
         Name of driver to use for deleting.  Defaults to whatever GDAL
-        determines is the appropriate driver.
+        determines is the appropriate driver
     """
 
     cdef GDALDatasetH h_dataset = NULL

--- a/tests/test_rio_blocks.py
+++ b/tests/test_rio_blocks.py
@@ -19,14 +19,14 @@ def check_features_block_windows(features, src, bidx):
     Parameters
     ----------
     features : iter
-        GeoJSON features.
-    src : DatasetReader
-        Open input datasource.
+        GeoJSON features
+    src : a dataset object opened in 'r' mode
+        Open input datasource
 
     Returns
     -------
     bool
-        ``True`` if the two block/window streams match and ``False`` otherwise.
+        ``True`` if the two block/window streams match and ``False`` otherwise
     """
 
     out = []

--- a/tests/test_rio_blocks.py
+++ b/tests/test_rio_blocks.py
@@ -20,7 +20,7 @@ def check_features_block_windows(features, src, bidx):
     ----------
     features : iter
         GeoJSON features.
-    src : RasterReader
+    src : DatasetReader
         Open input datasource.
 
     Returns

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -420,5 +420,5 @@ def test_merge_rgb(tmpdir):
 def test_merge_tiny_intres(tiffs):
     inputs = [str(x) for x in tiffs.listdir()]
     inputs.sort()
-    sources = [rasterio.open(x) for x in inputs]
-    merge(sources, res=2)
+    datasets = [rasterio.open(x) for x in inputs]
+    merge(datasets, res=2)


### PR DESCRIPTION
Addresses #1221 

- [x] Replace deprecated `RasterReader` with `DatasetReader` everywhere
- [x] Replace `sources` with `datasets`
- [x] Replace `source` with `dataset` where no distinction to `destination` is necessary
- [x] Clarify usage of `image`