### PR TITLE
Make default modes r+ and w+ for MemoryFile datasets

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1924,7 +1924,7 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
         # Validate write mode arguments.
 
         log.debug("Path: %s, mode: %s, driver: %s", path, mode, driver)
-        if mode == 'w':
+        if mode in ('w', 'w+'):
             if not isinstance(driver, string_types):
                 raise TypeError("A driver name string is required.")
             try:
@@ -1973,7 +1973,7 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
 
         memdrv = GDALGetDriverByName("MEM")
 
-        if self.mode == 'w':
+        if self.mode in ('w', 'w+'):
             # Find the equivalent GDAL data type or raise an exception
             # We've mapped numpy scalar types to GDAL types so see
             # if we can crosswalk those.

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -127,10 +127,10 @@ class MemoryFile(MemoryFileBase):
             raise IOError("I/O operation on closed file.")
         if self.exists():
             log.debug("VSI path: {}".format(vsi_path.path))
-            return DatasetReader(vsi_path, driver=driver, **kwargs)
+            return DatasetReader(vsi_path, mode='r+', driver=driver, **kwargs)
         else:
             writer = get_writer_for_driver(driver)
-            return writer(vsi_path, 'w', driver=driver, width=width,
+            return writer(vsi_path, 'w+', driver=driver, width=width,
                           height=height, count=count, crs=crs,
                           transform=transform, dtype=dtype,
                           nodata=nodata, **kwargs)

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -5,13 +5,13 @@ from io import BytesIO
 import logging
 import os.path
 
+from affine import Affine
+import numpy
 import pytest
 
 import rasterio
 from rasterio.io import MemoryFile, ZipMemoryFile
 from rasterio.env import GDALVersion
-
-logging.basicConfig(level=logging.DEBUG)
 
 
 # Skip ENTIRE module if not GDAL >= 2.x.
@@ -233,3 +233,15 @@ def test_vrt_memfile():
             assert src.count == 3
             assert src.dtypes == ('uint8', 'uint8', 'uint8')
             assert src.read().shape == (3, 768, 1024)
+
+
+def test_write_plus_mode():
+    with MemoryFile() as memfile:
+        with memfile.open(driver='GTiff', dtype='uint8', count=3, height=32, width=32, crs='epsg:3226', transform=Affine.identity() * Affine.scale(0.5, -0.5)) as dst:
+            dst.write(numpy.full((32, 32), 255, dtype='uint8'), 1)
+            dst.write(numpy.full((32, 32), 204, dtype='uint8'), 2)
+            dst.write(numpy.full((32, 32), 153, dtype='uint8'), 3)
+            data = dst.read()
+            assert (data[0] == 255).all()
+            assert (data[1] == 204).all()
+            assert (data[2] == 153).all()

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -245,3 +245,15 @@ def test_write_plus_mode():
             assert (data[0] == 255).all()
             assert (data[1] == 204).all()
             assert (data[2] == 153).all()
+
+
+def test_write_plus_model_jpeg():
+    with MemoryFile() as memfile:
+        with memfile.open(driver='JPEG', dtype='uint8', count=3, height=32, width=32, crs='epsg:3226', transform=Affine.identity() * Affine.scale(0.5, -0.5)) as dst:
+            dst.write(numpy.full((32, 32), 255, dtype='uint8'), 1)
+            dst.write(numpy.full((32, 32), 204, dtype='uint8'), 2)
+            dst.write(numpy.full((32, 32), 153, dtype='uint8'), 3)
+            data = dst.read()
+            assert (data[0] == 255).all()
+            assert (data[1] == 204).all()
+            assert (data[2] == 153).all()


### PR DESCRIPTION
A user pointed out in https://rasterio.groups.io/g/main/message/66 that r and w are too restrictive.