### PR TITLE
Flatten GeometryCollection to individual parts to avoid holes in output

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -259,7 +259,18 @@ def rasterize(
                 'Invalid geometry object at index {0}'.format(index)
             )
 
-        valid_shapes.append((geom, value))
+        if geom['type'] == 'GeometryCollection':
+            # GeometryCollections need to be handled as individual parts to
+            # avoid holes in output:
+            # https://github.com/mapbox/rasterio/issues/1253.
+            # Only 1-level deep since GeoJSON spec discourages nested
+            # GeometryCollections
+            for part in geom['geometries']:
+                valid_shapes.append((part, value))
+
+        else:
+            valid_shapes.append((geom, value))
+
         shape_values.append(value)
 
     if not valid_shapes:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -400,17 +400,12 @@ def test_rasterize_geomcollection(geojson_geomcollection):
     )
 
 
-@pytest.mark.xfail(reason="rasterize creates a hole between overlapping "
-                          "polygons in a GeometryCollection")
-def test_rasterize_geomcollection_hole():
+def test_rasterize_geomcollection_no_hole():
     """
-    Reported in https://github.com/mapbox/rasterio/issues/1253
-
-    rasterize creates a hole when passed a GeometryCollection of overlapping
-    geometries, yet does not create a hole when passed the same underlying
-    polygons directly.
-
-    This appears to be a bug in GDAL.
+    Make sure that bug reported in
+    https://github.com/mapbox/rasterio/issues/1253
+    does not recur.  GeometryCollections are flattened to individual parts,
+    and should result in no holes where parts overlap.
     """
 
     geomcollection = {'type': 'GeometryCollection', 'geometries': [
@@ -420,7 +415,6 @@ def test_rasterize_geomcollection_hole():
         'coordinates': (((2, 2), (2, 7), (7, 7), (7, 2), (2, 2)),)}
     ]}
 
-    # No hole when there are two overlapping polygon geometries
     expected = rasterize(geomcollection['geometries'], out_shape=DEFAULT_SHAPE)
 
     assert np.array_equal(

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -400,6 +400,35 @@ def test_rasterize_geomcollection(geojson_geomcollection):
     )
 
 
+@pytest.mark.xfail(reason="rasterize creates a hole between overlapping "
+                          "polygons in a GeometryCollection")
+def test_rasterize_geomcollection_hole():
+    """
+    Reported in https://github.com/mapbox/rasterio/issues/1253
+
+    rasterize creates a hole when passed a GeometryCollection of overlapping
+    geometries, yet does not create a hole when passed the same underlying
+    polygons directly.
+
+    This appears to be a bug in GDAL.
+    """
+
+    geomcollection = {'type': 'GeometryCollection', 'geometries': [
+        {'type': 'Polygon',
+        'coordinates': (((0, 0), (0, 5), (5, 5), (5, 0), (0, 0)),)},
+        {'type': 'Polygon',
+        'coordinates': (((2, 2), (2, 7), (7, 7), (7, 2), (2, 2)),)}
+    ]}
+
+    # No hole when there are two overlapping polygon geometries
+    expected = rasterize(geomcollection['geometries'], out_shape=DEFAULT_SHAPE)
+
+    assert np.array_equal(
+        rasterize([geomcollection], out_shape=DEFAULT_SHAPE),
+        expected
+    )
+
+
 def test_rasterize_invalid_geom():
     """Invalid GeoJSON should fail with exception"""
 


### PR DESCRIPTION
Resolves #1253 

Apparently, GDAL creates holes where parts of a `GeometryCollection` overlap, whereas it creates no holes when parts are submitted individually.  To avoid holes, we simply extract out the parts of the `GeometryCollection` prior to rasterize.