### PR TITLE
added ValueError if driver is missing when getting writer for driver

### DIFF
--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -175,6 +175,8 @@ class ZipMemoryFile(MemoryFile):
 
 def get_writer_for_driver(driver):
     """Return the writer class appropriate for the specified driver."""
+    if not driver:
+        raise ValueError("'driver' is required to write dataset.")
     cls = None
     if driver_can_create(driver):
         cls = DatasetWriter

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -320,3 +320,9 @@ def test_wplus_transform(tmpdir):
     with rasterio.open(name, 'w+', driver='GTiff', crs='epsg:4326', transform=transform, height=10, width=10, count=1, dtype='uint8') as dst:
         dst.write(np.ones((1, 10, 10), dtype='uint8'))
         assert dst.transform == transform
+
+
+def test_write_no_driver__issue_1203(tmpdir):
+    name = str(tmpdir.join("test.tif"))
+    with pytest.raises(ValueError), rasterio.open(name, 'w', height=1, width=1, count=1, dtype='uint8'):
+        print("TEST FAILED IF THIS IS REACHED.")


### PR DESCRIPTION
Fixes issue #1203. Though likely will be superseded by #265 