### PR TITLE
Optionally disable sharing on open

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -113,6 +113,7 @@ cdef class DatasetBase(object):
     def __init__(self, path=None, driver=None, **kwargs):
         cdef GDALDatasetH hds = NULL
         cdef int flags = 0
+        cdef int sharing_flag = (0x20 if kwargs.pop('sharing', True) else 0x0)
 
         self._hds = NULL
 
@@ -125,7 +126,7 @@ cdef class DatasetBase(object):
                 driver = [driver]
 
             # Read-only + Rasters + Sharing + Errors
-            flags = 0x00 | 0x02 | 0x20 | 0x40
+            flags = 0x00 | 0x02 | sharing_flag | 0x40
 
             try:
                 self._hds = open_dataset(filename, flags, driver, kwargs, None)


### PR DESCRIPTION
This pull request adds an optional parameter `sharing=True|False` to `open` method when used in read-only mode. Default value is `True` meaning that files will be opened with `GDAL_OF_SHARED` flag set (matches existing behaviour), however if user passes in `sharing=False` files will be opened without `GDAL_OF_SHARED` bit set.

Motivation for this feature is to support multi-threaded programs that want to read from the same resource concurrently. According to gdal threading model one has to open new dataset for each concurrent thread accessing the dataset.

**Note**: I have not added any documentation.

closes #1256 