### PR TITLE
Add WEBP to the compression enum

### DIFF
--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -66,6 +66,7 @@ class Compression(Enum):
     none = 'NONE'
     zstd = 'ZSTD'
     lerc = 'LERC'
+    webp = 'WEBP'
 
 
 class Interleaving(Enum):


### PR DESCRIPTION
To support GDAL 2.4.0-dev and the upcoming [Tiff WebP compression](https://github.com/OSGeo/gdal/pull/704)