### PR TITLE
WIP: Add -G to main_group

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -125,9 +125,11 @@ cdef class DatasetBase(object):
 
             if isinstance(path, GDALFilename):
                 filename = path.filename
+                self.name = filename
 
             else:
                 filename = vsi_path(*parse_path(path))
+                self.name = path
 
             # driver may be a string or list of strings. If the
             # former, we put it into a list.
@@ -142,7 +144,6 @@ cdef class DatasetBase(object):
             except CPLE_OpenFailedError as err:
                 raise RasterioIOError(str(err))
 
-        self.name = path
         self.mode = 'r'
         self.options = kwargs.copy()
         self._dtypes = []

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -62,11 +62,12 @@ def gdal_version_cb(ctx, param, value):
 @cligj.quiet_opt
 @click.option('--aws-profile',
               help="Selects a profile from your shared AWS credentials file")
+@options.use_legacy_filenames_opt
 @click.version_option(version=rasterio.__version__, message='%(version)s')
 @click.option('--gdal-version', is_eager=True, is_flag=True,
-              callback=gdal_version_cb)
+              callback=gdal_version_cb, help="Show GDAL library version.")
 @click.pass_context
-def main_group(ctx, verbose, quiet, aws_profile, gdal_version):
+def main_group(ctx, verbose, quiet, aws_profile, use_legacy_filenames, gdal_version):
     """Rasterio command line interface.
     """
     verbosity = verbose - quiet
@@ -74,5 +75,6 @@ def main_group(ctx, verbose, quiet, aws_profile, gdal_version):
     ctx.obj = {}
     ctx.obj['verbosity'] = verbosity
     ctx.obj['aws_profile'] = aws_profile
+    ctx.obj['use_legacy_filenames'] = use_legacy_filenames
     ctx.obj['env'] = rasterio.Env(CPL_DEBUG=(verbosity > 2),
                                   profile_name=aws_profile)

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -290,8 +290,11 @@ def test_info():
     assert info['dtype'] == 'uint8'
     assert info['crs'] == 'EPSG:32618'
 
+
+def test_info_legacy_filename():
+    runner = CliRunner()
     result = runner.invoke(
-        main_group, ['info', 'tests/data/float.tif'])
+        main_group, ['-G', 'info', 'tests/data/float.tif'])
     assert result.exit_code == 0
     info = json.loads(result.output)
     assert info['count'] == 1

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -114,6 +114,14 @@ def test_file_in_handler_s3():
     assert retval == 's3://example.com/RGB.byte.tif'
 
 
+def test_file_in_handler_legacy():
+    """Legacy filenames are handled"""
+    ctx = MockContext()
+    ctx.obj['use_legacy_filenames'] = True
+    retval = file_in_handler(ctx, 'INPUT', '/vsis3/example/RGB.byte.tif')
+    assert retval.filename == '/vsis3/example/RGB.byte.tif'
+
+
 def test_like_dataset_callback(data):
     ctx = MockContext()
     assert like_handler(ctx, 'like', str(data.join('RGB.byte.tif')))


### PR DESCRIPTION
This option puts the file_in_arg handler into legacy filename mode: `/vsi*/` paths will work and so will database connection strings that would not otherwise pass validation.

This resolves #871 and may possibly make obsolete #1079.

To be merged after #1346.

Example:

```
$ rio -G info /vsizip/tests/data/white-gemini-iv.zip/white-gemini-iv.vrt
/Users/sean/code/rasterio/rasterio/__init__.py:226: NotGeoreferencedWarning: Dataset has no geotransform set. Default transform will be applied (Affine.identity())
  s = DatasetReader(fp, driver=driver, **kwargs)
{"blockxsize": 128, "blockysize": 128, "bounds": [0.0, 768.0, 1024.0, 0.0], "colorinterp": ["grey", "grey", "grey"], "count": 3, "crs": null, "descriptions": [null, null, null], "driver": "VRT", "dtype": "uint8", "height": 768, "indexes": [1, 2, 3], "mask_flags": [["all_valid"], ["all_valid"], ["all_valid"]], "nodata": null, "res": [1.0, -1.0], "shape": [768, 1024], "tiled": true, "transform": [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], "units": [null, null, null], "width": 1024}
```