### PR TITLE
GDAL geotransform arrays are never passed to Rasterio funcs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,9 @@ Breaking changes:
 - The deprecated r- mode has been removed from ``rasterio.open()`` (#1116).
 - A bytearray is no longer allowed as input to the ``MemoryFile`` constructor.
   Users must convert byte arrays to ``bytes before calling ``MemoryFile()``.
+- Signatures of private functions and classes in _features, _warp, _io have
+  been changed to always take instances of Affine instead of GDAL geotransform
+  arrays (#796).
 
 A number of deprecated features have been removed (#1319).
 

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -33,7 +33,7 @@ def _shapes(image, mask, connectivity, transform):
         Must evaluate to bool (rasterio.bool_ or rasterio.uint8)
     connectivity : int
         Use 4 or 8 pixel connectivity for grouping pixels into features
-    transform : Affine transformation
+    transform : Affine
         If not provided, feature coordinates will be generated based on pixel
         coordinates
 
@@ -310,7 +310,7 @@ def _rasterize(shapes, image, transform, all_touched, merge_alg):
             exc_wrap_int(
                 GDALRasterizeGeometries(
                     mem.handle(), 1, mem.band_ids,num_geoms, geoms, NULL,
-                    mem.transform, pixel_values, options, NULL, NULL))
+                    mem.gdal_transform, pixel_values, options, NULL, NULL))
 
             # Read in-memory data back into image
             image = mem.read()

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -32,7 +32,7 @@ cdef class InMemoryRaster:
     cdef int band_ids[1]
     cdef np.ndarray _image
     cdef object crs
-    cdef object transform
+    cdef object transform  # this is an Affine object.
 
     cdef GDALDatasetH handle(self) except NULL
     cdef GDALRasterBandH band(self, int) except NULL

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -28,10 +28,11 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
 cdef class InMemoryRaster:
     cdef GDALDatasetH _hds
-    cdef double transform[6]
+    cdef double gdal_transform[6]
     cdef int band_ids[1]
     cdef np.ndarray _image
     cdef object crs
+    cdef object transform
 
     cdef GDALDatasetH handle(self) except NULL
     cdef GDALRasterBandH band(self, int) except NULL

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1624,7 +1624,7 @@ cdef class InMemoryRaster:
 
         :param image: 2D numpy array.  Must be of supported data type
         (see rasterio.dtypes.dtype_rev)
-        :param transform: GDAL compatible transform array
+        :param transform: Affine transform object
         """
 
         self._image = image
@@ -1658,9 +1658,11 @@ cdef class InMemoryRaster:
                        count, <GDALDataType>dtypes.dtype_rev[dtype], NULL))
 
         if transform is not None:
+            self.transform = transform
+            transform = transform.to_gdal()
             for i in range(6):
-                self.transform[i] = transform[i]
-            err = GDALSetGeoTransform(self._hds, self.transform)
+                self.gdal_transform[i] = transform[i]
+            err = GDALSetGeoTransform(self._hds, self.gdal_transform)
             if err:
                 raise ValueError("transform not set: %s" % transform)
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1659,9 +1659,9 @@ cdef class InMemoryRaster:
 
         if transform is not None:
             self.transform = transform
-            transform = transform.to_gdal()
+            gdal_transform = transform.to_gdal()
             for i in range(6):
-                self.gdal_transform[i] = transform[i]
+                self.gdal_transform[i] = gdal_transform[i]
             err = GDALSetGeoTransform(self._hds, self.gdal_transform)
             if err:
                 raise ValueError("transform not set: %s" % transform)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -275,22 +275,22 @@ def _reproject(
     # If working with identity transform, assume it is crs-less data
     # and that translating the matrix very slightly will avoid #674
     eps = 1e-100
+
     if src_transform:
+
         src_transform = guard_transform(src_transform)
         # if src_transform is like `identity` with positive or negative `e`,
         # translate matrix very slightly to avoid #674 and #1272.
         if src_transform.almost_equals(identity) or src_transform.almost_equals(Affine(1, 0, 0, 0, -1, 0)):
             src_transform = src_transform.translation(eps, eps)
+        src_transform = src_transform.to_gdal()
+
     if dst_transform:
+
         dst_transform = guard_transform(dst_transform)
         if dst_transform.almost_equals(identity) or dst_transform.almost_equals(Affine(1, 0, 0, 0, -1, 0)):
             dst_transform = dst_transform.translation(eps, eps)
-
-    # Convert transforms to GDAL format.
-    if src_transform:
-        src_transform = guard_transform(src_transform).to_gdal()
-    if dst_transform:
-        dst_transform = guard_transform(dst_transform).to_gdal()
+        dst_transform = dst_transform.to_gdal()
 
     # Validate nodata values immediately.
     if src_nodata is not None:

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -6,6 +6,7 @@ include "gdal.pxi"
 import logging
 import uuid
 
+from affine import identity
 import numpy as np
 
 from rasterio._err import (
@@ -15,7 +16,7 @@ from rasterio import dtypes
 from rasterio.control import GroundControlPoint
 from rasterio.enums import Resampling
 from rasterio.errors import DriverRegistrationError, CRSError, RasterioIOError
-from rasterio.transform import Affine, from_bounds, tastes_like_gdal
+from rasterio.transform import Affine, from_bounds, guard_transform, tastes_like_gdal
 from rasterio.vfs import parse_path, vsi_path
 
 cimport numpy as np
@@ -270,6 +271,26 @@ def _reproject(
     cdef void *hTransformArg = NULL
     cdef GDALTransformerFunc pfnTransformer = NULL
     cdef GDALWarpOptions *psWOptions = NULL
+
+    # If working with identity transform, assume it is crs-less data
+    # and that translating the matrix very slightly will avoid #674
+    eps = 1e-100
+    if src_transform:
+        src_transform = guard_transform(src_transform)
+        # if src_transform is like `identity` with positive or negative `e`,
+        # translate matrix very slightly to avoid #674 and #1272.
+        if src_transform.almost_equals(identity) or src_transform.almost_equals(Affine(1, 0, 0, 0, -1, 0)):
+            src_transform = src_transform.translation(eps, eps)
+    if dst_transform:
+        dst_transform = guard_transform(dst_transform)
+        if dst_transform.almost_equals(identity) or dst_transform.almost_equals(Affine(1, 0, 0, 0, -1, 0)):
+            dst_transform = dst_transform.translation(eps, eps)
+
+    # Convert transforms to GDAL format.
+    if src_transform:
+        src_transform = guard_transform(src_transform).to_gdal()
+    if dst_transform:
+        dst_transform = guard_transform(dst_transform).to_gdal()
 
     # Validate nodata values immediately.
     if src_nodata is not None:
@@ -566,7 +587,6 @@ def _calculate_default_transform(src_crs, dst_crs, width, height,
 
     if all(x is not None for x in (left, bottom, right, top)):
         transform = from_bounds(left, bottom, right, top, width, height)
-        transform = transform.to_gdal()
     elif any(x is not None for x in (left, bottom, right, top)):
         raise ValueError(
             "Some, but not all, bounding box parameters were provided.")

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -105,7 +105,7 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
 
     """
     transform = guard_transform(transform)
-    for s, v in _shapes(source, mask, connectivity, transform.to_gdal()):
+    for s, v in _shapes(source, mask, connectivity, transform):
         yield s, v
 
 
@@ -308,7 +308,7 @@ def rasterize(
         raise ValueError("width and height must be > 0")
 
     transform = guard_transform(transform)
-    _rasterize(valid_shapes, out, transform.to_gdal(), all_touched, merge_alg)
+    _rasterize(valid_shapes, out, transform, all_touched, merge_alg)
     return out
 
 
@@ -476,21 +476,21 @@ def is_valid_geom(geom):
         if geom_type == 'MultiLineString':
             # Multi lines must have at least one LineString
             return (len(coords) > 0 and len(coords[0]) >= 2 and
-                    len(coords[0][0]) >=2)
+                    len(coords[0][0]) >= 2)
 
         if geom_type == 'Polygon':
             # Polygons must have at least 1 ring, with at least 4 coordinates,
             # with at least x, y for a coordinate
             return (len(coords) > 0 and len(coords[0]) >= 4 and
-                    len(coords[0][0]) >=2)
+                    len(coords[0][0]) >= 2)
 
         if geom_type == 'MultiPolygon':
             # Muti polygons must have at least one Polygon
             return (len(coords) > 0 and len(coords[0]) > 0 and
-                    len(coords[0][0]) >= 4 and len(coords[0][0][0]) >=2)
+                    len(coords[0][0]) >= 4 and len(coords[0][0][0]) >= 2)
 
     if geom_type == 'GeometryCollection':
-        if not 'geometries' in geom:
+        if 'geometries' not in geom:
             return False
 
         if not len(geom['geometries']) > 0:


### PR DESCRIPTION
GDAL geotransform arrays are constructed and passed to GDAL functions, but Rasterio functions and methods, even the private ones, always take instances of Affine.

Resolves #796.