### PR TITLE
VRT XML implementation of boundless reads

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -381,7 +381,7 @@ cdef class DatasetReaderBase(DatasetBase):
             vrt_doc = _boundless_vrt_doc(
                 self, nodata=ndv, width=max(self.width, window.width) + 1,
                 height=max(self.height, window.height) + 1,
-                transform=self.window_transform(window))
+                transform=self.window_transform(window)).decode('ascii')
 
             with DatasetReaderBase(UnparsedPath(vrt_doc), driver='VRT') as vrt:
 
@@ -530,7 +530,6 @@ cdef class DatasetReaderBase(DatasetBase):
         else:
             out = np.zeros(win_shape, 'uint8')
 
-
         # We can jump straight to _read() in some cases. We can ignore
         # the boundless flag if there's no given window.
         if not boundless or not window:
@@ -543,7 +542,7 @@ cdef class DatasetReaderBase(DatasetBase):
             vrt_doc = _boundless_vrt_doc(
                 self, width=max(self.width, window.width) + 1,
                 height=max(self.height, window.height) + 1,
-                transform=self.window_transform(window))
+                transform=self.window_transform(window)).decode('ascii')
 
             with DatasetReaderBase(UnparsedPath(vrt_doc), driver='VRT') as vrt:
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -13,7 +13,7 @@ import warnings
 
 import numpy as np
 
-from rasterio._base import tastes_like_gdal
+from rasterio._base import tastes_like_gdal, gdal_version
 from rasterio._env import driver_count, GDALEnv
 from rasterio._err import (
     GDALError, CPLE_OpenFailedError, CPLE_IllegalArgError, CPLE_BaseError)
@@ -79,7 +79,8 @@ def _delete_dataset_if_exists(path):
         log.debug(
             "Skipped delete for overwrite.  Dataset does not exist: %s", path)
     finally:
-        GDALClose(h_dataset)
+        if h_dataset != NULL:
+            GDALClose(h_dataset)
 
 
 cdef bint in_dtype_range(value, dtype):
@@ -383,7 +384,11 @@ cdef class DatasetReaderBase(DatasetBase):
                 height=max(self.height, window.height) + 1,
                 transform=self.window_transform(window)).decode('ascii')
 
-            with DatasetReaderBase(UnparsedPath(vrt_doc), driver='VRT') as vrt:
+            if not gdal_version().startswith('1'):
+                vrt_kwds = {'driver': 'VRT'}
+            else:
+                vrt_kwds = {}
+            with DatasetReaderBase(UnparsedPath(vrt_doc), **vrt_kwds) as vrt:
 
                 out = vrt._read(
                     indexes, out, Window(0, 0, window.width, window.height),
@@ -544,7 +549,11 @@ cdef class DatasetReaderBase(DatasetBase):
                 height=max(self.height, window.height) + 1,
                 transform=self.window_transform(window)).decode('ascii')
 
-            with DatasetReaderBase(UnparsedPath(vrt_doc), driver='VRT') as vrt:
+            if not gdal_version().startswith('1'):
+                vrt_kwds = {'driver': 'VRT'}
+            else:
+                vrt_kwds = {}
+            with DatasetReaderBase(UnparsedPath(vrt_doc), **vrt_kwds) as vrt:
 
                 out = vrt._read(
                     indexes, out, Window(0, 0, window.width, window.height),

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -929,10 +929,10 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
         # This attribute will be used by read().
         self._nodatavals = [
-            self.dst_nodata for i in self.indexes]
+            self.dst_nodata for i in src_dataset.indexes]
 
-        if self.dst_alpha:
-            self._nodatavals[3] = None
+        if self.dst_alpha and len(self._nodatavals) == 3:
+            self._nodatavals.append(None)
 
     def get_crs(self):
         warnings.warn("get_crs() will be removed in 1.0", RasterioDeprecationWarning)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -914,7 +914,10 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
         if self.dst_nodata is None:
             for i in self.indexes:
-                delete_nodata_value(self.band(i))
+                try:
+                    delete_nodata_value(self.band(i))
+                except NotImplementedError as exc:
+                    log.warn(str(exc))
         else:
             for i in self.indexes:
                 GDALSetRasterNoDataValue(self.band(i), self.dst_nodata)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -949,3 +949,20 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         if self._hds != NULL:
             GDALClose(self._hds)
         self._hds = NULL
