### PR TITLE
Docstring update to plotting_extent - Minor Update 

### DIFF
--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -155,7 +155,8 @@ def plotting_extent(source, transform=None):
     Parameters
     ----------
     source : array or dataset object opened in 'r' mode
-        input data
+        If array, data in the order rows, columns and optionally bands. If array
+        is band order (bands in the first dimension), use arr[0]
     transform: Affine, required if source is array
         Defines the affine transform if source is an array
 


### PR DESCRIPTION
@sgillies this is a very minor update to the docstring for `plotting_extent()` [as discussed here](https://github.com/mapbox/rasterio/issues/1514):  Please let me know if you'd prefer different text or any changes to what is there.

I looked at your docs and *think* that docs for [this particular function](https://rasterio.readthedocs.io/en/latest/api/rasterio.plot.html?highlight=plotting_extent) are autogenerated from the docstring. If I am not correct I can also update the `.rst` file with just a bit of direction.