### PR TITLE
Increase required GDAL to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
   matrix:
+    - GDALVERSION="1.10.1"
     - GDALVERSION="1.11.5"
     - GDALVERSION="2.0.3"
     - GDALVERSION="2.1.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - GDALINST=$HOME/gdalinstall
     - GDALBUILD=$HOME/gdalbuild
   matrix:
-    - GDALVERSION="1.10.1"
     - GDALVERSION="1.11.5"
     - GDALVERSION="2.0.3"
     - GDALVERSION="2.1.4"

--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ tamper with your system's Python.
 Dependencies
 ------------
 
-Rasterio has a C library dependency: GDAL >=1.10. GDAL itself depends on some other libraries provided by most major operating systems and also
+Rasterio has a C library dependency: GDAL >=1.11. GDAL itself depends on some other libraries provided by most major operating systems and also
 depends on the non standard GEOS and PROJ4 libraries. How to meet these
 requirement will be explained below.
 

--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ tamper with your system's Python.
 Dependencies
 ------------
 
-Rasterio has a C library dependency: GDAL >=1.9. GDAL itself depends on some other libraries provided by most major operating systems and also
+Rasterio has a C library dependency: GDAL >=1.10. GDAL itself depends on some other libraries provided by most major operating systems and also
 depends on the non standard GEOS and PROJ4 libraries. How to meet these
 requirement will be explained below.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 Dependencies
 ============
 
-Rasterio has one C library dependency: ``GDAL >=1.10``. GDAL itself depends on
+Rasterio has one C library dependency: ``GDAL >=1.11``. GDAL itself depends on
 many of other libraries provided by most major operating systems and also
 depends on the non standard GEOS and PROJ4 libraries.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 Dependencies
 ============
 
-Rasterio has one C library dependency: ``GDAL >=1.9``. GDAL itself depends on
+Rasterio has one C library dependency: ``GDAL >=1.10``. GDAL itself depends on
 many of other libraries provided by most major operating systems and also
 depends on the non standard GEOS and PROJ4 libraries.
 

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,10 @@ gdal_version_parts = gdalversion.split('.')
 gdal_major_version = int(gdal_version_parts[0])
 gdal_minor_version = int(gdal_version_parts[1])
 
+if gdal_major_version == 1 and gdal_minor_version < 10:
+    log.fatal("GDAL >= 1.10 is required for rasterio.  Please upgrade GDAL.")
+    sys.exit(1)
+
 # Conditionally copy the GDAL data. To be used in conjunction with
 # the bdist_wheel command to make self-contained binary wheels.
 if os.environ.get('PACKAGE_DATA'):
@@ -189,9 +193,6 @@ ext_options = {
     'libraries': libraries,
     'extra_link_args': extra_link_args,
     'define_macros': []}
-
-#        ('GDAL_MAJOR_VERSION', gdal_major_version),
-#        ('GDAL_MINOR_VERSION', gdal_minor_version)]}
 
 if not os.name == "nt":
     # These options fail on Windows if using Visual Studio

--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,7 @@ try:
     import numpy as np
     include_dirs.append(np.get_include())
 except ImportError:
-    log.critical("Numpy and its headers are required to run setup(). Exiting.")
-    sys.exit(1)
+    sys.exit("ERROR: Numpy and its headers are required to run setup().")
 
 try:
     gdal_config = os.environ.get('GDAL_CONFIG', 'gdal-config')
@@ -133,18 +132,17 @@ if '--gdalversion' in sys.argv:
              gdalversion)
 
 if not gdalversion:
