### PR TITLE
add indexes / bidx parameter to merge

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -218,7 +218,7 @@ cdef class DatasetReaderBase(DatasetBase):
         # Check each index before processing 3D array
         for bidx in indexes:
             if bidx not in self.indexes:
-                raise IndexError("band index {} out of range".format(bidx))
+                raise IndexError("band index {} out of range (not in {})".format(bidx, self.indexes))
             idx = self.indexes.index(bidx)
 
             dtype = self.dtypes[idx]
@@ -1264,7 +1264,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         # Check each index before processing 3D array
         for bidx in indexes:
             if bidx not in self.indexes:
-                raise IndexError("band index {} out of range".format(bidx))
+                raise IndexError("band index {} out of range (not in {})".format(bidx, self.indexes))
             idx = self.indexes.index(bidx)
             check_dtypes.add(self.dtypes[idx])
         if len(check_dtypes) > 1:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -209,7 +209,7 @@ cdef class DatasetReaderBase(DatasetBase):
         # Check each index before processing 3D array
         for bidx in indexes:
             if bidx not in self.indexes:
-                raise IndexError("band index out of range")
+                raise IndexError("band index {} out of range".format(bidx))
             idx = self.indexes.index(bidx)
 
             dtype = self.dtypes[idx]
@@ -1245,7 +1245,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         # Check each index before processing 3D array
         for bidx in indexes:
             if bidx not in self.indexes:
-                raise IndexError("band index out of range")
+                raise IndexError("band index {} out of range".format(bidx))
             idx = self.indexes.index(bidx)
             check_dtypes.add(self.dtypes[idx])
         if len(check_dtypes) > 1:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1258,7 +1258,8 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             src = np.array([src])
         if len(src.shape) != 3 or src.shape[0] != len(indexes):
             raise ValueError(
-                "Source shape is inconsistent with given indexes")
+                "Source shape {} is inconsistent with given indexes {}"
+                .format(src.shape, len(indexes)))
 
         check_dtypes = set()
         # Check each index before processing 3D array

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -15,7 +15,7 @@ from rasterio.transform import Affine
 logger = logging.getLogger(__name__)
 
 
