### PR TITLE
Add method to query block shapes of overview images

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -1114,6 +1114,34 @@ cdef class DatasetBase(object):
 
         return factors
 
+    def overview_block_shapes(self, bidx):
+        """An ordered list of block shapes for each overview level for a given band
+
+        Parameters
+        ----------
+        bidx : int
+            The band's index (1-indexed).
+
+        Returns
+        -------
+        list
+        """
+        cdef GDALRasterBandH ovrband = NULL
+        cdef GDALRasterBandH band = NULL
+        cdef int xsize
+        cdef int ysize
+
+        band = self.band(bidx)
+        num_overviews = GDALGetOverviewCount(band)
+        block_shapes = []
+
+        for i in range(num_overviews):
+            ovrband = GDALGetOverview(band, i)
+            GDALGetBlockSize(ovrband, &xsize, &ysize)
+            block_shapes.append((ysize, xsize))
+
+        return block_shapes
+
     def checksum(self, bidx, window=None):
         """Compute an integer checksum for the stored band
 

--- a/tests/test_overviews.py
+++ b/tests/test_overviews.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+import os
 
 from click.testing import CliRunner
 import pytest
@@ -90,3 +91,17 @@ def test_issue1333(data):
         with rasterio.open(inputfile, 'r+') as src:
             overview_factors = [1024, 2048]
             src.build_overviews(overview_factors, resampling=Resampling.average)
+
+
+def test_overview_block_shapes_none(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif, 'r') as src:
+        assert src.overview_block_shapes(1) == []
+
+
+def test_overview_block_shapes(data_dir):
+    inputfile = os.path.join(data_dir, 'cogeo.tif')
+
+    with rasterio.open(inputfile, 'r') as src:
+        ovr_block_shapes = src.overview_block_shapes(1)
+        assert len(ovr_block_shapes) == len(src.overviews(1))
+        assert ovr_block_shapes == [(512, 512)]*6


### PR DESCRIPTION
I would like to be able to query `block_shape` property for overview images.

Not sure from the API perspective, maybe it's better to have method that describes the whole overview image in full detail. But this is what I have come up with so far.

```python
    def overview_block_shapes(self, bidx):
        """An ordered list of block shapes for each overview level for a given band

        Parameters
        ----------
        bidx : int
            The band's index (1-indexed).

        Returns
        -------
        list
        """
```