### PR TITLE
Safeguard/isolate legacy GDAL filenames

### DIFF
--- a/docs/topics/datasets.rst
+++ b/docs/topics/datasets.rst
@@ -47,3 +47,26 @@ Datasets on AWS S3 may be identified using "s3" scheme identifiers.
 ``'s3://landsat-pds/L8/139/045/LC81390452014295LGN00/LC81390452014295LGN00_B1.TIF'``
 
 Resources in other cloud storage systems will be similarly supported.
+
+Legacy GDAL filenames
+---------------------
+
+Legacy GDAL filenames like
+
+* ``'/vsis3/landsat-pds/L8/139/045/LC81390452014295LGN00/LC81390452014295LGN00_B1.TIF'``
+* ``'PG:"host=localhost port:80 dbname=foo user=bar password=xxxxxx"'``
+
+may be used by wrapping them in an instance of ``GDALFilename``.
+
+.. code-block:: python
+
+    import rasterio
+
+    filename = rasterio.GDALFilename(
+        'PG:host=localhost port:80 dbname=foo user=bar password=xxx')
+
+    with rasterio.open(filename) as src:
+        print(src.profile)
+
+Without ``GDALFilename`` Rasterio cannot guarantee that the legacy filenames
+are handled as you would expect.

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -29,7 +29,7 @@ from rasterio.errors import (
     RasterBlockError, BandOverviewError)
 from rasterio.profiles import Profile
 from rasterio.transform import Affine, guard_transform, tastes_like_gdal
-from rasterio.vfs import parse_path, vsi_path
+from rasterio.vfs import parse_path, vsi_path, GDALFilename
 from rasterio import windows
 
 include "gdal.pxi"
@@ -59,7 +59,11 @@ def get_dataset_driver(path):
     cdef GDALDatasetH dataset = NULL
     cdef GDALDriverH driver = NULL
 
-    path = vsi_path(*parse_path(path))
+    if isinstance(path, GDALFilename):
+        path = path.filename
+    else:
+        path = vsi_path(*parse_path(path))
+
     path = path.encode('utf-8')
 
     try:
@@ -118,7 +122,12 @@ cdef class DatasetBase(object):
         self._hds = NULL
 
         if path is not None:
-            filename = vsi_path(*parse_path(path))
+
+            if isinstance(path, GDALFilename):
+                filename = path.filename
+
+            else:
+                filename = vsi_path(*parse_path(path))
 
             # driver may be a string or list of strings. If the
             # former, we put it into a list.

--- a/rasterio/vfs.py
+++ b/rasterio/vfs.py
@@ -77,3 +77,21 @@ def vsi_path(path, archive=None, scheme=None):
     else:
         result = path
     return result
+
+
+class GDALFilename(object):
+    """A GDAL filename object
+
+    All legacy GDAL filenames must be wrapped using this class.
+
+    Attributes
+    ----------
+    filename : str
+        A GDAL filename such as "/vsicurl/https://example.com/data.tif".
+    """
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __repr__(self):
+        return "<GDALFilename filename={}>".format(self.filename)

--- a/tests/test_vfs.py
+++ b/tests/test_vfs.py
@@ -5,7 +5,7 @@ import pytest
 
 import rasterio
 from rasterio.profiles import default_gtiff_profile
-from rasterio.vfs import parse_path, vsi_path
+from rasterio.vfs import parse_path, vsi_path, GDALFilename
 
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
@@ -98,3 +98,12 @@ def test_parse_path_accept_get_params():
     # See https://github.com/mapbox/rasterio/issues/1121
     assert parse_path('http://example.com/index?a=1') == (
         'example.com/index?a=1', None, 'http')
+
+
+def test_gdal_filename():
+    assert GDALFilename("foo.tif").filename == "foo.tif"
+
+
+def test_gdal_filename_open():
+    with rasterio.open(GDALFilename("tests/data/RGB.byte.tif")) as src:
+        assert src.count == 3


### PR DESCRIPTION
I had a minor brain storm this afternoon and came up with a way to have 💯support for legacy GDAL filenames while also promoting the better "https", "s3", and "zip+https" identifiers. It's inspired by our relatively new support for `pathlib.Path` objects.

Here's the accompanying documentation:

<img width="773" alt="untitled" src="https://user-images.githubusercontent.com/33697/40260338-490ac8f6-5ab7-11e8-9c51-c7730d2af2b4.png">