-def merge(sources, bounds=None, res=None, nodata=None, precision=7):
+def merge(sources, bounds=None, res=None, nodata=None, precision=7, indexes=None):
     """Copy valid pixels from input files to an output file.
 
     All files must have the same number of bands, data type, and
@@ -43,6 +43,8 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
     nodata: float, optional
         nodata value to use in output file. If not set, uses the nodata value
         in the first input raster.
+    indexes : list of ints or a single int, optional
+        bands to read and merge
 
     Returns
     -------
@@ -51,7 +53,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         Two elements:
 
             dest: numpy ndarray
-                Contents of all input rasters in single array.
+                Contents of all input rasters in single array
 
             out_transform: affine.Affine()
                 Information for mapping pixel coordinates in `dest` to another
@@ -62,11 +64,19 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
     nodataval = first.nodatavals[0]
     dtype = first.dtypes[0]
 
-    # Extent from option or extent of all inputs.
+    # Determine output band count
+    if indexes is None:
+        output_count = first.count
+    elif isinstance(indexes, int):
+        output_count = 1
+    else:
+        output_count = len(indexes)
+
+    # Extent from option or extent of all inputs
     if bounds:
         dst_w, dst_s, dst_e, dst_n = bounds
     else:
-        # scan input files.
+        # scan input files
         xs = []
         ys = []
         for src in sources:
@@ -79,7 +89,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
     output_transform = Affine.translation(dst_w, dst_n)
     logger.debug("Output transform, before scaling: %r", output_transform)
 
-    # Resolution/pixel size.
+    # Resolution/pixel size
     if not res:
         res = first_res
     elif not np.iterable(res):
@@ -90,24 +100,24 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
     logger.debug("Output transform, after scaling: %r", output_transform)
 
     # Compute output array shape. We guarantee it will cover the output
-    # bounds completely.
+    # bounds completely
     output_width = int(math.ceil((dst_e - dst_w) / res[0]))
     output_height = int(math.ceil((dst_n - dst_s) / res[1]))
 
-    # Adjust bounds to fit.
+    # Adjust bounds to fit
     dst_e, dst_s = output_transform * (output_width, output_height)
     logger.debug("Output width: %d, height: %d", output_width, output_height)
     logger.debug("Adjusted bounds: %r", (dst_w, dst_s, dst_e, dst_n))
 
     # create destination array
-    dest = np.zeros((first.count, output_height, output_width), dtype=dtype)
+    dest = np.zeros((output_count, output_height, output_width), dtype=dtype)
 
     if nodata is not None:
         nodataval = nodata
         logger.debug("Set nodataval: %r", nodataval)
 
     if nodataval is not None:
-        # Only fill if the nodataval is within dtype's range.
+        # Only fill if the nodataval is within dtype's range
         inrange = False
         if np.dtype(dtype).kind in ('i', 'u'):
             info = np.iinfo(dtype)
@@ -134,7 +144,7 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         # This approach uses the maximum amount of memory to solve the
         # problem. Making it more efficient is a TODO.
 
-        # 1. Compute spatial intersection of destination and source.
+        # 1. Compute spatial intersection of destination and source
         src_w, src_s, src_e, src_n = src.bounds
 
         int_w = src_w if src_w > dst_w else dst_w
@@ -142,28 +152,25 @@ def merge(sources, bounds=None, res=None, nodata=None, precision=7):
         int_e = src_e if src_e < dst_e else dst_e
         int_n = src_n if src_n < dst_n else dst_n
 
-        # 2. Compute the source window.
+        # 2. Compute the source window
         src_window = windows.from_bounds(
             int_w, int_s, int_e, int_n, src.transform)
         logger.debug("Src %s window: %r", src.name, src_window)
 
         src_window = src_window.round_shape()
 
-        # 3. Compute the destination window.
+        # 3. Compute the destination window
         dst_window = windows.from_bounds(
             int_w, int_s, int_e, int_n, output_transform)
 
-        # 4. Initialize temp array.
-        tcount = first.count
+        # 4. Read data in source window into temp
         trows, tcols = (
             int(round(dst_window.height)), int(round(dst_window.width)))
-
-        temp_shape = (tcount, trows, tcols)
-
+        temp_shape = (output_count, trows, tcols)
         temp = src.read(out_shape=temp_shape, window=src_window,
-                        boundless=False, masked=True)
+                        boundless=False, masked=True, indexes=indexes)
 
-        # 5. Copy elements of temp into dest.
+        # 5. Copy elements of temp into dest
         roff, coff = (
             int(round(dst_window.row_off)), int(round(dst_window.col_off)))
 

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -40,8 +40,6 @@ def merge(ctx, files, output, driver, bounds, res, nodata, bidx, force_overwrite
 
     Note: --res changed from 2 parameters in 0.25.
 
-    Note: --bidx advanced usage: please see rio stack --help
-
     \b
       --res 0.1 0.1  => --res 0.1 (square)
       --res 0.1 0.2  => --res 0.1 --res 0.2  (rectangular)

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -54,7 +54,8 @@ def merge(ctx, files, output, driver, bounds, res, nodata, bidx, force_overwrite
     with ctx.obj['env']:
         sources = [rasterio.open(f) for f in files]
         dest, output_transform = merge_tool(sources, bounds=bounds, res=res,
-                                            nodata=nodata, precision=precision, indexes=bidx)
+                                            nodata=nodata, precision=precision,
+                                            indexes=(bidx or None))
 
         profile = sources[0].profile
         profile['transform'] = output_transform

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -16,13 +16,14 @@ from rasterio.rio.helpers import resolve_inout
 @options.bounds_opt
 @options.resolution_opt
 @options.nodata_opt
+@options.bidx_mult_opt
 @options.force_overwrite_opt
 @click.option('--precision', type=int, default=7,
               help="Number of decimal places of precision in alignment of "
                    "pixels")
 @options.creation_options
 @click.pass_context
-def merge(ctx, files, output, driver, bounds, res, nodata, force_overwrite,
+def merge(ctx, files, output, driver, bounds, res, nodata, bidx, force_overwrite,
           precision, creation_options):
     """Copy valid pixels from input files to an output file.
 
