### PR TITLE
Add __geo_interface__ support to features.py::bounds()

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -309,13 +309,17 @@ def bounds(geometry, north_up=True):
 
     Parameters
     ----------
-    geometry: GeoJSON-like feature, feature collection, or geometry.
+    geometry: GeoJSON-like feature (implements __geo_interface__),
+              feature collection, or geometry.
 
     Returns
     -------
     tuple
         Bounding box: (left, bottom, right, top)
     """
+
+    geometry = getattr(geometry, '__geo_interface__', None) or geometry
+
     if 'bbox' in geometry:
         return tuple(geometry['bbox'])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -502,6 +502,12 @@ def path_zip_file():
     return path
 
 
+class MockGeoInterface(object):
+    """Tiny wrapper for GeoJSON to present an object with __geo_interface__ for testing"""
+    def __init__(self, geojson):
+        self.__geo_interface__ = geojson
+
+
 # Define helpers to skip tests based on GDAL version
 gdal_version = GDALVersion.runtime()
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -5,11 +5,27 @@ from affine import Affine
 import rasterio
 from rasterio.mask import raster_geometry_mask, mask
 
+from .conftest import MockGeoInterface
+
 
 def test_raster_geometrymask(basic_image_2x2, basic_image_file, basic_geometry):
     """Pixels inside the geometry are False in the mask"""
 
     geometries = [basic_geometry]
+
+    with rasterio.open(basic_image_file) as src:
+        geometrymask, transform, window = raster_geometry_mask(src, geometries)
+
+    assert np.array_equal(geometrymask, (basic_image_2x2 == 0))
+    assert transform == Affine.identity()
+    assert window is None
+
+
+def test_raster_geometrymask_geo_interface(basic_image_2x2, basic_image_file,
+                                           basic_geometry):
+    """Pixels inside the geometry are False in the mask"""
+
+    geometries = [MockGeoInterface(basic_geometry)]
 
     with rasterio.open(basic_image_file) as src:
         geometrymask, transform, window = raster_geometry_mask(src, geometries)


### PR DESCRIPTION
Resolves #1268 

Adds a `MockGeoInterface` class that we can use for testing other functions that should support `__geo_interface__`