### PR TITLE
WIP: Do not save opening options in tags

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -26,7 +26,7 @@ from rasterio.enums import (
 from rasterio.env import Env
 from rasterio.errors import (
     RasterioIOError, CRSError, DriverRegistrationError, NotGeoreferencedWarning,
-    RasterBlockError, BandOverviewError)
+    RasterBlockError, BandOverviewError, RasterioDeprecationWarning)
 from rasterio.profiles import Profile
 from rasterio.transform import Affine, guard_transform, tastes_like_gdal
 from rasterio.vfs import parse_path, vsi_path
@@ -677,8 +677,6 @@ cdef class DatasetBase(object):
         """
         def __get__(self):
             m = Profile(**self.meta)
-            m.update((k, v.lower()) for k, v in self.tags(
-                ns='rio_creation_kwds').items())
             if self.is_tiled:
                 m.update(
                     blockxsize=self.block_shapes[0][1],
@@ -932,7 +930,8 @@ cdef class DatasetBase(object):
 
     @property
     def kwds(self):
-        return self.tags(ns='rio_creation_kwds')
+        warnings.warn("Dataset creation options will no longer be stored as tags in 1.0.", RasterioDeprecationWarning)
+        return {}
 
     # Overviews.
     def overviews(self, bidx):

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1086,7 +1086,6 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         # touch self.meta
         _ = self.meta
 
-        self.update_tags(ns='rio_creation_kwds', **kwargs)
         self._closed = False
 
     def __repr__(self):
@@ -1867,7 +1866,6 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
         # touch self.meta
         _ = self.meta
 
-        self.update_tags(ns='rio_creation_kwds', **kwargs)
         self._closed = False
 
     def close(self):

--- a/tests/test_colorinterp.py
+++ b/tests/test_colorinterp.py
@@ -1,5 +1,7 @@
 """Tests for interacting with color interpretation."""
 
+import logging
+import numpy as np
 import pytest
 
 import rasterio
@@ -7,15 +9,25 @@ from rasterio.enums import ColorInterp
 
 from .conftest import requires_gdal22
 
+logging.basicConfig(level=logging.DEBUG)
+
 
 def test_cmyk_interp(tmpdir):
     """A CMYK TIFF has cyan, magenta, yellow, black bands."""
     with rasterio.open('tests/data/RGB.byte.tif') as src:
-        meta = src.meta
-    meta['photometric'] = 'CMYK'
-    meta['count'] = 4
+        profile = src.profile
+
+    profile['photometric'] = 'CMYK'
+    profile['count'] = 4
+
     tiffname = str(tmpdir.join('foo.tif'))
-    with rasterio.open(tiffname, 'w', **meta) as dst:
+    with rasterio.open(tiffname, 'w', **profile) as dst:
+        pass
+        # dst.write(np.ones((profile['count'], profile['height'], profile['width']), profile['dtype']))
+
+    with rasterio.open(tiffname) as dst:
+        import pdb
+        pdb.set_trace()
         assert dst.profile['photometric'] == 'cmyk'
         assert dst.colorinterp == (
             ColorInterp.cyan,

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -264,7 +264,6 @@ def test_write_lzw(tmpdir):
             width=100, height=100, count=1,
             dtype=a.dtype,
             compress='LZW') as s:
-        assert ('compress', 'LZW') in s.kwds.items()
         s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
     assert "LZW" in info


### PR DESCRIPTION
Saving opening options passed to `open` as tags on the opened dataset can be misleading because opening options are always driver-specific and may be ignored or overridden. If added back into the dataset's `profile`, these options may "lie" to other functions that use the dataset's profile.