-    log.fatal("A GDAL API version must be specified. Provide a path "
+    sys.exit("ERROR: A GDAL API version must be specified. Provide a path "
               "to gdal-config using a GDAL_CONFIG environment variable "
               "or use a GDAL_VERSION environment variable.")
-    sys.exit(1)
 
 gdal_version_parts = gdalversion.split('.')
 gdal_major_version = int(gdal_version_parts[0])
 gdal_minor_version = int(gdal_version_parts[1])
 
 if gdal_major_version == 1 and gdal_minor_version < 11:
-    log.fatal("GDAL >= 1.11 is required for rasterio.  Please upgrade GDAL.")
-    sys.exit(1)
+    sys.exit("ERROR: GDAL >= 1.11 is required for rasterio.  "
+             "Please upgrade GDAL.")
 
 # Conditionally copy the GDAL data. To be used in conjunction with
 # the bdist_wheel command to make self-contained binary wheels.
@@ -221,10 +219,9 @@ if os.path.exists("MANIFEST.in") and "clean" not in sys.argv:
     log.info("MANIFEST.in found, presume a repo, cythonizing...")
 
     if not cythonize:
-        log.critical(
-            "Cython.Build.cythonize not found. "
+        sys.exit(
+            "ERROR: Cython.Build.cythonize not found. "
             "Cython is required to build from a repo.")
-        sys.exit(1)
 
     # Copy the GDAL version-specific shim module to _shim.pyx.
     if gdal_major_version == 2 and gdal_minor_version >= 1:

--- a/setup.py
+++ b/setup.py
@@ -142,8 +142,8 @@ gdal_version_parts = gdalversion.split('.')
 gdal_major_version = int(gdal_version_parts[0])
 gdal_minor_version = int(gdal_version_parts[1])
 
-if gdal_major_version == 1 and gdal_minor_version < 10:
-    log.fatal("GDAL >= 1.10 is required for rasterio.  Please upgrade GDAL.")
+if gdal_major_version == 1 and gdal_minor_version < 11:
+    log.fatal("GDAL >= 1.11 is required for rasterio.  Please upgrade GDAL.")
     sys.exit(1)
 
 # Conditionally copy the GDAL data. To be used in conjunction with

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,10 +504,6 @@ requires_only_gdal1 = pytest.mark.skipif(
     gdal_version.major != 1,
     reason="Only relevant for GDAL 1.x")
 
-requires_less_than_gdal110 = pytest.mark.skipif(
-    gdal_version.at_least('1.10'),
-    reason="Requires GDAL 1.9.x or earlier")
-
 requires_gdal110 = pytest.mark.skipif(
     not gdal_version.at_least('1.10'),
     reason="Requires GDAL 1.10.x")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,10 +504,6 @@ requires_only_gdal1 = pytest.mark.skipif(
     gdal_version.major != 1,
     reason="Only relevant for GDAL 1.x")
 
-requires_gdal110 = pytest.mark.skipif(
-    not gdal_version.at_least('1.10'),
-    reason="Requires GDAL 1.10.x")
-
 requires_gdal2 = pytest.mark.skipif(
     not gdal_version.major >= 2,
     reason="Requires GDAL 2.x")

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -16,7 +16,7 @@ from rasterio.rio.edit_info import (
 from rasterio.rio.main import main_group
 import rasterio.shutil
 
-from .conftest import requires_gdal110, requires_less_than_gdal110, requires_gdal21
+from .conftest import requires_gdal110, requires_gdal21
 
 
 PARAM_HANDLER = {
@@ -66,21 +66,6 @@ def test_unset_crs(data):
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
         assert src.crs is None
-
-@requires_less_than_gdal110
-def test_unset_crs_gdal19(data):
-    """unsetting crs doesn't work for geotiff and gdal 1.9
-    and should emit an warning"""
-    runner = CliRunner()
-    inputfile = str(data.join('RGB.byte.tif'))
-    with rasterio.open(inputfile) as src:
-        orig_crs = src.crs
-    with pytest.warns(UserWarning):
-        result = runner.invoke(main_group,
-                               ['edit-info', inputfile, '--unset-crs'])
-    assert result.exit_code == 0
-    with rasterio.open(inputfile) as src:
-        assert src.crs == orig_crs  # nochange
 
 
 def test_edit_nodata_err(data):

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -16,7 +16,7 @@ from rasterio.rio.edit_info import (
 from rasterio.rio.main import main_group
 import rasterio.shutil
 
-from .conftest import requires_gdal110, requires_gdal21
+from .conftest import requires_gdal21
 
 
 PARAM_HANDLER = {
@@ -55,17 +55,6 @@ def test_delete_crs_exclusive_opts(data):
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--unset-crs', '--crs', 'epsg:4326'])
     assert result.exit_code == 2
-
-
-@requires_gdal110
-def test_unset_crs(data):
-    runner = CliRunner()
-    inputfile = str(data.join('RGB.byte.tif'))
-    result = runner.invoke(main_group,
-                           ['edit-info', inputfile, '--unset-crs'])
-    assert result.exit_code == 0
-    with rasterio.open(inputfile) as src:
-        assert src.crs is None
 
 
 def test_edit_nodata_err(data):

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -8,7 +8,7 @@ import rasterio
 from rasterio.rio.main import main_group
 from rasterio.env import GDALVersion
 
-from .conftest import requires_gdal110, requires_gdal21
+from .conftest import requires_gdal21
 
 
 with rasterio.Env() as env:
@@ -31,17 +31,6 @@ def test_delete_crs_exclusive_opts(data):
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--unset-crs', '--crs', 'epsg:4326'])
     assert result.exit_code == 2
-
-
-@requires_gdal110
-def test_unset_crs(data):
-    runner = CliRunner()
-    inputfile = str(data.join('RGB.byte.tif'))
-    result = runner.invoke(main_group,
-                           ['edit-info', inputfile, '--unset-crs'])
-    assert result.exit_code == 0
-    with rasterio.open(inputfile) as src:
-        assert src.crs is None
 
 
 def test_edit_nodata_err(data):

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -8,7 +8,7 @@ import rasterio
 from rasterio.rio.main import main_group
 from rasterio.env import GDALVersion
 
-from .conftest import requires_gdal110, requires_less_than_gdal110, requires_gdal21
+from .conftest import requires_gdal110, requires_gdal21
 
 
 with rasterio.Env() as env:
@@ -42,22 +42,6 @@ def test_unset_crs(data):
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
         assert src.crs is None
-
-
-@requires_less_than_gdal110
-def test_unset_crs_gdal19(data):
-    """unsetting crs doesn't work for geotiff and gdal 1.9
-    and should emit an warning"""
-    runner = CliRunner()
-    inputfile = str(data.join('RGB.byte.tif'))
-    with rasterio.open(inputfile) as src:
-        orig_crs = src.crs
-    with pytest.warns(UserWarning):
-        result = runner.invoke(main_group,
-                               ['edit-info', inputfile, '--unset-crs'])
-    assert result.exit_code == 0
-    with rasterio.open(inputfile) as src:
-        assert src.crs == orig_crs  # nochange
 
 
 def test_edit_nodata_err(data):

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -37,13 +37,9 @@ def flatten_coords(coordinates):
 def supported_resampling(method):
     if method == Resampling.gauss:
         return False
-    gdal110plus_only = (
-        Resampling.mode, Resampling.average)
     gdal2plus_only = (
         Resampling.max, Resampling.min, Resampling.med,
         Resampling.q1, Resampling.q3)
-    if not gdal_version.at_least('1.10'):
-        return method not in gdal2plus_only and method not in gdal110plus_only
     if not gdal_version.at_least('2.0'):
         return method not in gdal2plus_only
     return True


### PR DESCRIPTION
This resolves #1218 and starts to pave the way for more standardized handling of functionality with respect to GDAL version by eliminating early versions that do not support full use in `rasterio`.

This PR adds a check to `setup.py` that prevents installation with GDAL < 1.11.  This feels a bit bold to me, but the hope is that it prevents users from encountering errors due to running an unsupported version of GDAL.

This also removes tests for versions < 1.11 that are now no longer needed.