+
+    def read(self, indexes=None, out=None, window=None, masked=False,
+            out_shape=None, boundless=False, resampling=Resampling.nearest,
+            fill_value=None):
+        """Read a dataset's raw pixels as an N-d array"""
+        if boundless:
+            raise ValueError("WarpedVRT does not permit boundless reads")
+        else:
+            return super(WarpedVRTReaderBase, self).read(indexes=indexes, out=out, window=window, masked=masked, out_shape=out_shape, resampling=resampling, fill_value=fill_value)
+
+    def read_masks(self, indexes=None, out=None, out_shape=None, window=None,
+                   boundless=False, resampling=Resampling.nearest):
+        """Read raster band masks as a multidimensional array"""
+        if boundless:
+            raise ValueError("WarpedVRT does not permit boundless reads")
+        else:
+            return super(WarpedVRTReaderBase, self).read_masks(indexes=indexes, out=out, window=window, out_shape=out_shape, resampling=resampling)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -931,8 +931,8 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self._nodatavals = [
             self.dst_nodata for i in src_dataset.indexes]
 
-        if self.dst_alpha and len(self._nodatavals) == 3:
-            self._nodatavals.append(None)
+        # if self.dst_alpha and len(self._nodatavals) == 3:
+        #     self._nodatavals.append(None)
 
     def get_crs(self):
         warnings.warn("get_crs() will be removed in 1.0", RasterioDeprecationWarning)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -928,11 +928,10 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self._set_attrs_from_dataset_handle()
 
         # This attribute will be used by read().
-        self._nodatavals = [
-            self.dst_nodata for i in src_dataset.indexes]
+        self._nodatavals = [self.dst_nodata for i in self.indexes]
 
-        # if self.dst_alpha and len(self._nodatavals) == 3:
-        #     self._nodatavals.append(None)
+        if self.dst_alpha and len(self._nodatavals) == 3:
+            self._nodatavals[3] = None
 
     def get_crs(self):
         warnings.warn("get_crs() will be removed in 1.0", RasterioDeprecationWarning)

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -499,11 +499,6 @@ def _reproject(
         CPLFree(imgProjOptions)
         raise
 
-    # Note: warp_extras is pointed to different memory locations on every
-    # call to CSLSetNameValue call below, but needs to be set here to
-    # get the defaults.
-    # warp_extras = psWOptions.papszWarpOptions
-
     valb = str(num_threads).encode('utf-8')
     warp_extras = CSLSetNameValue(warp_extras, "NUM_THREADS", <const char *>valb)
 
@@ -919,8 +914,8 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         finally:
             CPLFree(dst_crs_wkt)
             CSLDestroy(c_warp_extras)
-            # if psWOptions != NULL:
-            #    GDALDestroyWarpOptions(psWOptions)
+            if psWOptions != NULL:
+                GDALDestroyWarpOptions(psWOptions)
 
         if self.dst_nodata is None:
             for i in self.indexes:

--- a/rasterio/rio/insp.py
+++ b/rasterio/rio/insp.py
@@ -28,8 +28,6 @@ except RuntimeError as e:  # pragma: no cover
     plt = None
 
 
-logger = logging.getLogger('rasterio')
-
 Stats = collections.namedtuple('Stats', ['min', 'max', 'mean'])
 
 # Collect dictionary of functions for use in the interpreter in main()
@@ -73,7 +71,7 @@ def main(banner, dataset, alt_interpreter=None):
 @click.pass_context
 def insp(ctx, input, mode, interpreter):
     """Open the input file in a Python interpreter."""
-    logger = logging.getLogger('rio')
+    logger = logging.getLogger()
     try:
         with ctx.obj['env']:
             with rasterio.open(input, mode) as src:

--- a/rasterio/shutil.pyx
+++ b/rasterio/shutil.pyx
@@ -43,7 +43,8 @@ def exists(path):
         return False
     finally:
         with nogil:
-            GDALClose(h_dataset)
+            if h_dataset != NULL:
+                GDALClose(h_dataset)
 
 
 @ensure_env
@@ -112,9 +113,11 @@ def copy(src, dst, driver='GTiff', strict=True, **creation_options):
     finally:
         CSLDestroy(options)
         with nogil:
-            GDALClose(dst_dataset)
+            if dst_dataset != NULL:
+                GDALClose(dst_dataset)
             if close_src:
-                GDALClose(src_dataset)
+                if src_dataset != NULL:
+                    GDALClose(src_dataset)
 
 
 @ensure_env
@@ -155,7 +158,8 @@ def copyfiles(src, dst):
         raise RasterioIOError(str(e))
     finally:
         with nogil:
-            GDALClose(h_dataset)
+            if h_dataset != NULL:
+                GDALClose(h_dataset)
 
 
 @ensure_env
@@ -202,7 +206,8 @@ def delete(path, driver=None):
                 "Invalid dataset: {}".format(path))
         finally:
             with nogil:
