### PR TITLE
Really, really resolve #1471

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,14 @@
 Changes
 =======
 
+Next
+----
+
+Bug fixes:
+
+- We have a more general fix for the problem of filling the empty regions of
+  boundless reads (#1471).
+
 1.0.5 (2018-09-19)
 ------------------
 

--- a/tests/test_boundless_read.py
+++ b/tests/test_boundless_read.py
@@ -80,3 +80,18 @@ def test_boundless_fill_value():
     assert (filled[:, -1] == 5).all()
     assert (filled[0, :] == 5).all()
     assert (filled[-1, :] == 5).all()
+
+
+def test_boundless_fill_value_overview_masks():
+    """Confirm a more general resolution to issue #1471"""
+    with rasterio.open("tests/data/cogeo.tif") as src:
+        data = src.read(1, boundless=True, window=Window(-300, -335, 1000, 1000), fill_value=5, out_shape=(512, 512))
+    assert (data[:, 0] == 5).all()
+
+
+def test_boundless_masked_fill_value_overview_masks():
+    """Confirm a more general resolution to issue #1471"""
+    with rasterio.open("tests/data/cogeo.tif") as src:
+        data = src.read(1, masked=True, boundless=True, window=Window(-300, -335, 1000, 1000), fill_value=5, out_shape=(512, 512))
+    assert data.fill_value == 5
+    assert data.mask[:, 0].all()


### PR DESCRIPTION
There seems to be a conflict between VRTs, overviews, and masks, so instead of asking GDAL's VRT driver to do the filling, we ask dataset.read to make a masked array and then call `filled()` on it to collapse it to a filled non-masked array.

Resolves #1471