### PR TITLE
Change properties from tuples to lists

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Next
 
 Breaking changes:
 
+- Properties block_shapes, dtypes, indexes, nodatavals, colorinterp, files,
+  descriptions, units, mask_flag_enums have been changed from tuples to lists.
 - Whether to print GeoJSON feature sequences or a GeoJSON feature collection
   from rio-shapes is now controlled by a ``--sequence/--collection`` option.
   A sequence is now the default (#927).

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -996,7 +996,7 @@ cdef class DatasetBase(object):
             from rasterio.enums import ColorInterp
 
             with rasterio.open('rgba.tif', 'r+') as src:
-                src.coolorinterp = [
+                src.colorinterp = [
                     ColorInterp.red,
                     ColorInterp.green,
                     ColorInterp.blue,

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1106,6 +1106,17 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         self._closed = True
         log.debug("Dataset %r has been stopped.", self)
 
+    def _set_colorinterp(self, value):
+        if len(value) != len(self.indexes):
+            raise ValueError(
+                "Must set color interpretation for all bands.  Found "
+                "{} bands but attempting to set color interpretation to: "
+                "{}".format(len(self.indexes), value))
+
+        for bidx, ci in zip(self.indexes, value):
+            exc_wrap_int(
+                GDALSetRasterColorInterpretation(self.band(bidx), ci.value))
+
     def _set_crs(self, crs):
         """Writes a coordinate reference system to the dataset."""
         cdef char *proj_c = NULL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,6 @@ def geojson_geomcollection():
     }
 
 
-
 @pytest.fixture
 def basic_feature(basic_geometry):
     """
@@ -429,7 +428,7 @@ def rotated_image_file(tmpdir, pixelated_image):
     image = 128 * np.ones((1000, 2000), dtype=np.uint8)
 
     rotated_transform = Affine(-0.05, 0.07, 481060,
-                                0.07, 0.05, 4481030)
+                               0.07, 0.05, 4481030)
 
     outfilename = str(tmpdir.join('rotated_image.tif'))
     kwargs = {
@@ -506,7 +505,6 @@ def _path_multiband_no_colorinterp(tmpdir):
             'photometric': 'minisblack'
         }
 
-        undefined_ci = tuple(undefined_ci)
         with rasterio.open(dst_path, 'w', **profile) as src:
             src.colorinterp = undefined_ci
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -68,12 +68,13 @@ class RasterBlocksTest(unittest.TestCase):
     def test_blocks(self):
         with rasterio.open('tests/data/RGB.byte.tif') as s:
             self.assertEqual(len(s.block_shapes), 3)
-            self.assertEqual(s.block_shapes, ((3, 791), (3, 791), (3, 791)))
+            self.assertEqual(s.block_shapes, [(3, 791), (3, 791), (3, 791)])
             itr = s.block_windows(1)
             (j, i), first = next(itr)
             self.assertEqual((j, i), (0, 0))
             self.assertEqual(first, windows.Window.from_slices((0, 3), (0, 791)))
             itr = s.block_windows()
+
             (j, i), first = next(itr)
             self.assertEqual((j, i), (0, 0))
             self.assertEqual(first, windows.Window.from_slices((0, 3), (0, 791)))

--- a/tests/test_colorinterp.py
+++ b/tests/test_colorinterp.py
@@ -19,11 +19,11 @@ def test_cmyk_interp(tmpdir):
     tiffname = str(tmpdir.join('foo.tif'))
     with rasterio.open(tiffname, 'w', **profile) as dst:
         assert dst.profile['count'] == 4
-        assert dst.colorinterp == (
+        assert dst.colorinterp == [
             ColorInterp.cyan,
             ColorInterp.magenta,
             ColorInterp.yellow,
-            ColorInterp.black)
+            ColorInterp.black]
 
 
 @requires_gdal22(reason="Some versions prior to 2.2.2 segfault on a Mac OSX "
@@ -37,8 +37,8 @@ def test_ycbcr_interp(tmpdir):
     meta['count'] = 3
     tiffname = str(tmpdir.join('foo.tif'))
     with rasterio.open(tiffname, 'w', **meta) as dst:
-        assert dst.colorinterp == (
-            ColorInterp.red, ColorInterp.green, ColorInterp.blue)
+        assert dst.colorinterp == [
+            ColorInterp.red, ColorInterp.green, ColorInterp.blue]
 
 
 @pytest.mark.parametrize("dtype", [rasterio.ubyte, rasterio.int16])
@@ -62,17 +62,17 @@ def test_set_colorinterp(path_rgba_byte_tif, tmpdir, dtype):
 
     # This is should be the default color interpretation of the copied
     # image.  GDAL defines these defaults, not Rasterio.
-    src_ci = (
+    src_ci = [
         ColorInterp.gray,
         ColorInterp.undefined,
         ColorInterp.undefined,
-        ColorInterp.undefined)
+        ColorInterp.undefined]
 
-    dst_ci = (
+    dst_ci = [
         ColorInterp.alpha,
         ColorInterp.blue,
         ColorInterp.green,
-        ColorInterp.red)
+        ColorInterp.red]
 
     with rasterio.open(no_ci_path, 'r+') as src:
         assert src.colorinterp == src_ci
@@ -90,7 +90,7 @@ def test_set_colorinterp_all(path_4band_no_colorinterp, ci):
     """Test setting with all color interpretations."""
 
     with rasterio.open(path_4band_no_colorinterp, 'r+') as src:
-        all_ci = list(src.colorinterp)
+        all_ci = src.colorinterp
         all_ci[1] = ci
         src.colorinterp = all_ci
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -15,7 +15,7 @@ def test_files(data):
     with open(aux, 'w'):
         pass
     with rasterio.open(tif) as src:
-        assert src.files == (tif, aux)
+        assert src.files == [tif, aux]
 
 
 def test_handle_closed(path_rgb_byte_tif):

--- a/tests/test_descriptions.py
+++ b/tests/test_descriptions.py
@@ -11,10 +11,10 @@ def test_set_band_descriptions(tmpdir):
     with rasterio.open(
             tmptiff, 'w', count=3, height=256, width=256,
             **default_gtiff_profile) as dst:
-        assert dst.descriptions == (None, None, None)
+        assert dst.descriptions == [None, None, None]
         dst.descriptions = ["this is a test band", "this is another test band", None]
-        assert dst.descriptions == (
-            "this is a test band", "this is another test band", None)
+        assert dst.descriptions == [
+            "this is a test band", "this is another test band", None]
 
 
 @pytest.mark.parametrize('value', [[], ['x'], ['x', 'y', 'z']])
@@ -34,9 +34,9 @@ def test_set_band_descriptions_deprecated(tmpdir):
     with rasterio.open(
             tmptiff, 'w', count=2, height=256, width=256,
             **default_gtiff_profile) as dst:
-        assert dst.descriptions == (None, None)
+        assert dst.descriptions == [None, None]
         with pytest.warns(RasterioDeprecationWarning):
             dst.set_description(1, "this is a test band")
             dst.set_description(2, "this is another test band")
-            assert dst.descriptions == (
-                "this is a test band", "this is another test band")
+            assert dst.descriptions == [
+                "this is a test band", "this is another test band"]

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -57,7 +57,7 @@ def test_initial_bytes(rgb_file_bytes):
         with memfile.open() as src:
             assert src.driver == 'GTiff'
             assert src.count == 3
-            assert src.dtypes == ('uint8', 'uint8', 'uint8')
+            assert src.dtypes == ['uint8', 'uint8', 'uint8']
             assert src.read().shape == (3, 718, 791)
 
 
@@ -67,7 +67,7 @@ def test_initial_lzw_bytes(rgb_lzw_file_bytes):
         with memfile.open() as src:
             assert src.driver == 'GTiff'
             assert src.count == 3
-            assert src.dtypes == ('uint8', 'uint8', 'uint8')
+            assert src.dtypes == ['uint8', 'uint8', 'uint8']
             assert src.read().shape == (3, 718, 791)
 
 
@@ -77,7 +77,7 @@ def test_initial_file_object(rgb_file_object):
         with memfile.open() as src:
             assert src.driver == 'GTiff'
             assert src.count == 3
-            assert src.dtypes == ('uint8', 'uint8', 'uint8')
+            assert src.dtypes == ['uint8', 'uint8', 'uint8']
             assert src.read().shape == (3, 718, 791)
 
 
@@ -96,7 +96,7 @@ def test_non_initial_bytes(rgb_file_bytes):
         with memfile.open() as src:
             assert src.driver == 'GTiff'
             assert src.count == 3
-            assert src.dtypes == ('uint8', 'uint8', 'uint8')
+            assert src.dtypes == ['uint8', 'uint8', 'uint8']
             assert src.read().shape == (3, 718, 791)
 
 
@@ -108,7 +108,7 @@ def test_non_initial_bytes_in_two(rgb_file_bytes):
         with memfile.open() as src:
             assert src.driver == 'GTiff'
             assert src.count == 3
-            assert src.dtypes == ('uint8', 'uint8', 'uint8')
+            assert src.dtypes == ['uint8', 'uint8', 'uint8']
             assert src.read().shape == (3, 718, 791)
 
 
@@ -151,7 +151,7 @@ def test_file_object_read(rgb_file_object):
     with rasterio.open(rgb_file_object) as src:
         assert src.driver == 'GTiff'
         assert src.count == 3
-        assert src.dtypes == ('uint8', 'uint8', 'uint8')
+        assert src.dtypes == ['uint8', 'uint8', 'uint8']
         assert src.read().shape == (3, 718, 791)
 
 
@@ -160,7 +160,7 @@ def test_file_object_read_variant(rgb_file_bytes):
     with rasterio.open(MemoryFile(rgb_file_bytes)) as src:
         assert src.driver == 'GTiff'
         assert src.count == 3
-        assert src.dtypes == ('uint8', 'uint8', 'uint8')
+        assert src.dtypes == ['uint8', 'uint8', 'uint8']
         assert src.read().shape == (3, 718, 791)
 
 
@@ -169,7 +169,7 @@ def test_file_object_read_variant2(rgb_file_bytes):
     with rasterio.open(BytesIO(rgb_file_bytes)) as src:
         assert src.driver == 'GTiff'
         assert src.count == 3
-        assert src.dtypes == ('uint8', 'uint8', 'uint8')
+        assert src.dtypes == ['uint8', 'uint8', 'uint8']
         assert src.read().shape == (3, 718, 791)
 
 
@@ -183,7 +183,7 @@ def test_test_file_object_write(tmpdir, rgb_data_and_profile):
     with rasterio.open(str(tmpdir.join('test.tif'))) as src:
         assert src.driver == 'GTiff'
         assert src.count == 3
-        assert src.dtypes == ('uint8', 'uint8', 'uint8')
+        assert src.dtypes == ['uint8', 'uint8', 'uint8']
         assert src.read().shape == (3, 718, 791)
 
 
@@ -214,5 +214,5 @@ def test_zip_file_object_read(path_zip_file):
             with zipmemfile.open('white-gemini-iv.vrt') as src:
                 assert src.driver == 'VRT'
                 assert src.count == 3
-                assert src.dtypes == ('uint8', 'uint8', 'uint8')
+                assert src.dtypes == ['uint8', 'uint8', 'uint8']
                 assert src.read().shape == (3, 768, 1024)

--- a/tests/test_nodata.py
+++ b/tests/test_nodata.py
@@ -14,7 +14,7 @@ def test_nodata(tmpdir):
         with rasterio.open(dst_path, 'w', **src.meta) as dst:
             assert dst.nodata == 0.0
             assert dst.meta['nodata'] == 0.0
-            assert dst.nodatavals == (0.0, 0.0, 0.0)
+            assert dst.nodatavals == [0.0, 0.0, 0.0]
     info = subprocess.check_output([
         'gdalinfo', dst_path])
     pattern = b'Band 1.*?NoData Value=0'
@@ -32,7 +32,7 @@ def test_set_nodata(tmpdir):
         with rasterio.open(dst_path, 'w', **meta) as dst:
             assert dst.nodata == 42
             assert dst.meta['nodata'] == 42
-            assert dst.nodatavals == (42, 42, 42)
+            assert dst.nodatavals == [42, 42, 42]
     info = subprocess.check_output([
         'gdalinfo', dst_path])
     pattern = b'Band 1.*?NoData Value=42'

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -60,11 +60,11 @@ def test_show_cmyk_interp(tmpdir):
     meta['count'] = 4
     tiffname = str(tmpdir.join('foo.tif'))
     with rasterio.open(tiffname, 'w', **meta) as dst:
-        assert dst.colorinterp == (
+        assert dst.colorinterp == [
             ColorInterp.cyan,
             ColorInterp.magenta,
             ColorInterp.yellow,
-            ColorInterp.black)
+            ColorInterp.black]
 
     with rasterio.open(tiffname) as src:
         try:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -32,9 +32,9 @@ class ReaderContextTest(unittest.TestCase):
             self.assertEqual(s.width, 791)
             self.assertEqual(s.height, 718)
             self.assertEqual(s.shape, (718, 791))
-            self.assertEqual(s.dtypes, tuple([rasterio.ubyte] * 3))
-            self.assertEqual(s.nodatavals, (0, 0, 0))
-            self.assertEqual(s.indexes, (1, 2, 3))
+            self.assertEqual(s.dtypes, [rasterio.ubyte] * 3)
+            self.assertEqual(s.nodatavals, [0, 0, 0])
+            self.assertEqual(s.indexes, [1, 2, 3])
             self.assertEqual(s.crs['init'], 'epsg:32618')
             self.assertTrue(s.crs.wkt.startswith('PROJCS'), s.crs.wkt)
             for i, v in enumerate((101985.0, 2611485.0, 339315.0, 2826915.0)):
@@ -54,8 +54,8 @@ class ReaderContextTest(unittest.TestCase):
         self.assertEqual(s.width, 791)
         self.assertEqual(s.height, 718)
         self.assertEqual(s.shape, (718, 791))
-        self.assertEqual(s.dtypes, tuple([rasterio.ubyte] * 3))
-        self.assertEqual(s.nodatavals, (0, 0, 0))
+        self.assertEqual(s.dtypes, [rasterio.ubyte] * 3)
+        self.assertEqual(s.nodatavals, [0, 0, 0])
         self.assertEqual(s.crs['init'], 'epsg:32618')
         self.assertEqual(
             s.transform,

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -127,7 +127,7 @@ def test_dtype(tmpdir):
         ['convert', 'tests/data/RGB.byte.tif', outputname, '--dtype', 'uint16'])
     assert result.exit_code == 0
     with rasterio.open(outputname) as src:
-        assert src.dtypes == tuple(['uint16'] * 3)
+        assert src.dtypes == list(['uint16'] * 3)
 
 
 def test_dtype_rescaling_uint8_full(tmpdir):

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -330,8 +330,8 @@ def test_colorinterp_wrong_band_count(runner, path_3band_no_colorinterp, setci):
 
 
 @pytest.mark.parametrize("setci,expected", [
-    ('RGB', (ColorInterp.red, ColorInterp.green, ColorInterp.blue)),
-    ('red,green,blue', (ColorInterp.red, ColorInterp.green, ColorInterp.blue)),
+    ('RGB', [ColorInterp.red, ColorInterp.green, ColorInterp.blue]),
+    ('red,green,blue', [ColorInterp.red, ColorInterp.green, ColorInterp.blue]),
 ])
 def test_colorinterp_rgb(setci, expected, path_3band_no_colorinterp):
     """Set 3 band color interpretation."""
@@ -345,9 +345,9 @@ def test_colorinterp_rgb(setci, expected, path_3band_no_colorinterp):
 
 
 @pytest.mark.parametrize("setci,expected", [
-    ('red,green,blue,undefined', (ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.undefined)),
-    ('RGBA', (ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.alpha)),
-    ('red,green,blue,alpha', (ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.alpha)),
+    ('red,green,blue,undefined', [ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.undefined]),
+    ('RGBA', [ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.alpha]),
+    ('red,green,blue,alpha', [ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.alpha]),
 ])
 def test_colorinterp_4band(setci, expected, path_4band_no_colorinterp):
     """Set 4 band color interpretation."""
@@ -379,11 +379,11 @@ def test_colorinterp_like(path_4band_no_colorinterp, path_rgba_byte_tif):
         '--colorinterp', 'like'])
     assert result.exit_code == 0
     with rasterio.open(path_4band_no_colorinterp) as src:
-        assert src.colorinterp == (
+        assert src.colorinterp == [
             ColorInterp.red,
             ColorInterp.green,
             ColorInterp.blue,
-            ColorInterp.alpha)
+            ColorInterp.alpha]
 
 
 def test_like_band_count_mismatch(runner, data):
@@ -409,11 +409,11 @@ def test_colorinterp_like_all(
         'edit-info', noci, '--like', path_rgba_byte_tif, '--all'])
     assert result.exit_code == 0
     with rasterio.open(noci) as src:
-        assert src.colorinterp == (
+        assert src.colorinterp == [
             ColorInterp.red,
             ColorInterp.green,
             ColorInterp.blue,
-            ColorInterp.alpha)
+            ColorInterp.alpha]
 
 
 def test_transform_callback_pass(data):

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -118,8 +118,8 @@ def test_like_dataset_callback(data):
     ctx = MockContext()
     assert like_handler(ctx, 'like', str(data.join('RGB.byte.tif')))
     assert ctx.obj['like']['crs'] == {'init': 'epsg:32618'}
-    assert ctx.obj['like']['colorinterp'] == (
-        ColorInterp.red, ColorInterp.green, ColorInterp.blue)
+    assert ctx.obj['like']['colorinterp'] == [
+        ColorInterp.red, ColorInterp.green, ColorInterp.blue]
 
 
 def test_like_dataset_callback_obj_init(data):

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -11,9 +11,9 @@ def test_set_units(tmpdir):
     with rasterio.open(
             tmptiff, 'w', count=3, height=256, width=256,
             **default_gtiff_profile) as dst:
-        assert dst.units == (None, None, None)
+        assert dst.units == [None, None, None]
         dst.units = ['meters', 'degC', None]
-        assert dst.units == ('meters', 'degC', None)
+        assert dst.units == ['meters', 'degC', None]
 
 
 @pytest.mark.parametrize('value', [['m'], ['m', 'ft', 'sec'], []])
@@ -33,8 +33,8 @@ def test_set_units_deprecated(tmpdir):
     with rasterio.open(
             tmptiff, 'w', count=2, height=256, width=256,
             **default_gtiff_profile) as dst:
-        assert dst.units == (None, None)
+        assert dst.units == [None, None]
         with pytest.warns(RasterioDeprecationWarning):
             dst.set_units(1, 'meters')
             dst.set_units(2, 'degC')
-            assert dst.units == ('meters', 'degC')
+            assert dst.units == ['meters', 'degC']

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -63,7 +63,7 @@ def test_update_nodata(data):
     with rasterio.open(tiffname, 'r+') as f:
         f.nodata = 255
     with rasterio.open(tiffname) as f:
-        assert f.nodatavals == (255, 255, 255)
+        assert f.nodatavals == [255, 255, 255]
 
 
 @pytest.mark.skipif(
@@ -84,7 +84,7 @@ def test_update_nodatavals_none(data):
     with rasterio.open(tiffname, 'r+') as f:
         f.nodata = None
     with rasterio.open(tiffname) as f:
-        assert f.nodatavals == (None, None, None)
+        assert f.nodatavals == [None, None, None]
 
 
 def test_update_mask_true(data):

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -76,9 +76,9 @@ def test_wrap_file(path_rgb_byte_tif):
             -8789636.7, 2700460.0, -8524406.4, 2943560.2)
         assert vrt.name.startswith('WarpedVRT(')
         assert vrt.name.endswith('tests/data/RGB.byte.tif)')
-        assert vrt.indexes == (1, 2, 3)
-        assert vrt.nodatavals == (0, 0, 0)
-        assert vrt.dtypes == ('uint8', 'uint8', 'uint8')
+        assert vrt.indexes == [1, 2, 3]
+        assert vrt.nodatavals == [0, 0, 0]
+        assert vrt.dtypes == ['uint8', 'uint8', 'uint8']
         assert vrt.read().shape == (3, 736, 803)
 
 
@@ -127,9 +127,9 @@ def test_wrap_s3():
             assert tuple(round(x, 1) for x in vrt.bounds) == (
                 9556764.6, 2345109.3, 9804595.9, 2598509.1)
             assert vrt.name == 'WarpedVRT(s3://landsat-pds/L8/139/045/LC81390452014295LGN00/LC81390452014295LGN00_B1.TIF)'
-            assert vrt.indexes == (1,)
-            assert vrt.nodatavals == (0,)
-            assert vrt.dtypes == ('uint16',)
+            assert vrt.indexes == [1]
+            assert vrt.nodatavals == [0]
+            assert vrt.dtypes == ['uint16']
             assert vrt.shape == (7827, 7655)
 
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -73,7 +73,7 @@ def test_context(tmpdir):
         assert s.width == 100
         assert s.height == 100
         assert s.shape == (100, 100)
-        assert s.indexes == (1,)
+        assert s.indexes == [1]
         assert repr(s) == "<open DatasetWriter name='%s' mode='w'>" % name
     assert s.closed
     assert s.count == 1
@@ -142,7 +142,7 @@ def test_write_float(tmpdir):
             name, 'w',
             driver='GTiff', width=100, height=100, count=2,
             dtype=rasterio.float32) as s:
-        assert s.dtypes == (rasterio.float32, rasterio.float32)
+        assert s.dtypes == [rasterio.float32, rasterio.float32]
         s.write(a, indexes=1)
         s.write(a, indexes=2)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')


### PR DESCRIPTION
Lists are a better fit for band-aggregated properties because of the cultural difference identifed by Ned Batchelder (https://nedbatchelder.com/blog/201608/lists_vs_tuples.html):

> For the most part, you should choose whether to use a list or a tuple based on the Cultural Difference. Think about what your data means. If it can have different lengths based on what your program encounters in the real world, then it is probably a list. If you know when you write the code what the third element means, then it is probably a tuple.

This reverses @perrygeo's work in #655 to resolve #321. These properties used to be lists. I feel I was overthinking the situation and wrong in opening #321.

While technically a breaking change, the code this would break would be pretty unusual in treating the properties as anything other than containers.

There were no reports of #655 breaking anything, and I expect the same for this PR.