-                GDALClose(h_dataset)
+                if h_dataset != NULL:
+                    GDALClose(h_dataset)
 
     with nogil:
         res = GDALDeleteDataset(h_driver, c_path)

--- a/tests/test_boundless_read.py
+++ b/tests/test_boundless_read.py
@@ -7,7 +7,10 @@ import numpy
 import rasterio
 from rasterio.windows import Window
 
+from .conftest import requires_gdal21
 
+
+@requires_gdal21(reason="Pixel equality tests require float windows and GDAL 2.1")
 @given(col_start=st.integers(min_value=-700, max_value=0),
        row_start=st.integers(min_value=-700, max_value=0),
        col_stop=st.integers(min_value=0, max_value=700),

--- a/tests/test_vrt.py
+++ b/tests/test_vrt.py
@@ -1,0 +1,24 @@
+"""Tests of the rasterio.vrt module"""
+
+import rasterio
+import rasterio.vrt
+
+
+def test_boundless_vrt(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as rgb:
+        doc = rasterio.vrt._boundless_vrt_doc(rgb)
+        assert doc.startswith('<VRTDataset')
+        with rasterio.open(doc) as vrt:
+            assert rgb.count == vrt.count
+            assert rgb.dtypes == vrt.dtypes
+            assert rgb.mask_flag_enums == vrt.mask_flag_enums
+
+
+def test_boundless_msk_vrt(path_rgb_msk_byte_tif):
+    with rasterio.open(path_rgb_msk_byte_tif) as msk:
+        doc = rasterio.vrt._boundless_vrt_doc(msk)
+        assert doc.startswith('<VRTDataset')
+        with rasterio.open(doc) as vrt:
+            assert msk.count == vrt.count
+            assert msk.dtypes == vrt.dtypes
+            assert msk.mask_flag_enums == vrt.mask_flag_enums

--- a/tests/test_vrt.py
+++ b/tests/test_vrt.py
@@ -7,8 +7,8 @@ import rasterio.vrt
 def test_boundless_vrt(path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as rgb:
         doc = rasterio.vrt._boundless_vrt_doc(rgb)
-        assert doc.startswith('<VRTDataset')
-        with rasterio.open(doc) as vrt:
+        assert doc.startswith(b'<VRTDataset')
+        with rasterio.open(doc.decode('ascii')) as vrt:
             assert rgb.count == vrt.count
             assert rgb.dtypes == vrt.dtypes
             assert rgb.mask_flag_enums == vrt.mask_flag_enums
@@ -17,8 +17,8 @@ def test_boundless_vrt(path_rgb_byte_tif):
 def test_boundless_msk_vrt(path_rgb_msk_byte_tif):
     with rasterio.open(path_rgb_msk_byte_tif) as msk:
         doc = rasterio.vrt._boundless_vrt_doc(msk)
-        assert doc.startswith('<VRTDataset')
-        with rasterio.open(doc) as vrt:
+        assert doc.startswith(b'<VRTDataset')
+        with rasterio.open(doc.decode('ascii')) as vrt:
             assert msk.count == vrt.count
             assert msk.dtypes == vrt.dtypes
             assert msk.mask_flag_enums == vrt.mask_flag_enums

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -247,11 +247,11 @@ def test_crs_should_be_set(path_rgb_byte_tif, tmpdir, complex):
             assert src.crs
 
 
-@pytest.mark.skip(reason="Boundless read of a WarpedVRT is nonsensical but not disallow")
 def test_add_alpha_read(path_rgb_byte_tif):
-    """Boundless read of a VRT with added alpha succeeds"""
-    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, add_alpha=True) as vrt:
-        vrt.read(boundless=True, window=Window(-200, -200, 1000, 1000), out_shape=((3, 600, 600)))
+    """Boundless read of a VRT is prohibited"""
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src) as vrt:
+        with pytest.raises(ValueError):
+            vrt.read(boundless=True, window=Window(-200, -200, 1000, 1000), out_shape=((3, 600, 600)))
 
 
 def test_default_add_alpha_read(path_rgb_msk_byte_tif):

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -247,12 +247,11 @@ def test_crs_should_be_set(path_rgb_byte_tif, tmpdir, complex):
             assert src.crs
 
 
+@pytest.mark.xfail(reason="Boundless read of a WarpedVRT is nonsensical but not disallow")
 def test_add_alpha_read(path_rgb_byte_tif):
     """Boundless read of a VRT with added alpha succeeds"""
     with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, add_alpha=True) as vrt:
