### PR TITLE
Remove eval_window() etc from __init__.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Breaking changes:
 - Whether to print GeoJSON feature sequences or a GeoJSON feature collection
   from rio-shapes is now controlled by a ``--sequence/--collection`` option.
   A sequence is now the default (#927).
+- Deprecated window functions have been removed from the mapbox module. Their
+  replacements are in mapbox.windows (#1115).
 
 New features:
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -39,13 +39,6 @@ from rasterio.vfs import parse_path
 from rasterio import _err, coords, enums, vfs
 
 
-def window_index(*args, **kwargs):
-    from rasterio.windows import window_index
-    warnings.warn(
-        "Deprecated; Use rasterio.windows instead", RasterioDeprecationWarning)
-    return window_index(*args, **kwargs)
-
-
 __all__ = ['band', 'open', 'pad']
 __version__ = "1.0a12"
 __gdal_version__ = gdal_version()

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -33,19 +33,10 @@ from rasterio.io import (
 from rasterio.profiles import default_gtiff_profile
 from rasterio.transform import Affine, guard_transform
 from rasterio.vfs import parse_path
-from rasterio import windows
 
 # These modules are imported from the Cython extensions, but are also import
 # here to help tools like cx_Freeze find them automatically
 from rasterio import _err, coords, enums, vfs
-
-
-# TODO deprecate or remove in factor of rasterio.windows.___
-def eval_window(*args, **kwargs):
-    from rasterio.windows import evaluate
-    warnings.warn(
-        "Deprecated; Use rasterio.windows instead", RasterioDeprecationWarning)
-    return evaluate(*args, **kwargs)
 
 
 def window_shape(*args, **kwargs):

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -39,13 +39,6 @@ from rasterio.vfs import parse_path
 from rasterio import _err, coords, enums, vfs
 
 
-def window_shape(*args, **kwargs):
-    from rasterio.windows import shape
-    warnings.warn(
-        "Deprecated; Use rasterio.windows instead", RasterioDeprecationWarning)
-    return shape(*args, **kwargs)
-
-
 def window_index(*args, **kwargs):
     from rasterio.windows import window_index
     warnings.warn(

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -45,10 +45,10 @@ class WindowTest(unittest.TestCase):
 
     def test_eval(self):
         self.assertEqual(
-            rasterio.eval_window(((-10, None), (-10, None)), 100, 90),
+            rasterio.windows.evaluate(((-10, None), (-10, None)), 100, 90),
             windows.Window.from_ranges((90, 100), (80, 90)))
         self.assertEqual(
-            rasterio.eval_window(((None, -10), (None, -10)), 100, 90),
+            rasterio.windows.evaluate(((None, -10), (None, -10)), 100, 90),
             windows.Window.from_ranges((0, 90), (0, 80)))
 
 def test_window_index():

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -52,7 +52,7 @@ class WindowTest(unittest.TestCase):
             windows.Window.from_ranges((0, 90), (0, 80)))
 
 def test_window_index():
-    idx = rasterio.window_index(((0, 4), (1, 12)))
+    idx = rasterio.windows.window_index(((0, 4), (1, 12)))
     assert len(idx) == 2
     r, c = idx
     assert r.start == 0

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -19,28 +19,28 @@ class WindowTest(unittest.TestCase):
 
     def test_window_shape_None_start(self):
         self.assertEqual(
-            rasterio.window_shape(((None, 4), (None, 102))),
+            rasterio.windows.shape(((None, 4), (None, 102))),
             (4, 102))
 
     def test_window_shape_None_stop(self):
         self.assertEqual(
-            rasterio.window_shape(((10, None), (10, None)), 100, 90),
+            rasterio.windows.shape(((10, None), (10, None)), 100, 90),
             (90, 80))
 
     def test_window_shape_positive(self):
         self.assertEqual(
-            rasterio.window_shape(((0, 4), (1, 102))),
+            rasterio.windows.shape(((0, 4), (1, 102))),
             (4, 101))
 
     def test_window_shape_negative(self):
         self.assertEqual(
-            rasterio.window_shape(((-10, None), (-10, None)), 100, 90),
+            rasterio.windows.shape(((-10, None), (-10, None)), 100, 90),
             (10, 10))
         self.assertEqual(
-            rasterio.window_shape(((~0, None), (~0, None)), 100, 90),
+            rasterio.windows.shape(((~0, None), (~0, None)), 100, 90),
             (1, 1))
         self.assertEqual(
-            rasterio.window_shape(((None, ~0), (None, ~0)), 100, 90),
+            rasterio.windows.shape(((None, ~0), (None, ~0)), 100, 90),
             (99, 89))
 
     def test_eval(self):
@@ -102,7 +102,7 @@ class WindowReadTest(unittest.TestCase):
             self.assertEqual(first_block.dtype, rasterio.ubyte)
             self.assertEqual(
                 first_block.shape,
-                rasterio.window_shape(first_window))
+                rasterio.windows.shape(first_window))
 
 
 class WindowWriteTest(unittest.TestCase):


### PR DESCRIPTION
closes https://github.com/mapbox/rasterio/issues/1115

This PR removes:
- eval_window
- window_shape
- window_index 

from `rasterio/__init__py`
