### PR TITLE
New decorator for requiring specific GDAL version

### DIFF
--- a/rasterio/compat.py
+++ b/rasterio/compat.py
@@ -12,6 +12,7 @@ if sys.version_info[0] >= 3:   # pragma: no cover
     import configparser
     from urllib.parse import urlparse
     from collections import UserDict
+    from inspect import getfullargspec as getargspec
 else:  # pragma: no cover
     string_types = basestring,
     text_type = unicode
@@ -20,3 +21,4 @@ else:  # pragma: no cover
     import ConfigParser as configparser
     from urlparse import urlparse
     from UserDict import UserDict
+    from inspect import getargspec

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -31,6 +31,11 @@ class Resampling(IntEnum):
     The subset of 'nearest', 'cubic', 'average', 'mode', and 'gauss'
     are available in making dataset overviews.
 
+    'max', 'min', 'med', 'q1', 'q3' are only supported in GDAL >= 2.0.0.
+
+    'nearest', 'bilinear', 'cubic', 'cubic_spline', 'lanczos', 'average', 'mode'
+    are always available (GDAL >= 1.10).
+
     Note: 'gauss' is not available to the functions in rio.warp.
     """
     nearest = 0

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -71,6 +71,10 @@ class GDALOptionNotImplementedError(RasterioError):
     by GDAL 1.x.
     """
 
+class GDALVersionError(RasterioError):
+    """Raised if the runtime version of GDAL does not meet the required
+    version of GDAL."""
+
 
 class WindowEvaluationError(ValueError):
     """Raised when window evaluation fails"""

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -15,7 +15,7 @@ from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
 from rasterio.transform import Affine
 from rasterio.warp import (
-    reproject, Resampling, transform_bounds,
+    reproject, Resampling, SUPPORTED_RESAMPLING, transform_bounds,
     calculate_default_transform as calcdt)
 
 
