### PR TITLE
Add an enum for ZSTD compression

### DIFF
--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -64,6 +64,7 @@ class Compression(Enum):
     ccittfax4 = 'CCITTFAX4'
     lzma = 'LZMA'
     none = 'NONE'
+    zstd = 'ZSTD'
 
 
 class Interleaving(Enum):


### PR DESCRIPTION
The `quay.io/repository/gdal:trunk` Docker image now includes ZSTD support (after https://github.com/mojodna/docker-gdal/commit/558f134b844ac52697acd8da50a70e979584a9b2).

rasterio can be built against it fairly easily by changing https://github.com/mojodna/marblecutter-tools/blob/master/requirements.txt#L4 and building with `docker-compose build` in a marblecutter-tools working directory.