### PR TITLE
Fix link to TravisCI CloudFormation IAM template

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -16,5 +16,5 @@ key like so:
   $ AWS_ACCESS_KEY_ID=ID AWS_SECRET_ACCESS_KEY=KEY python -m pytest
 
 The key used for Travis is generated using the Amazon CloudFormation template at
-https://github.com/mapbox/rasterio/blob/master/cloudformation/testuser.json. If you had to fork
+https://github.com/mapbox/rasterio/blob/master/cloudformation/travis.template. If you had to fork
 Rasterio and run your own tests, you could `use this template <http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html>`__ to create your own IAM user and get a new key from your stack's "Outputs" field.


### PR DESCRIPTION
Fix link to TravisCI CloudFormation IAM template in tests README.