-        assert vrt.count == 4
-        assert vrt.colorinterp[3] == ColorInterp.alpha
-        data = vrt.read(boundless=True, window=Window(-200, -200, 1000, 1000), out_shape=((3, 600, 600)))
+        vrt.read(boundless=True, window=Window(-200, -200, 1000, 1000), out_shape=((3, 600, 600)))
 
 
 def test_default_add_alpha_read(path_rgb_msk_byte_tif):

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -76,7 +76,7 @@ def test_warped_vrt_dst_alpha(path_rgb_byte_tif):
 def test_warped_vrt_msk_default(path_rgb_msk_byte_tif):
     """Add an alpha band to the VRT to access per-dataset mask of a source"""
     with rasterio.open(path_rgb_msk_byte_tif) as src:
-        vrt = WarpedVRT(src, crs=DST_CRS)
+        vrt = WarpedVRT(src, crs=DST_CRS, add_alpha=True)
         assert vrt.src_nodata is None
         assert vrt.dst_nodata is None
         assert vrt.count == 4
@@ -259,14 +259,6 @@ def test_boundless_masks_read_prohibited(path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src) as vrt:
         with pytest.raises(ValueError):
             vrt.read_masks(boundless=True, window=Window(-200, -200, 1000, 1000), out_shape=((3, 600, 600)))
-
-
-@requires_gdal2()
-def test_default_add_alpha_read(path_rgb_msk_byte_tif):
-    """An alpha band is added if add_alpha is unspecified and source has .msk"""
-    with rasterio.open(path_rgb_msk_byte_tif) as src, WarpedVRT(src) as vrt:
-        assert vrt.count == 4
-        assert vrt.colorinterp[3] == ColorInterp.alpha
 
 
 def test_no_add_alpha_read(path_rgb_msk_byte_tif):

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -247,7 +247,7 @@ def test_crs_should_be_set(path_rgb_byte_tif, tmpdir, complex):
             assert src.crs
 
 
-@pytest.mark.xfail(reason="Boundless read of a WarpedVRT is nonsensical but not disallow")
+@pytest.mark.skip(reason="Boundless read of a WarpedVRT is nonsensical but not disallow")
 def test_add_alpha_read(path_rgb_byte_tif):
     """Boundless read of a VRT with added alpha succeeds"""
     with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, add_alpha=True) as vrt:

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -7,7 +7,7 @@ import affine
 import boto3
 import pytest
 
-from .conftest import requires_gdal21
+from .conftest import requires_gdal21, requires_gdal2
 import rasterio
 from rasterio.crs import CRS
 from rasterio.enums import Resampling, MaskFlags, ColorInterp
@@ -247,13 +247,21 @@ def test_crs_should_be_set(path_rgb_byte_tif, tmpdir, complex):
             assert src.crs
 
 
-def test_add_alpha_read(path_rgb_byte_tif):
+def test_boundless_read_prohibited(path_rgb_byte_tif):
     """Boundless read of a VRT is prohibited"""
     with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src) as vrt:
         with pytest.raises(ValueError):
             vrt.read(boundless=True, window=Window(-200, -200, 1000, 1000), out_shape=((3, 600, 600)))
 
 
+def test_boundless_masks_read_prohibited(path_rgb_byte_tif):
+    """Boundless masks read of a VRT is prohibited"""
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src) as vrt:
+        with pytest.raises(ValueError):
+            vrt.read_masks(boundless=True, window=Window(-200, -200, 1000, 1000), out_shape=((3, 600, 600)))
+
+
+@requires_gdal2()
 def test_default_add_alpha_read(path_rgb_msk_byte_tif):
     """An alpha band is added if add_alpha is unspecified and source has .msk"""
     with rasterio.open(path_rgb_msk_byte_tif) as src, WarpedVRT(src) as vrt:


### PR DESCRIPTION
This resolves #1266.

<img width="1085" alt="untitled" src="https://user-images.githubusercontent.com/33697/41501877-c8ce42c0-7169-11e8-93c6-7055100eab61.png">

We're no longer using WarpedVRT internally and I've removed some features added to the class that were intended to support boundless reads and haven't been needed otherwise.