@@ -39,6 +40,8 @@ def merge(ctx, files, output, driver, bounds, res, nodata, force_overwrite,
 
     Note: --res changed from 2 parameters in 0.25.
 
+    Note: --bidx advanced usage: please see rio stack --help
+
     \b
       --res 0.1 0.1  => --res 0.1 (square)
       --res 0.1 0.2  => --res 0.1 --res 0.2  (rectangular)
@@ -51,7 +54,7 @@ def merge(ctx, files, output, driver, bounds, res, nodata, force_overwrite,
     with ctx.obj['env']:
         sources = [rasterio.open(f) for f in files]
         dest, output_transform = merge_tool(sources, bounds=bounds, res=res,
-                                            nodata=nodata, precision=precision)
+                                            nodata=nodata, precision=precision, indexes=bidx)
 
         profile = sources[0].profile
         profile['transform'] = output_transform

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -60,6 +60,7 @@ def merge(ctx, files, output, driver, bounds, res, nodata, bidx, force_overwrite
         profile['height'] = dest.shape[1]
         profile['width'] = dest.shape[2]
         profile['driver'] = driver
+        profile['count'] = dest.shape[0]
 
         profile.update(**creation_options)
 

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -222,6 +222,12 @@ bidx_opt = click.option(
 
 bidx_mult_opt = click.option(
     '-b', '--bidx',
+    type=int,
+    multiple=True,
+    help="Indexes of input file bands.")
+
+bidx_magic_opt = click.option(
+    '-b', '--bidx',
     multiple=True,
     help="Indexes of input file bands.")
 

--- a/rasterio/rio/stack.py
+++ b/rasterio/rio/stack.py
@@ -17,7 +17,7 @@ from rasterio.rio.helpers import resolve_inout
 @files_inout_arg
 @options.output_opt
 @format_opt
-@options.bidx_mult_opt
+@options.bidx_magic_opt
 @options.rgb_opt
 @options.force_overwrite_opt
 @options.creation_options

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -73,6 +73,33 @@ def test_data_dir_2(tmpdir):
     return tmpdir
 
 
+@fixture(scope='function')
+def test_data_dir_3(tmpdir):
+    kwargs = {
+        "crs": {'init': 'epsg:4326'},
+        "transform": affine.Affine(0.2, 0, -114,
+                                   0, -0.2, 46),
+        "count": 2,  # important: band count > 1
+        "dtype": rasterio.uint8,
+        "driver": "GTiff",
+        "width": 10,
+        "height": 10,
+        "nodata": 1
+    }
+
+    with rasterio.open(str(tmpdir.join('b.tif')), 'w', **kwargs) as dst:
+        data = np.ones((2, 10, 10), dtype=rasterio.uint8)
+        data[:, 0:6, 0:6] = 255
+        dst.write(data, indexes=1)
+
+    with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
+        data = np.ones((2, 10, 10), dtype=rasterio.uint8)
+        data[:, 4:8, 4:8] = 254
+        dst.write(data, indexes=[1, 2])
+
+    return tmpdir
+
+
 def test_merge_with_colormap(test_data_dir_1):
     outputname = str(test_data_dir_1.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_1.listdir()]
@@ -123,6 +150,21 @@ def test_merge_warn(test_data_dir_1):
     assert result.exit_code == 0
     assert '--nodata option for better results' in warnings[0].message.args[0]
     assert os.path.exists(outputname)
+
+
+def test_merge_bidx(test_data_dir_3):
+    outputname = str(test_data_dir_3.join('merged.tif'))
+    inputs = [str(x) for x in test_data_dir_3.listdir()]
+    inputs.sort()
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group, ['merge'] + inputs + [outputname] + ['--bidx', '1'])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+    with rasterio.open(inputs[0]) as src:
+        assert src.count > 1
+    with rasterio.open(outputname) as out:
+        assert out.count == 1
 
 
 @requires_gdal22(

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -90,12 +90,12 @@ def test_data_dir_3(tmpdir):
     with rasterio.open(str(tmpdir.join('b.tif')), 'w', **kwargs) as dst:
         data = np.ones((2, 10, 10), dtype=rasterio.uint8)
         data[:, 0:6, 0:6] = 255
-        dst.write(data, indexes=1)
+        dst.write(data)
 
     with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
         data = np.ones((2, 10, 10), dtype=rasterio.uint8)
         data[:, 4:8, 4:8] = 254
-        dst.write(data, indexes=[1, 2])
+        dst.write(data)
 
     return tmpdir
 

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -90,12 +90,12 @@ def test_data_dir_3(tmpdir):
     with rasterio.open(str(tmpdir.join('b.tif')), 'w', **kwargs) as dst:
         data = np.ones((2, 10, 10), dtype=rasterio.uint8)
         data[:, 0:6, 0:6] = 255
-        dst.write(data)
+        dst.write(data, indexes=1)
 
     with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
         data = np.ones((2, 10, 10), dtype=rasterio.uint8)
         data[:, 4:8, 4:8] = 254
-        dst.write(data)
+        dst.write(data, indexes=[1, 2])
 
     return tmpdir
 


### PR DESCRIPTION
Sorry for bombarding you with PRs... 

This one adds the `indexes` parameter to `rasterio.merge.merge`, equivalent to the PR you just merged for `rasterio.mask.mask` (#1225).

I also added the functionality to `rio merge` as a `--bidx` parameter.