### PR TITLE
Remove the dev channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: _rasterio
 channels:
 - conda-forge
-- conda-forge/label/dev
+- defaults
 dependencies:
 - python>=3.5
 - cython


### PR DESCRIPTION
@sgillies conda works in a different way than `pip` when dealing with dev releases. If you need any of those packages to come from the dev channel I recommend to do something like:

```yaml
name: _rasterio
channels:
  - conda-forge
  - defaults
dependencies:
  - python>=3.5
  - cython
  - libgdal
  - numpy
  - conda-forge/label/dev::rasterio  # this will get only rasterio from that channel
```

This will ensure that will get only that package from `dev` and prevent the solver from taking the whole channel into consideration when creating the env.

In addition, I don't think you need any of the packages from the dev channel, my guess is that you readthedocs builds `rasterio` from `master` and the stable versions of `numpy`, `libgdal`, `cython`, and `python` are OK. Is that correct?

PS: adding `defaults` below conda-forge is not really needed but I like to be explicit.

---
Should fix https://github.com/mapbox/rasterio/issues/1399 and close https://github.com/conda-forge/libgdal-feedstock/issues/53.