### PR TITLE
Boundless reads that don't alter pixels

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -24,6 +24,7 @@ Submodules
    rasterio.sample
    rasterio.transform
    rasterio.vfs
+   rasterio.vrt
    rasterio.warp
    rasterio.windows
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -358,10 +358,10 @@ cdef class DatasetReaderBase(DatasetBase):
                     dst_width=max(self.width, window.width) + 1,
                     dst_height=max(self.height, window.height) + 1,
                     dst_transform=self.window_transform(window),
-                    resampling=resampling) as vrt:
+                    resampling=Resampling.nearest) as vrt:
                 out = vrt._read(
                     indexes, out, Window(0, 0, window.width, window.height),
-                    None)
+                    None, resampling=resampling)
 
                 if masked:
                     if all_valid:
@@ -504,10 +504,10 @@ cdef class DatasetReaderBase(DatasetBase):
                     dst_width=max(self.width, window.width) + 1,
                     dst_height=max(self.height, window.height) + 1,
                     dst_transform=self.window_transform(window),
-                    resampling=resampling) as vrt:
+                    resampling=Resampling.nearest) as vrt:
                 out = vrt._read(
                     indexes, out, Window(0, 0, window.width, window.height),
-                    None, masks=True)
+                    None, resampling=resampling, masks=True)
 
         if return2d:
             out.shape = out.shape[1:]

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -122,7 +122,10 @@ cdef class DatasetReaderBase(DatasetBase):
     def read(self, indexes=None, out=None, window=None, masked=False,
             out_shape=None, boundless=False, resampling=Resampling.nearest,
             fill_value=None):
-        """Read raster bands as a multidimensional array
+        """Read a dataset's raw pixels as an N-d array
+
+        This data is read from the dataset's band cache, which means
+        that repeated reads of the same windows may avoid I/O.
 
         Parameters
         ----------
@@ -169,6 +172,12 @@ cdef class DatasetReaderBase(DatasetBase):
             If `True`, windows that extend beyond the dataset's extent
             are permitted and partially or completely filled arrays will
             be returned as appropriate.
+
+        resampling : Resampling
+            By default, pixel values are read raw or interpolated using
+            a nearest neighbor algorithm from the band cache. Other
+            resampling algorithms may be specified. Resampled pixels
+            are not cached.
 
         fill_value : scalar
             Fill value applied in the `boundless=True` case only.
@@ -389,6 +398,9 @@ cdef class DatasetReaderBase(DatasetBase):
                    boundless=False, resampling=Resampling.nearest):
         """Read raster band masks as a multidimensional array
 
+        This data is read from the dataset's band cache, which means
+        that repeated reads of the same windows may avoid I/O.
+
         Parameters
         ----------
         indexes : list of ints or a single int, optional
@@ -424,6 +436,12 @@ cdef class DatasetReaderBase(DatasetBase):
             If `True`, windows that extend beyond the dataset's extent
             are permitted and partially or completely filled arrays will
             be returned as appropriate.
+
+        resampling : Resampling
+            By default, pixel values are read raw or interpolated using
+            a nearest neighbor algorithm from the band cache. Other
+            resampling algorithms may be specified. Resampled pixels
+            are not cached.
 
         Returns
         -------

--- a/tests/test_boundless_read.py
+++ b/tests/test_boundless_read.py
@@ -7,6 +7,7 @@ from rasterio.windows import Window
 
 
 def test_pixel_fidelity(path_rgb_byte_tif):
+    """Boundless read doesn't change pixels"""
     with rasterio.open(path_rgb_byte_tif) as dataset:
         rgb = dataset.read()
         rgb_padded = dataset.read(window=Window(-100, -100, dataset.width + 200, dataset.height + 200), boundless=True)

--- a/tests/test_boundless_read.py
+++ b/tests/test_boundless_read.py
@@ -1,15 +1,19 @@
 """Test of boundless reads"""
 
+from hypothesis import given
+import hypothesis.strategies as st
 import numpy
 
 import rasterio
 from rasterio.windows import Window
 
 
-def test_pixel_fidelity(path_rgb_byte_tif):
-    """Boundless read doesn't change pixels"""
+@given(st.integers(min_value=0, max_value=700))
+def test_outer_boundless_pixel_fidelity(size):
+    """An outer boundless read doesn't change pixels"""
+    path_rgb_byte_tif = 'tests/data/RGB.byte.tif'
     with rasterio.open(path_rgb_byte_tif) as dataset:
         rgb = dataset.read()
-        rgb_padded = dataset.read(window=Window(-100, -100, dataset.width + 200, dataset.height + 200), boundless=True)
-
-    assert numpy.all(rgb == rgb_padded[:, 100:-100, 100:-100])
+        rgb_padded = dataset.read(window=Window(-size, -size, dataset.width + 2 * size, dataset.height + 2 * size), boundless=True)
+        assert rgb_padded.shape == (3, dataset.height + 2 * size, dataset.width + 2 * size)
+    assert numpy.all(rgb == rgb_padded[:, size:(-size or None), size:(-size or None)])

--- a/tests/test_boundless_read.py
+++ b/tests/test_boundless_read.py
@@ -1,0 +1,14 @@
+"""Test of boundless reads"""
+
+import numpy
+
+import rasterio
+from rasterio.windows import Window
+
+
+def test_pixel_fidelity(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as dataset:
+        rgb = dataset.read()
+        rgb_padded = dataset.read(window=Window(-100, -100, dataset.width + 200, dataset.height + 200), boundless=True)
+
+    assert numpy.all(rgb == rgb_padded[:, 100:-100, 100:-100])


### PR DESCRIPTION
I'm proposing a new test of boundless reads. The test asserts that a boundless read with no resampling (nearest neighbor, in other words) from our testing dataset gives the same results as a not-boundless read. For example, do boundless read with a window 1 pixel larger on every side. We expect that the interior of this read would be the same as a not-boundless read.

The `WarpedVRT` usage change is adapted from #1238. @ungarj: could you check this out and let me know if it matches your expectations?