### PR TITLE
Allow src_bounds to override src.bounds with --dimensions

### DIFF
--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -231,6 +231,7 @@ def warp(ctx, files, output, driver, like, dst_crs, dimensions, src_bounds,
                 # Same projection, different dimensions, calculate resolution.
                 dst_crs = src.crs
                 dst_width, dst_height = dimensions
+                l, b, r, t = src_bounds or (l, b, r, t)
                 dst_transform = Affine(
                     (r - l) / float(dst_width),
                     0, l, 0,

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -212,6 +212,28 @@ def test_warp_no_reproject_bounds_res(runner, tmpdir):
             assert np.allclose(output.bounds, out_bounds)
 
 
+def test_warp_no_reproject_src_bounds_dimensions(runner, tmpdir):
+    """--src-bounds option works with dimensions"""
+    srcname = 'tests/data/shade.tif'
+    outputname = str(tmpdir.join('test.tif'))
+    out_bounds = [-11850000, 4810000, -11849000, 4812000]
+    result = runner.invoke(
+        main_group, [
+            'warp', srcname, outputname, '--dimensions', 9, 14,
+            '--src-bounds'] + out_bounds)
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(srcname) as src:
+        with rasterio.open(outputname) as output:
+            assert output.crs == src.crs
+            assert np.allclose(output.bounds, out_bounds)
+            assert np.allclose([111.111111, 142.857142],
+                               [output.transform.a, -output.transform.e])
+            assert output.width == 9
+            assert output.height == 14
+
+
 def test_warp_reproject_dst_crs(runner, tmpdir):
     srcname = 'tests/data/RGB.byte.tif'
     outputname = str(tmpdir.join('test.tif'))


### PR DESCRIPTION
In case of `dst_crs` is not set.