### PR TITLE
[WIP] Add C++11 flag when compiling against GDAL>=2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,6 +197,20 @@ if not os.name == "nt":
     ext_options['extra_compile_args'] = ['-Wno-unused-parameter',
                                          '-Wno-unused-function']
 
+
+# GDAL 2.3 and newer requires C++11
+if (gdal_major_version, gdal_minor_version) >= (2, 3):
+    cpp11_flag = '-std=c++11'
+
+    # 'extra_compile_args' may not be defined
+    eca = ext_options.get('extra_compile_args', [])
+    eca.append(cpp11_flag)
+    ext_options['extra_compile_args'] = eca
+
+    # Link args are always defined
+    ext_options['extra_link_args'].append(cpp11_flag)
+
+
 cythonize_options = {}
 if os.environ.get('CYTHON_COVERAGE'):
     cythonize_options['compiler_directives'] = {'linetrace': True}


### PR DESCRIPTION
**This PR cannot be merged unless the GDAL trunk tests on Travis pass.**

Closes #1230 

I don't know a lot about compiling C++, but [StackOverflow](https://stackoverflow.com/questions/19246783/are-c11-containers-supported-by-cython) suggests this is all we need to do.  I ran some local tests against a version of GDAL pretty close to trunk and hit some failures, but they may just be GDAL changes.  I'll investigate.