### PR TITLE
Refactor --force-overwrite to --overwrite.

### DIFF
--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -40,10 +40,10 @@ def read_array(ix, subix=None, dtype=None):
                    '"a=tests/data/RGB.byte.tif".')
 @options.dtype_opt
 @options.masked_opt
-@options.force_overwrite_opt
+@options.overwrite_opt
 @options.creation_options
 @click.pass_context
-def calc(ctx, command, files, output, name, dtype, masked, force_overwrite,
+def calc(ctx, command, files, output, name, dtype, masked, overwrite,
          creation_options):
     """A raster data calculator
 
@@ -89,7 +89,7 @@ def calc(ctx, command, files, output, name, dtype, masked, force_overwrite,
     try:
         with ctx.obj['env']:
             output, files = resolve_inout(files=files, output=output,
-                                          force_overwrite=force_overwrite)
+                                          overwrite=overwrite)
 
             inputs = ([tuple(n.split('=')) for n in name] +
                       [(None, n) for n in files])

--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -66,28 +66,28 @@ def write_features(
         fobj.write('\n')
 
 
-def resolve_inout(input=None, output=None, files=None, force_overwrite=False):
+def resolve_inout(input=None, output=None, files=None, overwrite=False):
     """Resolves inputs and outputs from standard args and options.
 
     :param input: a single input filename, optional.
     :param output: a single output filename, optional.
     :param files: a sequence of filenames in which the last is the
         output filename.
-    :param force_overwrite: whether to force overwriting the output
+    :param overwrite: whether to force overwriting the output
         file, bool.
     :return: the resolved output filename and input filenames as a
         tuple of length 2.
 
     If provided, the :param:`output` file may be overwritten. An output
     file extracted from :param:`files` will not be overwritten unless
-    :param:`force_overwrite` is `True`.
+    :param:`overwrite` is `True`.
     """
     resolved_output = output or (files[-1] if files else None)
-    if not force_overwrite and resolved_output and os.path.exists(
+    if not overwrite and resolved_output and os.path.exists(
             resolved_output):
         raise FileOverwriteError(
             "file exists and won't be overwritten without use of the "
-            "`--force-overwrite` option.")
+            "`--overwrite` option.")
     resolved_inputs = (
         [input] if input else [] +
         list(files[:-1 if not output else None]) if files else [])

--- a/rasterio/rio/mask.py
+++ b/rasterio/rio/mask.py
@@ -31,7 +31,7 @@ logger = logging.getLogger('rio')
               help='Inverts the mask, so that areas covered by features are'
                    'masked out and areas not covered are retained.  Ignored '
                    'if using --crop')
-@options.force_overwrite_opt
+@options.overwrite_opt
 @options.creation_options
 @click.pass_context
 def mask(
@@ -43,7 +43,7 @@ def mask(
         all_touched,
         crop,
         invert,
-        force_overwrite,
+        overwrite,
         creation_options):
     """Masks in raster using GeoJSON features (masks out all areas not covered
     by features), and optionally crops the output raster to the extent of the
@@ -68,7 +68,7 @@ def mask(
     """
 
     output, files = resolve_inout(
-        files=files, output=output, force_overwrite=force_overwrite)
+        files=files, output=output, overwrite=overwrite)
     input = files[0]
 
     if geojson_mask is None:

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -17,13 +17,13 @@ from rasterio.rio.helpers import resolve_inout
 @options.resolution_opt
 @options.nodata_opt
 @options.bidx_mult_opt
-@options.force_overwrite_opt
+@options.overwrite_opt
 @click.option('--precision', type=int, default=7,
               help="Number of decimal places of precision in alignment of "
                    "pixels")
 @options.creation_options
 @click.pass_context
-def merge(ctx, files, output, driver, bounds, res, nodata, bidx, force_overwrite,
+def merge(ctx, files, output, driver, bounds, res, nodata, bidx, overwrite,
           precision, creation_options):
     """Copy valid pixels from input files to an output file.
 
@@ -47,7 +47,7 @@ def merge(ctx, files, output, driver, bounds, res, nodata, bidx, force_overwrite
     from rasterio.merge import merge as merge_tool
 
     output, files = resolve_inout(
-        files=files, output=output, force_overwrite=force_overwrite)
+        files=files, output=output, overwrite=overwrite)
 
     with ctx.obj['env']:
         datasets = [rasterio.open(f) for f in files]

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -294,8 +294,8 @@ rgb_opt = click.option(
     default=False,
     help="Set RGB photometric interpretation.")
 
-force_overwrite_opt = click.option(
-    '--force-overwrite', 'force_overwrite',
+overwrite_opt = click.option(
+    '--overwrite', 'overwrite',
     is_flag=True, type=bool, default=False,
     help="Always overwrite an existing output file.")
 

--- a/rasterio/rio/rasterize.py
+++ b/rasterio/rio/rasterize.py
@@ -53,7 +53,7 @@ files_inout_arg = click.argument(
 @click.option('--property', 'prop', type=str, default=None, help='Property in '
               'GeoJSON features to use for rasterized values.  Any features '
               'that lack this property will be given --default_value instead.')
-@options.force_overwrite_opt
+@options.overwrite_opt
 @options.creation_options
 @click.pass_context
 def rasterize(
@@ -70,7 +70,7 @@ def rasterize(
         default_value,
         fill,
         prop,
-        force_overwrite,
+        overwrite,
         creation_options):
     """Rasterize GeoJSON into a new or existing raster.
 
@@ -116,7 +116,7 @@ def rasterize(
     from rasterio.features import bounds as calculate_bounds
 
     output, files = resolve_inout(
-        files=files, output=output, force_overwrite=force_overwrite)
+        files=files, output=output, overwrite=overwrite)
 
     bad_param = click.BadParameter('invalid CRS.  Must be an EPSG code.',
                                    ctx, param=src_crs, param_hint='--src_crs')

--- a/rasterio/rio/stack.py
+++ b/rasterio/rio/stack.py
@@ -19,10 +19,10 @@ from rasterio.rio.helpers import resolve_inout
 @format_opt
 @options.bidx_magic_opt
 @options.rgb_opt
-@options.force_overwrite_opt
+@options.overwrite_opt
 @options.creation_options
 @click.pass_context
-def stack(ctx, files, output, driver, bidx, photometric, force_overwrite,
+def stack(ctx, files, output, driver, bidx, photometric, overwrite,
           creation_options):
     """Stack a number of bands from one or more input files into a
     multiband dataset.
@@ -59,7 +59,7 @@ def stack(ctx, files, output, driver, bidx, photometric, force_overwrite,
     try:
         with ctx.obj['env']:
             output, files = resolve_inout(files=files, output=output,
-                                          force_overwrite=force_overwrite)
+                                          overwrite=overwrite)
             output_count = 0
             indexes = []
             for path, item in zip_longest(files, bidx, fillvalue=None):

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -61,12 +61,12 @@ MAX_OUTPUT_HEIGHT = 100000
               help='Constrain output to valid coordinate region in dst-crs')
 @click.option('--target-aligned-pixels/--no-target-aligned-pixels', default=False,
               help='align the output bounds based on the resolution')
-@options.force_overwrite_opt
+@options.overwrite_opt
 @options.creation_options
 @click.pass_context
 def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
          dst_bounds, res, resampling, src_nodata, dst_nodata, threads,
-         check_invert_proj, force_overwrite, creation_options,
+         check_invert_proj, overwrite, creation_options,
          target_aligned_pixels):
     """
     Warp a raster dataset.
@@ -111,7 +111,7 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
 
     """
     output, files = resolve_inout(
-        files=files, output=output, force_overwrite=force_overwrite)
+        files=files, output=output, overwrite=overwrite)
 
     resampling = Resampling[resampling]  # get integer code for method
 

--- a/tests/test_rio_helpers.py
+++ b/tests/test_rio_helpers.py
@@ -29,12 +29,12 @@ def test_fail_overwrite(tmpdir):
         helpers.resolve_inout(files=[str(x) for x in tmpdir.listdir()])
         assert "file exists and won't be overwritten without use of the " in str(excinfo.value)
 
-def test_force_overwrite(tmpdir):
+def test_overwrite(tmpdir):
     """Forced overwrite of existing file succeeds."""
     foo_tif = tmpdir.join('foo.tif')
     foo_tif.write("content")
     output, inputs = helpers.resolve_inout(
-        files=[str(x) for x in tmpdir.listdir()], force_overwrite=True)
+        files=[str(x) for x in tmpdir.listdir()], overwrite=True)
     assert output == str(foo_tif)
 
 

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -200,7 +200,7 @@ def test_merge_output_exists(tmpdir):
 
 
 def test_merge_output_exists_without_nodata_fails(test_data_dir_2):
-    """Fails without --force-overwrite"""
+    """Fails without --overwrite"""
     runner = CliRunner()
     result = runner.invoke(
         main_group, [
@@ -210,11 +210,11 @@ def test_merge_output_exists_without_nodata_fails(test_data_dir_2):
 
 
 def test_merge_output_exists_without_nodata(test_data_dir_2):
-    """Succeeds with --force-overwrite"""
+    """Succeeds with --overwrite"""
     runner = CliRunner()
     result = runner.invoke(
         main_group, [
-            'merge', '--force-overwrite', str(test_data_dir_2.join('a.tif')),
+            'merge', '--overwrite', str(test_data_dir_2.join('a.tif')),
             str(test_data_dir_2.join('b.tif'))])
     assert result.exit_code == 0
 

--- a/tests/test_rio_rasterize.py
+++ b/tests/test_rio_rasterize.py
@@ -157,7 +157,7 @@ def test_rasterize_existing_output(tmpdir, runner, basic_feature):
 
     result = runner.invoke(
         main_group, [
-            'rasterize', '--force-overwrite', '-o', output, '--dimensions', DEFAULT_SHAPE[0],
+            'rasterize', '--overwrite', '-o', output, '--dimensions', DEFAULT_SHAPE[0],
             DEFAULT_SHAPE[1]],
         input=json.dumps(basic_feature))
 
@@ -234,7 +234,7 @@ def test_rasterize_src_crs_mismatch(tmpdir, runner, basic_feature,
 
     result = runner.invoke(
         main_group, [
-            'rasterize', output, '--force-overwrite', '--src-crs', 'EPSG:3857'],
+            'rasterize', output, '--overwrite', '--src-crs', 'EPSG:3857'],
         input=json.dumps(basic_feature))
     assert result.exit_code == 2
     assert 'GeoJSON does not match crs of existing output raster' in result.output


### PR DESCRIPTION
This addresses #1181.

I do not believe -f is actually being used anywhere in the code as short for --force-overwrite. And now the only instances of --force-overwrite are in the CHANGES file.

I just chose a simple issue to get back up and running on this code. Not sure if it needs anything more, but seems to be good.