### PR TITLE
No more bytearray input for MemoryFile

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -720,7 +720,7 @@ cdef class MemoryFileBase(object):
         Parameters
         ----------
         file_or_bytes : file or bytes
-            A file opened in binary mode or bytes or a bytearray
+            A file opened in binary mode or bytes
         filename : str
             A filename for the in-memory file under /vsimem
         ext : str
@@ -732,12 +732,12 @@ cdef class MemoryFileBase(object):
         if file_or_bytes:
             if hasattr(file_or_bytes, 'read'):
                 initial_bytes = file_or_bytes.read()
-            else:
+            elif isinstance(file_or_bytes, bytes):
                 initial_bytes = file_or_bytes
-            if not isinstance(initial_bytes, (bytearray, bytes)):
+            else:
                 raise TypeError(
                     "Constructor argument must be a file opened in binary "
-                    "mode or bytes/bytearray.")
+                    "mode or bytes.")
         else:
             initial_bytes = b''
 

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -112,17 +112,6 @@ def test_non_initial_bytes_in_two(rgb_file_bytes):
             assert src.read().shape == (3, 718, 791)
 
 
-def test_non_initial_bytearray(rgb_file_bytes):
-    """MemoryFile contents can be read from bytearray and opened."""
-    with MemoryFile() as memfile:
-        assert memfile.write(bytearray(rgb_file_bytes)) == len(rgb_file_bytes)
-        with memfile.open() as src:
-            assert src.driver == 'GTiff'
-            assert src.count == 3
-            assert src.dtypes == ('uint8', 'uint8', 'uint8')
-            assert src.read().shape == (3, 718, 791)
-
-
 def test_no_initial_bytes(rgb_data_and_profile):
     """An empty MemoryFile can be opened and written into."""
     data, profile = rgb_data_and_profile
@@ -134,7 +123,7 @@ def test_no_initial_bytes(rgb_data_and_profile):
         # Exact size of the in-memory GeoTIFF varies with GDAL
         # version and configuration.
         assert view.size > 1000000
-        data = bytearray(view)
+        data = bytes(view)
 
     with MemoryFile(data) as memfile:
         with memfile.open() as src:

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -123,7 +123,8 @@ def test_no_initial_bytes(rgb_data_and_profile):
         # Exact size of the in-memory GeoTIFF varies with GDAL
         # version and configuration.
         assert view.size > 1000000
-        data = bytes(view)
+        # NB: bytes(view) doesn't return what you'd expect with python 2.7.
+        data = bytes(bytearray(view))
 
     with MemoryFile(data) as memfile:
         with memfile.open() as src:


### PR DESCRIPTION
It's turning out to be buggy and we don't need it. Users can convert to `bytes` as we're doing in the tests.