### PR TITLE
WarpedVRT bugfix and recipe for normalizing data against a known grid

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Bug fixes:
   elsewhere in the package (#1224, #1225).
 - Sharing of dataset handles may be disabled for multithreaded applications
   using the new `sharing` keyword argument of `rasterio.open` (#1260).
+- ``WarpedVRT()`` properly sets a CRS on the internal VRT handle when
+  that VRT is produced by ``GDALCreateVRT()`` (#1283).
 
 1.0a12 (2017-12-01)
 -------------------

--- a/docs/topics/virtual-warping.rst
+++ b/docs/topics/virtual-warping.rst
@@ -54,3 +54,116 @@ extract pixels corresponding to its central zoom 9 tile, do the following.
           with rasterio.open('/tmp/test-tile.tif', 'w', **profile) as dst:
               dst.write(data)
 
+
+Normalizing Data to a Consistent Grid
+=====================================
+
+A ``WarpedVRT`` can be used to normalize a stack of images with differing
+projections, bounds, cell sizes, or dimensions against a regular grid
+in a defined bounding box.
+
+The `tests/data/RGB.byte.tif` file is in UTM zone 18, so another file in a
+different CRS is required for demonstration.  This command will create a new
+image with drastically different dimensions and cell size, and reproject to
+WGS84.  As of this writing ``$ rio warp`` implements only a subset of
+`$ gdalwarp <http://www.gdal.org/gdalwarp.html>`__'s features, so
+``$ gdalwarp`` must be used to achieve the desired transform:
+
+.. code-block:: console
+
+    $ gdalwarp \
+        -t_srs EPSG:4326 \
+        -te_srs EPSG:32618 \
+        -te 101985 2673031 339315 2801254 \
+        -ts 200 250 \
+        tests/data/RGB.byte.tif \
+        tests/data/WGS84-RGB.byte.tif
+
+So, the attributes of these two images drastically differ:
+
+.. code-block:: console
+
+    $ rio info --shape tests/data/RGB.byte.tif
+    718 791
+    $ rio info --shape tests/data/WGS84-RGB.byte.tif
+    250 200
+    $ rio info --crs tests/data/RGB.byte.tif
+    EPSG:32618
+    $ rio info --crs tests/data/WGS84-RGB.byte.tif
+    EPSG:4326
+    $ rio bounds --bbox --geographic --precision 7 tests/data/RGB.byte.tif
+    [-78.95865, 23.5649912, -76.5749237, 25.5508738]
+    $ rio bounds --bbox --geographic --precision 7 tests/data/WGS84-RGB.byte.tif
+    [-78.9147773, 24.119606, -76.5963819, 25.3192311]
+
+and this snippet demonstrates how to normalize data to consistent dimensions,
+CRS, and cell size within a pre-defined bounding box:
+
+.. code-block:: python
+
+    from __future__ import division
+
+    import os
+
+    import affine
+
+    import rasterio
+    from rasterio.crs import CRS
+    from rasterio.enums import Resampling
+    from rasterio import shutil as rio_shutil
+    from rasterio.vrt import WarpedVRT
+
+
+    input_files = (
+        # This file is in EPSG:32618
+        'tests/data/RGB.byte.tif',
+        # This file is in EPSG:4326
+        'tests/data/WGS84-RGB.byte.tif'
+    )
+
+    # Destination CRS is Web Mercator
+    dst_crs = CRS.from_epsg(3857)
+
+    # These coordiantes are in Web Mercator
+    dst_bounds = -8744355, 2768114, -8559167, 2908677
+
+    # Output image dimensions
+    dst_height = dst_width = 100
+
+    # Output image transform
+    left, bottom, right, top = dst_bounds
+    xres = (right - left) / dst_width
+    yres = (top - bottom) / dst_height
+    dst_transform = affine.Affine(xres, 0.0, left,
+                                  0.0, -yres, top)
+
+    vrt_options = {
+        'resampling': Resampling.cubic,
+        'dst_crs': dst_crs,
+        'dst_transform': dst_transform,
+        'dst_height': dst_height,
+        'dst_width': dst_width,
+    }
+
+    for path in input_files:
+
+        with rasterio.open(path) as src:
+
+            with WarpedVRT(src, **vrt_options) as vrt:
+
+                # At this point 'vrt' is a full dataset with dimensions,
+                # CRS, and spatial extent matching 'vrt_options'.
+
+                # Read all data into memory.
+                data = vrt.read()
+
+                # Process the dataset in chunks.  Likely not very efficient.
+                for _, window in vrt.block_windows():
+                    data = vrt.read(window=window)
+
+                # Dump the aligned data into a new file.  A VRT representing
+                # this transformation can also be produced by switching
+                # to the VRT driver.
+                directory, name = os.path.split(path)
+                outfile = os.path.join(directory, 'aligned-{}'.format(name))
+                rio_shutil.copy(vrt, outfile, driver='GTiff')

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -752,6 +752,7 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
                 with nogil:
                     hds_warped = GDALCreateWarpedVRT(
                         hds, c_width, c_height, dst_gt, psWOptions)
+                    GDALSetProjection(hds_warped, dst_crs_wkt)
                 self._hds = exc_wrap_pointer(hds_warped)
             else:
                 with nogil:

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -3,13 +3,13 @@
 
 from __future__ import division
 
+import affine
 import boto3
 import pytest
 
 import rasterio
 from rasterio.enums import Resampling
 from rasterio import shutil as rio_shutil
-from rasterio.transform import Affine
 from rasterio.vrt import WarpedVRT
 from rasterio.warp import transform_bounds
 
@@ -65,7 +65,7 @@ def test_warped_vrt_dimensions(path_rgb_byte_tif):
         extent = (-20037508.34, 20037508.34)
         size = (2 ** 16) * 256
         resolution = (extent[1] - extent[0]) / size
-        dst_transform = Affine(resolution, 0.0, extent[0],
+        dst_transform = affine.Affine(resolution, 0.0, extent[0],
                                0.0, -resolution, extent[1])
         vrt = WarpedVRT(src, dst_crs='EPSG:3857',
                         dst_width=size, dst_height=size,
@@ -142,7 +142,7 @@ def test_crs_should_be_set(path_rgb_byte_tif, tmpdir, complex):
         left, bottom, right, top = dst_bounds
         xres = (right - left) / dst_width
         yres = (top - bottom) / dst_height
-        dst_transform = Affine(xres, 0.0, left,
+        dst_transform = affine.Affine(xres, 0.0, left,
                                0.0, -yres, top)
 
         # The 'complex' test case hits the affected code path


### PR DESCRIPTION
Closes #1198 via some documentation.

I also discovered that when a `WarpedVRT()` is instantiated with `dst_height`, `dst_width`, and `dst_transform` calls `GDALCreateWarpedVRT()`, which does not have a CRS parameter, thus the resulting dataset handle lacks a CRS..  Users interacting with `WarpedVRT.crs` get a cached object, but flushing the data to disk via GDAL's copy mechanism (`rasterio.shutil.copy()`) receives the dataset handle provided by `GDALCreateWarpedVRT()` and creates a new dataset without a CRS.  The solution is to add a CRS to the new dataset handle as soon as it is created.  I also added a test for this specific condition.