### PR TITLE
resampling when boundless reading from a WarpedVRT

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -364,7 +364,8 @@ cdef class DatasetReaderBase(DatasetBase):
                     dst_crs=self.crs,
                     dst_width=max(self.width, window.width) + 1,
                     dst_height=max(self.height, window.height) + 1,
-                    dst_transform=self.window_transform(window)) as vrt:
+                    dst_transform=self.window_transform(window),
+                    resampling=resampling) as vrt:
                 out = vrt._read(
                     indexes,
                     out,
@@ -382,7 +383,8 @@ cdef class DatasetReaderBase(DatasetBase):
                             mask,
                             Window(0, 0, window.width, window.height),
                             None,
-                            masks=True).astype('bool')
+                            masks=True,
+                            resampling=resampling).astype('bool')
 
                     kwds = {'mask': mask}
                     # Set a fill value only if the read bands share a

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -357,11 +357,13 @@ cdef class DatasetReaderBase(DatasetBase):
                     dst_crs=self.crs,
                     dst_width=max(self.width, window.width) + 1,
                     dst_height=max(self.height, window.height) + 1,
-                    dst_transform=self.window_transform(window),
-                    resampling=resampling) as vrt:
+                    dst_transform=self.window_transform(window)) as vrt:
                 out = vrt._read(
-                    indexes, out, Window(0, 0, window.width, window.height),
-                    None)
+                    indexes,
+                    out,
+                    Window(0, 0, window.width, window.height),
+                    None,
+                    resampling=resampling)
 
                 if masked:
                     if all_valid:
@@ -369,7 +371,11 @@ cdef class DatasetReaderBase(DatasetBase):
                     else:
                         mask = np.zeros(out.shape, 'uint8')
                         mask = ~vrt._read(
-                            indexes, mask, Window(0, 0, window.width, window.height), None, masks=True).astype('bool')
+                            indexes,
+                            mask,
+                            Window(0, 0, window.width, window.height),
+                            None,
+                            masks=True).astype('bool')
 
                     kwds = {'mask': mask}
                     # Set a fill value only if the read bands share a


### PR DESCRIPTION
As described in #1206, when using ``read()`` with ``boundless=True`` and a window the ``resampling`` method from the initialized ``WarpedVRT`` is not passed on, so it falls back to ``nearest``. This PR contains the fix & a test asserting the correct behavior.

However, it is a bit unclear to me how ``resampling`` should be used as there are two ways to apply it: when initializing ``WarpedVRT`` as well as calling ``read()``. The latter one though doesn't seem to have any effect, see the [uncommented test](https://github.com/ungarj/rasterio/commit/7f3200b4d6b737f1a96c8a0bc035843160659ed8#diff-e2937f93425979eec69dffba64475224R112) which fails when activated. It seems ``resampling`` gets omitted if its only set in ``read()`` and I guess this is not an intended behavior.

Is there any internal caching when reading multiple times? If so, it wouldn't make sense to have a ``resampling`` keyword in ``read()`` because there could be data cached which was resampled using a different method.

So, I see 3 options here:
1) ``resampling`` should only be set when initializing a ``WarpedVRT``
2) ``resampling`` should only be set when calling ``read()``
3) ``resampling`` could be set in both, but ``read()`` would overrule the VRT setting

Because ``resampling`` is also a property of ``WarpedVRT``, I think the most explicit way is to go with option 1 because then it is clear from the beginning which resampling is used with the current ``WarpedVRT`` object. This would also mean to omit the ``resampling`` keyword in ``read()`` where we could raise a deprecation warning.

What do you think?