### PR TITLE
Pass precision to from_bounds in merge

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -154,14 +154,14 @@ def merge(datasets, bounds=None, res=None, nodata=None, precision=7, indexes=Non
 
         # 2. Compute the source window
         src_window = windows.from_bounds(
-            int_w, int_s, int_e, int_n, src.transform)
+            int_w, int_s, int_e, int_n, src.transform, precision=precision)
         logger.debug("Src %s window: %r", src.name, src_window)
 
         src_window = src_window.round_shape()
 
         # 3. Compute the destination window
         dst_window = windows.from_bounds(
-            int_w, int_s, int_e, int_n, output_transform)
+            int_w, int_s, int_e, int_n, output_transform, precision=precision)
 
         # 4. Read data in source window into temp
         trows, tcols = (


### PR DESCRIPTION
The precision argument was still in the keywords for `merge.merge`, but wasn't being used anywhere.

I had a difficult time devising a test without adding new test fixtures. One possibility that did occur to me was setting a very low precision, attempting a merge, and verifying that it throws an exception when there's a size mismatch. I'd be happy to do so if that seems desirable.

There's potential for more change along these lines, with respect to rounding the window sizes and offsets. However, this particular fix on its own addressed the issue I ran into. 