### PR TITLE
Populate `pan{Src|Dst}Bands` indexes when reprojecting

### DIFF
--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1270,6 +1270,10 @@ def test_reproject_dst_alpha(path_rgb_msk_byte_tif):
         assert dst_arr[3].any()
 
 
+@pytest.mark.skipif(
+    (gdal_version.major == 2 and gdal_version.minor == 2),
+    reason=("GDAL had regression in 2.2.X series, fixed in 2.2.4,"
+            " reproject used dst index instead of src index when destination was single band"))
 def test_issue1350():
     """Warp bands other than 1 or All"""
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1268,3 +1268,23 @@ def test_reproject_dst_alpha(path_rgb_msk_byte_tif):
             dst_alpha=4)
 
         assert dst_arr[3].any()
+
+
+def test_issue1350():
+    """Warp bands other than 1 or All"""
+
+    with rasterio.open('tests/data/RGB.byte.tif') as src:
+        dst_crs = {'init': 'EPSG:3857'}
+        out1 = np.zeros(src.shape, dtype=src.dtypes[0])
+        out2 = np.zeros(src.shape, dtype=src.dtypes[1])
+        out3 = np.zeros(src.shape, dtype=src.dtypes[2])
+
+        for i, out in enumerate([out1, out2, out3]):
+            reproject(
+                rasterio.band(src, i+1),
+                out,
+                dst_transform=DST_TRANSFORM,
+                dst_crs=dst_crs)
+
+        assert not (out1 == out2).all()
+        assert not (out2 == out3).all()

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1283,6 +1283,7 @@ def test_issue1350():
             reproject(
                 rasterio.band(src, i+1),
                 out,
+                resampling=Resampling.nearest,
                 dst_transform=DST_TRANSFORM,
                 dst_crs=dst_crs)
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1275,17 +1275,20 @@ def test_issue1350():
 
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         dst_crs = {'init': 'EPSG:3857'}
-        out1 = np.zeros(src.shape, dtype=src.dtypes[0])
-        out2 = np.zeros(src.shape, dtype=src.dtypes[1])
-        out3 = np.zeros(src.shape, dtype=src.dtypes[2])
 
-        for i, out in enumerate([out1, out2, out3]):
+        reprojected = []
+
+        for dtype, idx in zip(src.dtypes, src.indexes):
+            out = np.zeros((1,) + src.shape, dtype=dtype)
+
             reproject(
-                rasterio.band(src, i+1),
+                rasterio.band(src, idx),
                 out,
                 resampling=Resampling.nearest,
                 dst_transform=DST_TRANSFORM,
                 dst_crs=dst_crs)
 
-        assert not (out1 == out2).all()
-        assert not (out2 == out3).all()
+            reprojected.append(out)
+
+        for i in range(1, len(reprojected)):
+            assert not (reprojected[0] == reprojected[i]).all()


### PR DESCRIPTION
This is addressing issue #1350. 

Basically warping for cases other than

- Warping first band
- Warping all bands

didn't work, because of the way warping structure was configured. With this change we actually populate `pan{Src|Dst}Bands` parameters properly.

Also when destination is an `ndarray` and there are multiple bands being processed destination bands are assumed to be `1,2,..N` if the output size matches the number of bands being processed simultaneously. So you can extract say bands `4,7,19` into a `3xHxW` `ndarray`.