### PR TITLE
Generalize to support cloud providers other than AWS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Next
+----
+
+Refactoring:
+
+- Generalize sessions to support cloud providers other than AWS (#1429).
+
 1.0.2 (2018-07-27)
 ------------------
 

--- a/rasterio/rio/env.py
+++ b/rasterio/rio/env.py
@@ -11,7 +11,7 @@ import rasterio
 @click.option('--formats', 'key', flag_value='formats', default=True,
               help="Enumerate the available formats.")
 @click.option('--credentials', 'key', flag_value='credentials', default=False,
-              help="Print AWS credentials.")
+              help="Print credentials.")
 @click.pass_context
 def env(ctx, key):
     """Print information about the Rasterio environment."""
@@ -20,7 +20,4 @@ def env(ctx, key):
             for k, v in sorted(env.drivers().items()):
                 click.echo("{0}: {1}".format(k, v))
         elif key == 'credentials':
-            click.echo(json.dumps({
-                'aws_access_key_id': env._creds.access_key,
-                'aws_secret_access_key': env._creds.secret_key,
-                'aws_session_token': env._creds.token}))
+            click.echo(json.dumps(env.session.credentials))

--- a/rasterio/rio/rasterize.py
+++ b/rasterio/rio/rasterize.py
@@ -21,7 +21,10 @@ import rasterio.shutil
 logger = logging.getLogger(__name__)
 
 
-# Common options used below
+def files_handler(ctx, param, value):
+    """Process and validate input file names"""
+    return value
+
 
 # Unlike the version in cligj, this one doesn't require values.
 files_inout_arg = click.argument(
@@ -29,7 +32,7 @@ files_inout_arg = click.argument(
     nargs=-1,
     type=click.Path(resolve_path=True),
     metavar="INPUTS... OUTPUT",
-    callback=options.files_inout_handler)
+    callback=files_handler)
 
 
 @click.command(short_help='Rasterize features.')

--- a/tests/test_rio_rasterize.py
+++ b/tests/test_rio_rasterize.py
@@ -35,6 +35,25 @@ def test_rasterize(tmpdir, runner, basic_feature):
         assert np.all(data)
 
 
+def test_rasterize_file(tmpdir, runner, basic_feature):
+    """Confirm fix of #1425"""
+    geojson_file = tmpdir.join('input.geojson')
+    geojson_file.write(json.dumps(basic_feature))
+    output = str(tmpdir.join('test.tif'))
+    result = runner.invoke(
+        main_group, [
+            'rasterize', str(geojson_file), output, '--dimensions', DEFAULT_SHAPE[0],
+            DEFAULT_SHAPE[1]])
+
+    assert result.exit_code == 0
+    assert os.path.exists(output)
+    with rasterio.open(output) as out:
+        assert np.allclose(out.bounds, (2, 2, 4.25, 4.25))
+        data = out.read(1, masked=False)
+        assert data.shape == DEFAULT_SHAPE
+        assert np.all(data)
+
+
 def test_rasterize_bounds(tmpdir, runner, basic_feature, basic_image_2x2):
     output = str(tmpdir.join('test.tif'))
     result = runner.invoke(


### PR DESCRIPTION
This refactor resolves #1423. Summary of changes:

- We have a new session module and an extendable abstraction for cloud API access sessions. Adding support for a new cloud provider means writing a new subclass of `Session` (like `AWSSession`) and then adding a new condition to the `from_path` staticmethod of `Session`.
- With two exceptions, the `Env` class doesn't know about subclasses of `Session` anymore. Except for the special AWS cases (for backwards compatibility) it should only know about abstract Sessions.
- The duty of figuring out which kind of session to use for a given dataset path or identifier now belongs to `Session.from_path`. I expect it could become slightly complex, but at least we're containing the complexity.

The deep nesting of sessions gets a little humorous, I admit (rasterio:boto3:botocore, for example), but I think that's the nature of this beast.