### PR TITLE
support writing windowed internal masks

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -15,7 +15,7 @@ import numpy as np
 from rasterio._base import tastes_like_gdal
 from rasterio._env import driver_count, GDALEnv
 from rasterio._err import (
-    GDALError, CPLE_OpenFailedError, CPLE_IllegalArgError)
+    GDALError, CPLE_OpenFailedError, CPLE_IllegalArgError, CPLE_BaseError)
 from rasterio.crs import CRS
 from rasterio.compat import text_type, string_types
 from rasterio import dtypes
@@ -1462,12 +1462,12 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             try:
                 exc_wrap_int(GDALCreateMaskBand(band, MaskFlags.per_dataset))
                 log.debug("Created mask band")
-            except:
+            except CPLE_BaseError:
                 raise RasterioIOError("Failed to create mask.")
 
         try:
             mask = exc_wrap_pointer(GDALGetMaskBand(band))
-        except:
+        except CPLE_BaseError:
             raise RasterioIOError("Failed to get mask.")
 
         if window:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1458,10 +1458,15 @@ cdef class DatasetWriterBase(DatasetReaderBase):
 
         band = self.band(1)
 
+        if not all(MaskFlags.per_dataset in flags for flags in self.mask_flag_enums):
+            try:
+                exc_wrap_int(GDALCreateMaskBand(band, MaskFlags.per_dataset))
+                log.debug("Created mask band")
+            except:
+                raise RasterioIOError("Failed to create mask.")
+
         try:
-            exc_wrap_int(GDALCreateMaskBand(band, 0x02))
             mask = exc_wrap_pointer(GDALGetMaskBand(band))
-            log.debug("Created mask band")
         except:
             raise RasterioIOError("Failed to get mask.")
 

--- a/tests/test_mask_creation.py
+++ b/tests/test_mask_creation.py
@@ -2,7 +2,6 @@
 Tests of band mask creation, both .msk sidecar and internal.
 """
 
-import pytest
 import rasterio
 from rasterio.enums import MaskFlags
 
@@ -63,11 +62,8 @@ def test_create_mask_windowed_sidecar(data):
                 dst.write_mask(mask, window=window)
 
 
-@pytest.mark.xfail(reason="https://github.com/mapbox/rasterio/issues/781")
 def test_create_mask_windowed_internal(data):
     """Writing masks by window with internal mask
-    Currently fails with
-        rasterio.errors.RasterioIOError: Failed to get mask.
     """
     with rasterio.Env(GDAL_TIFF_INTERNAL_MASK=True):
         with rasterio.open(str(data.join('RGB.byte.tif')), 'r+') as dst:


### PR DESCRIPTION
Support for windowed mask writes on internal GeoTiff bit masks. Only call `GDALCreateMaskBand` if we don't already have a per_dataset mask.

We have an existing test for this functionality - removed the `xfail` decorator as this should now pass.

resolves #895

cc @sgillies 