### PR TITLE
Address Mask Error with Rotated Datasets

### DIFF
--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -337,7 +337,7 @@ def _explode(coords):
                 yield f
 
 
-def _bounds(geometry, north_up=True):
+def _bounds(geometry, north_up=True, transform=None):
     """Bounding box of a GeoJSON geometry.
 
     left, bottom, right, top
@@ -365,11 +365,17 @@ def _bounds(geometry, north_up=True):
             return min(xmins), max(ymaxs), max(xmaxs), min(ymins)
 
     else:
-        xyz = tuple(zip(*list(_explode(geometry['coordinates']))))
-        if north_up:
-            return min(xyz[0]), min(xyz[1]), max(xyz[0]), max(xyz[1])
-        else:
+        if transform is not None:
+            xyz = list(_explode(geometry['coordinates']))
+            xyz_px = [point * transform for point in xyz]
+            xyz = tuple(zip(*xyz_px))
             return min(xyz[0]), max(xyz[1]), max(xyz[0]), min(xyz[1])
+        else:
+            xyz = tuple(zip(*list(_explode(geometry['coordinates']))))
+            if north_up:
+                return min(xyz[0]), min(xyz[1]), max(xyz[0]), max(xyz[1])
+            else:
+                return min(xyz[0]), max(xyz[1]), max(xyz[0]), min(xyz[1])
 
 
 # Mapping of OGR integer geometry types to GeoJSON type names.

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -399,8 +399,8 @@ def geometry_window(dataset, shapes, pad_x=0, pad_y=0, north_up=True,
         lefts, bottoms, rights, tops = zip(*all_bounds_px)
         left = min(lefts) - pad_x
         right = max(rights) + pad_x
-        top = min(tops)
-        bottom = max(bottoms)
+        top = min(tops) - pad_y
+        bottom = max(bottoms) + pad_y
         # do some clamping if there are any values less than zero or greater than dataset shape
         left = max(0, left)
         top = max(0, top)

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -74,10 +74,11 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
         pad_y = 0
 
     north_up = dataset.transform.e <= 0
+    rotated = dataset.transform.b != 0 or dataset.transform.d != 0 
 
     try:
-        window = geometry_window(dataset, shapes, north_up=north_up, pad_x=pad_x,
-                                 pad_y=pad_y)
+        window = geometry_window(dataset, shapes, north_up=north_up, rotated=rotated,
+                                 pad_x=pad_x, pad_y=pad_y)
 
     except WindowError:
         # If shapes do not overlap raster, raise Exception or UserWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,24 @@ def basic_geometry():
 
 
 @pytest.fixture
+def rotation_geometry():
+    """
+    Returns
+    -------
+
+    dict: GeoJSON-style geometry object.
+        Coordinates are in grid coordinates (Affine.identity()).
+    """
+
+    return {
+        'type': 'Polygon',
+        'coordinates': [[(481070, 4481140), (481040, 4481160),
+                         (481035, 4481130), (481060, 4481125),
+                         (481070, 4481140)]]
+    }
+
+
+@pytest.fixture
 def geojson_point():
     """
     Returns
@@ -385,6 +403,45 @@ def pixelated_image_file(tmpdir, pixelated_image):
         "width": image.shape[1],
         "height": image.shape[0],
         "nodata": 255
+    }
+    with rasterio.open(outfilename, 'w', **kwargs) as out:
+        out.write(image, indexes=1)
+
+    return outfilename
+
+
+@pytest.fixture()
+def rotated_image_file(tmpdir, pixelated_image):
+    """
+    A basic raster file with a 1000x2000 array for testing sieve functions.
+    Contains only one value: 128.
+
+    Returns
+    -------
+
+    string
+        Filename of test raster file
+    """
+
+    from affine import Affine
+    import rasterio
+
+    image = 128 * np.ones((1000, 2000), dtype=np.uint8)
+
+    rotated_transform = Affine(-0.05, 0.07, 481060,
+                                0.07, 0.05, 4481030)
+
+    outfilename = str(tmpdir.join('rotated_image.tif'))
+    kwargs = {
+        "crs": CRS({'init': 'epsg:32613'}),
+        "transform": rotated_transform,
+        "count": 1,
+        "dtype": rasterio.uint8,
+        "driver": "GTiff",
+        "width": image.shape[1],
+        "height": image.shape[0],
+        "nodata": 255,
+        "compress": "lzw"
     }
     with rasterio.open(outfilename, 'w', **kwargs) as out:
         out.write(image, indexes=1)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -144,6 +144,12 @@ def test_geometry_window_geo_interface(basic_image_file, basic_geometry):
         assert window.flatten() == (2, 2, 3, 3)
 
 
+def test_geometry_window_rotation(rotated_image_file, rotation_geometry):
+    with rasterio.open(rotated_image_file) as src:
+        window = geometry_window(src, [rotation_geometry], rotated=True)
+        assert window.flatten() == (898, 439, 467, 399)
+
+
 @pytest.mark.xfail(reason="https://github.com/mapbox/rasterio/issues/1139")
 # This test is failing due to https://github.com/mapbox/rasterio/issues/1139
 def test_geometry_window_pixel_precision(basic_image_file):


### PR DESCRIPTION
This commit proposes a strawman fix for mapbox/rasterio#1240 .

A test is included as well, and it uses new test fixtures to demonstrate the issue.

I believe this is the cleanest way to address the issue, though the transform round-trip is not particularly elegant.

Looking forward to hearing your thoughts!