### PR TITLE
Fix get_tag_item for the `ovr=0` case

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -993,7 +993,7 @@ cdef class DatasetBase(object):
         else:
             band = self._hds
 
-        if ovr:
+        if ovr is not None:
             obj = GDALGetOverview(band, ovr)
             if obj == NULL:
               raise BandOverviewError(

--- a/tests/test_tag_item.py
+++ b/tests/test_tag_item.py
@@ -21,6 +21,7 @@ def test_get_tag_item():
 def test_get_tag_item_Tiff():
     with rasterio.open('tests/data/cogeo.tif') as src:
         assert src.get_tag_item('IFD_OFFSET', 'TIFF', bidx=1) == '8'
+        assert src.get_tag_item('IFD_OFFSET', 'TIFF', bidx=1, ovr=0) == '1104'
         assert src.get_tag_item('IFD_OFFSET', 'TIFF', bidx=1, ovr=1) == '1504'
         assert not src.get_tag_item('IF', 'TIFF', bidx=1)
         with pytest.raises(Exception):


### PR DESCRIPTION
Allow querying tags for the first overview (`ovr=0`)

addresses #1490 