### PR TITLE
Copy ndarray to prevent PyArray_DATA to operate on a view (fix #1267)

### DIFF
--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -69,8 +69,7 @@ cdef int io_band(GDALRasterBandH band, int mode, float x0, float y0,
     """
     # GDAL handles all the buffering indexing, so a typed memoryview,
     # as in previous versions, isn't needed.
-    # Get a copy of the array (user may have passed a view).
-    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
+    cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[1]
     cdef int bufysize = data.shape[0]
     cdef int buftype = dtypes.dtype_rev[data.dtype.name]
@@ -107,8 +106,7 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int i = 0
     cdef int retval = 3
     cdef int *bandmap = NULL
-    # Get a copy of the array (user may have passed a view).
-    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
+    cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[2]
     cdef int bufysize = data.shape[1]
     cdef int buftype = dtypes.dtype_rev[data.dtype.name]
@@ -174,8 +172,7 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
         hmask = GDALGetMaskBand(band)
         if hmask == NULL:
             raise ValueError("Null mask band")
-        # Get a copy of the array (user may have passed a view).
-        buf = <void *>np.PyArray_DATA(data[i].copy())
+        buf = <void *>np.PyArray_DATA(data[i])
         if buf == NULL:
             raise ValueError("NULL data")
         with nogil:

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -69,6 +69,8 @@ cdef int io_band(GDALRasterBandH band, int mode, float x0, float y0,
     """
     # GDAL handles all the buffering indexing, so a typed memoryview,
     # as in previous versions, isn't needed.
+    # Get a copy of the array (user may have passed a view).
+    data = data.copy()
     cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[1]
     cdef int bufysize = data.shape[0]
@@ -106,6 +108,8 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int i = 0
     cdef int retval = 3
     cdef int *bandmap = NULL
+    # Get a copy of the array (user may have passed a view).
+    data = data.copy()
     cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[2]
     cdef int bufysize = data.shape[1]
@@ -164,6 +168,8 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int xsize = <int>width
     cdef int ysize = <int>height
 
+    # Get a copy of the array (user may have passed a view).
+    data = data.copy()
     for i in range(count):
         j = indexes[i]
         band = GDALGetRasterBand(hds, j)

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -70,8 +70,7 @@ cdef int io_band(GDALRasterBandH band, int mode, float x0, float y0,
     # GDAL handles all the buffering indexing, so a typed memoryview,
     # as in previous versions, isn't needed.
     # Get a copy of the array (user may have passed a view).
-    data = data.copy()
-    cdef void *buf = <void *>np.PyArray_DATA(data)
+    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
     cdef int bufxsize = data.shape[1]
     cdef int bufysize = data.shape[0]
     cdef int buftype = dtypes.dtype_rev[data.dtype.name]
@@ -109,8 +108,7 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int retval = 3
     cdef int *bandmap = NULL
     # Get a copy of the array (user may have passed a view).
-    data = data.copy()
-    cdef void *buf = <void *>np.PyArray_DATA(data)
+    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
     cdef int bufxsize = data.shape[2]
     cdef int bufysize = data.shape[1]
     cdef int buftype = dtypes.dtype_rev[data.dtype.name]
@@ -168,8 +166,6 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int xsize = <int>width
     cdef int ysize = <int>height
 
-    # Get a copy of the array (user may have passed a view).
-    data = data.copy()
     for i in range(count):
         j = indexes[i]
         band = GDALGetRasterBand(hds, j)
@@ -178,7 +174,8 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
         hmask = GDALGetMaskBand(band)
         if hmask == NULL:
             raise ValueError("Null mask band")
-        buf = <void *>np.PyArray_DATA(data[i])
+        # Get a copy of the array (user may have passed a view).
+        buf = <void *>np.PyArray_DATA(data[i].copy())
         if buf == NULL:
             raise ValueError("NULL data")
         with nogil:

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -286,6 +286,9 @@ def _reproject(
     # We need a src_transform and src_dst in this case. These will
     # be copied to the MEM dataset.
     if dtypes.is_ndarray(source):
+        # Copy array if it is a view.
+        if not source.flags['OWNDATA']:
+            source = source.copy()
         # Convert 2D single-band arrays to 3D multi-band.
         if len(source.shape) == 2:
             source = source.reshape(1, *source.shape)

--- a/rasterio/shim_rasterioex.pxi
+++ b/rasterio/shim_rasterioex.pxi
@@ -44,8 +44,7 @@ cdef int io_band(GDALRasterBandH band, int mode, float x0, float y0,
     """
     # GDAL handles all the buffering indexing, so a typed memoryview,
     # as in previous versions, isn't needed.
-    # Get a copy of the array (user may have passed a view).
-    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
+    cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[1]
     cdef int bufysize = data.shape[0]
     cdef GDALDataType buftype = dtypes.dtype_rev[data.dtype.name]
@@ -93,8 +92,7 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int i = 0
     cdef int retval = 3
     cdef int *bandmap = NULL
-    # Get a copy of the array (user may have passed a view).
-    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
+    cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[2]
     cdef int bufysize = data.shape[1]
     cdef GDALDataType buftype = dtypes.dtype_rev[data.dtype.name]
@@ -183,8 +181,7 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
         hmask = GDALGetMaskBand(band)
         if hmask == NULL:
             raise ValueError("Null mask band")
-        # Get a copy of the array (user may have passed a view).
-        buf = <void *>np.PyArray_DATA(data[i].copy())
+        buf = <void *>np.PyArray_DATA(data[i])
         if buf == NULL:
             raise ValueError("NULL data")
         with nogil:

--- a/rasterio/shim_rasterioex.pxi
+++ b/rasterio/shim_rasterioex.pxi
@@ -45,8 +45,7 @@ cdef int io_band(GDALRasterBandH band, int mode, float x0, float y0,
     # GDAL handles all the buffering indexing, so a typed memoryview,
     # as in previous versions, isn't needed.
     # Get a copy of the array (user may have passed a view).
-    data = data.copy()
-    cdef void *buf = <void *>np.PyArray_DATA(data)
+    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
     cdef int bufxsize = data.shape[1]
     cdef int bufysize = data.shape[0]
     cdef GDALDataType buftype = dtypes.dtype_rev[data.dtype.name]
@@ -95,8 +94,7 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int retval = 3
     cdef int *bandmap = NULL
     # Get a copy of the array (user may have passed a view).
-    data = data.copy()
-    cdef void *buf = <void *>np.PyArray_DATA(data)
+    cdef void *buf = <void *>np.PyArray_DATA(data.copy())
     cdef int bufxsize = data.shape[2]
     cdef int bufysize = data.shape[1]
     cdef GDALDataType buftype = dtypes.dtype_rev[data.dtype.name]
@@ -177,7 +175,6 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
     extras.pProgressData = NULL
 
     # Get a copy of the array (user may have passed a view).
-    data = data.copy()
     for i in range(count):
         j = indexes[i]
         band = GDALGetRasterBand(hds, j)
@@ -186,7 +183,8 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
         hmask = GDALGetMaskBand(band)
         if hmask == NULL:
             raise ValueError("Null mask band")
-        buf = <void *>np.PyArray_DATA(data[i])
+        # Get a copy of the array (user may have passed a view).
+        buf = <void *>np.PyArray_DATA(data[i].copy())
         if buf == NULL:
             raise ValueError("NULL data")
         with nogil:

--- a/rasterio/shim_rasterioex.pxi
+++ b/rasterio/shim_rasterioex.pxi
@@ -44,6 +44,8 @@ cdef int io_band(GDALRasterBandH band, int mode, float x0, float y0,
     """
     # GDAL handles all the buffering indexing, so a typed memoryview,
     # as in previous versions, isn't needed.
+    # Get a copy of the array (user may have passed a view).
+    data = data.copy()
     cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[1]
     cdef int bufysize = data.shape[0]
@@ -92,6 +94,8 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
     cdef int i = 0
     cdef int retval = 3
     cdef int *bandmap = NULL
+    # Get a copy of the array (user may have passed a view).
+    data = data.copy()
     cdef void *buf = <void *>np.PyArray_DATA(data)
     cdef int bufxsize = data.shape[2]
     cdef int bufysize = data.shape[1]
@@ -172,6 +176,8 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
     extras.pfnProgress = NULL
     extras.pProgressData = NULL
 
+    # Get a copy of the array (user may have passed a view).
+    data = data.copy()
     for i in range(count):
         j = indexes[i]
         band = GDALGetRasterBand(hds, j)


### PR DESCRIPTION
I tried to find a solution where we do the copy only when the user array is a view (you can check that with the `.flags['OWNDATA']` method). But it gets complicated to track down in the user API which function can lead to a `PyArray_DATA` call, and I am not familiar with the code. Not to mention that sometimes the array is reshaped internally, which makes it a view. So this solution always makes a copy before calling any `PyArray_DATA`, I hope it is fine.