@@ -24,14 +24,6 @@ from rasterio.warp import (
 # datasets and raise a usage error if the limits are exceeded.
 MAX_OUTPUT_WIDTH = 100000
 MAX_OUTPUT_HEIGHT = 100000
-
-
-# supported methods are based on GDAL version.
-# 7 (Gauss) is not allowed for warp.
-supported_resampling_methods = [r.name for r in Resampling if r.value < 7]
-if GDALVersion.runtime().at_least('2.0'):
-    supported_resampling_methods.extend(
-        [r.name for r in Resampling if r.value > 7 and r <= 12])
 
 
 @click.command(short_help='Warp a raster dataset.')
@@ -56,7 +48,7 @@ if GDALVersion.runtime().at_least('2.0'):
     help="Determine output extent from destination bounds: left bottom right top")
 @options.resolution_opt
 @click.option('--resampling',
-              type=click.Choice(supported_resampling_methods),
+              type=click.Choice([r.name for r in SUPPORTED_RESAMPLING]),
               default='nearest', help="Resampling method.",
               show_default=True)
 @click.option('--src-nodata', default=None, show_default=True,

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -59,6 +59,10 @@ def transform(src_crs, dst_crs, xs, ys, zs=None):
 
 
 @ensure_env
+@require_gdal_version('2.1', param='antimeridian_cutting', values=[False],
+                      is_max_version=True,
+                      reason="Antimeridian cutting is always enabled on "
+                             "GDAL >= 2.2")
 def transform_geom(
         src_crs,
         dst_crs,
@@ -94,11 +98,6 @@ def transform_geom(
     out: GeoJSON like dict object
         Transformed geometry in GeoJSON dict format
     """
-
-    if (GDALVersion.runtime().at_least('2.2') and not antimeridian_cutting):
-        raise GDALBehaviorChangeException(
-            "Antimeridian cutting is always enabled on GDAL 2.2.0 or "
-            "newer, which could produce a different geometry than expected.")
 
     return _transform_geom(
         src_crs,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -539,10 +539,15 @@ def test_require_gdal_version_param_version_too_low():
     def a(foo=None):
         return foo
 
-    assert a() == None  # param can't be checked if not passed as a kwd
+    assert a() == None  # param is not used, OK
+    assert a(None) == None  # param is default, OK
+    assert a(foo=None) == None  # param is keyword with default, OK
+
+    with pytest.raises(GDALVersionError):
+        a("not None")  # parameter passed as a position argument and not default
 
     with pytest.raises(GDALVersionError) as exc_info:
-        a(foo='bar')
+        a(foo='bar')  # parameter passed as a keyword argument and not default
 
     message = 'usage of parameter "foo" requires GDAL >= {0}'.format(version)
     assert message in exc_info.value.args[0]
@@ -556,7 +561,12 @@ def test_require_gdal_version_param_version_too_high():
     def a(foo=None):
         return foo
 
-    assert a() == None  # param can't be checked if not passed as a kwd
+    assert a() == None  # param is not used, OK
+    assert a(None) == None  # param is default, OK
+    assert a(foo=None) == None  # param is keyword with default, OK
+
+    with pytest.raises(GDALVersionError):
+        a("not None")
 
     with pytest.raises(GDALVersionError) as exc_info:
         a(foo='bar')
@@ -574,6 +584,7 @@ def test_require_gdal_version_param_values():
             return foo
 
         assert a() == None
+        assert a('bar') == 'bar'
         assert a(foo='bar') == 'bar'
 
 
@@ -600,7 +611,8 @@ def test_require_gdal_version_param_values_version_too_low():
     def a(foo=None):
         return foo
 
-    assert a(foo='ok') == 'ok'  # param value allowed if not in values
+    assert a('ok') == 'ok'  # param value allowed if not in values
+    assert a(foo='ok') == 'ok'
 
     with pytest.raises(GDALVersionError) as exc_info:
         a(foo='bar')
@@ -618,6 +630,9 @@ def test_require_gdal_version_param_values_version_too_high():
         return foo
 
     assert a(foo='ok') == 'ok'  # param value allowed if not in values
+
+    with pytest.raises(GDALVersionError):
+        a('bar')
 
     with pytest.raises(GDALVersionError) as exc_info:
         a(foo='bar')

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -10,8 +10,11 @@ import numpy as np
 import pytest
 
 import rasterio
+from rasterio.env import GDALVersion
 from rasterio.rio import warp
 from rasterio.rio.main import main_group
+
+from .test_warp import supported_resampling, not_yet_supported_resampling
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -27,9 +30,6 @@ def test_dst_crs_error(runner, tmpdir):
     assert 'for dst_crs: crs appears to be JSON but is not' in result.output
 
 
-@pytest.mark.xfail(
-    os.environ.get('GDALVERSION', 'a.b.c').startswith('1.9'),
-    reason="GDAL 1.9 doesn't catch this error")
 def test_dst_crs_error_2(runner, tmpdir):
     """Invalid PROJ.4 is a bad parameter."""
     srcname = 'tests/data/RGB.byte.tif'
@@ -534,3 +534,36 @@ def test_warp_vrt_gcps(runner, tmpdir):
         assert not data[:, 0, -1].any()
         assert not data[:, -1, -1].any()
         assert not data[:, -1, 0].any()
+
+
+@pytest.mark.parametrize("method", supported_resampling)
+def test_warp_resampling(runner, path_rgb_byte_tif, tmpdir, method):
+    """Resampling methods supported by this version of GDAL should run
+    successfully"""
+
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(main_group, [
+        'warp', path_rgb_byte_tif, outputname,
+        '--dst-crs', 'epsg:3857',
+        '--resampling', method.name])
+
+    print(result.output)
+    assert result.exit_code == 0
+
+
+@pytest.mark.skipif(
+    GDALVersion.runtime().at_least('2.0'),
+    reason="Tests resampling methods only available in GDAL >= 2.0")
+@pytest.mark.parametrize("method", not_yet_supported_resampling)
+def test_warp_resampling_not_yet_supported(
+        runner, path_rgb_byte_tif, tmpdir, method):
+    """Resampling methods not yet supported should fail with error"""
+
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(main_group, [
+        'warp', path_rgb_byte_tif, outputname,
+        '--dst-crs', 'epsg:3857',
+        '--resampling', method.name])
+
+    assert result.exit_code == 2
+    assert 'Invalid value for "--resampling"' in result.output

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -11,10 +11,9 @@ import pytest
 
 import rasterio
 from rasterio.env import GDALVersion
+from rasterio.warp import SUPPORTED_RESAMPLING, GDAL2_RESAMPLING
 from rasterio.rio import warp
 from rasterio.rio.main import main_group
-
-from .test_warp import supported_resampling, not_yet_supported_resampling
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -536,7 +535,7 @@ def test_warp_vrt_gcps(runner, tmpdir):
         assert not data[:, -1, 0].any()
 
 
-@pytest.mark.parametrize("method", supported_resampling)
+@pytest.mark.parametrize("method", SUPPORTED_RESAMPLING)
 def test_warp_resampling(runner, path_rgb_byte_tif, tmpdir, method):
     """Resampling methods supported by this version of GDAL should run
     successfully"""
@@ -553,8 +552,8 @@ def test_warp_resampling(runner, path_rgb_byte_tif, tmpdir, method):
 
 @pytest.mark.skipif(
     GDALVersion.runtime().at_least('2.0'),
-    reason="Tests resampling methods only available in GDAL >= 2.0")
-@pytest.mark.parametrize("method", not_yet_supported_resampling)
+    reason="Test only applicable to GDAL < 2.0")
+@pytest.mark.parametrize("method", GDAL2_RESAMPLING)
 def test_warp_resampling_not_yet_supported(
         runner, path_rgb_byte_tif, tmpdir, method):
     """Resampling methods not yet supported should fail with error"""

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -17,6 +17,9 @@ from rasterio.warp import (
     calculate_default_transform, SUPPORTED_RESAMPLING, GDAL2_RESAMPLING)
 from rasterio import windows
 
+from .conftest import requires_gdal22
+
+
 gdal_version = GDALVersion.runtime()
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
@@ -1091,8 +1094,7 @@ def test_reproject_gcps(rgb_byte_profile):
     assert not out[:, -1, 0].any()
 
 
-@pytest.mark.skipif(
-    not gdal_version.at_least('2.2'),
+@requires_gdal22(
     reason="GDAL 2.2.0 and newer has different antimeridian cutting behavior.")
 def test_transform_geom_gdal22():
     """Enabling `antimeridian_cutting` has no effect on GDAL 2.2.0 or newer
@@ -1103,7 +1105,7 @@ def test_transform_geom_gdal22():
         'type': 'Point',
         'coordinates': [0, 0]
     }
-    with pytest.raises(GDALBehaviorChangeException):
+    with pytest.raises(GDALVersionError):
         transform_geom(
             'EPSG:4326', 'EPSG:3857', geom, antimeridian_cutting=False)
 


### PR DESCRIPTION
Resolves #1208

This introduces a new decorator for functions to require at least a certain version of GDAL: `@require_gdal_version`, and applied it to `reproject` to ensure that resampling methods not yet supported by the runtime version of GDAL (if <2.0) raise an appropriate exception.  If we like this approach, we can introduce this in other places where we need to guard certain functions, parameters, or parameter values for specific versions of GDAL.

Introduces a new error `GDALVersionError` to indicate cases where the runtime version of GDAL is not sufficient.

Some filtering of the `Resampling` enum is used to limit the choices of resampling methods offered to the user by `rio warp` so that they are only those supported by their runtime version of GDAL.

Added more `reproject` tests to make sure that all supported resampling methods work properly, and all not yet supported methods raise `GDALVersionError`.

Also includes a small amount of refactoring of `GDALVersion` to consolidate methods.



