### PR TITLE
None means none, not default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ Changes
 
 Bug fixes:
 
+- The defaults for WarpedVRT's `src_nodata` and `nodata` keyword arguments are
+  no longer None, but are markers for the default behavior: inheritance of
+  nodata values from the VRT's source dataset. Values of `None` for these
+  keyword arguments means that the VRT does not inherit from the source and has
+  no nodata value at all (#1503).
 - WEBP has been added to the Compression enum. Exploitation of this new
   compression mode will require GDAL 2.4.
 - Rasterio now check for two AWS environment variables before creating a

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -592,11 +592,14 @@ def _calculate_default_transform(src_crs, dst_crs, width, height,
     return dst_affine, dst_width, dst_height
 
 
+DEFAULT_NODATA_FLAG = object()
+
+
 cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
     def __init__(self, src_dataset, src_crs=None, dst_crs=None, crs=None,
                  resampling=Resampling.nearest, tolerance=0.125,
-                 src_nodata=None, dst_nodata=None, nodata=None,
+                 src_nodata=DEFAULT_NODATA_FLAG, dst_nodata=None, nodata=DEFAULT_NODATA_FLAG,
                  dst_width=None, width=None, dst_height=None, height=None,
                  src_transform=None, dst_transform=None, transform=None,
                  init_dest_nodata=True, src_alpha=0, add_alpha=False,
@@ -612,7 +615,8 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         src_transfrom : Affine, optional
             Overrides the transform of `src_dataset`.
         src_nodata : float, optional
-            Overrides the nodata value of `src_dataset`.
+            Overrides the nodata value of `src_dataset`, which is the
+            default.
         crs : CRS or str, optional
             The coordinate reference system at the end of the warp
             operation.  Default: the crs of `src_dataset`. dst_crs is
@@ -727,8 +731,8 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self.resampling = resampling
         self.tolerance = tolerance
 
-        self.src_nodata = self.src_dataset.nodata if src_nodata is None else src_nodata
-        self.dst_nodata = self.src_nodata if nodata is None else nodata
+        self.src_nodata = self.src_dataset.nodata if src_nodata is DEFAULT_NODATA_FLAG else src_nodata
+        self.dst_nodata = self.src_nodata if nodata is DEFAULT_NODATA_FLAG else nodata
         self.dst_width = width
         self.dst_height = height
         self.dst_transform = transform

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -60,6 +60,7 @@ def test_warped_vrt(path_rgb_byte_tif):
         assert vrt.mask_flag_enums == ([MaskFlags.nodata],) * 3
 
 
+@requires_gdal21
 def test_warped_vrt_nondefault_nodata(path_rgb_byte_tif):
     """A VirtualVRT has expected nondefault nodata values."""
     with rasterio.open(path_rgb_byte_tif) as src:

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -60,6 +60,19 @@ def test_warped_vrt(path_rgb_byte_tif):
         assert vrt.mask_flag_enums == ([MaskFlags.nodata],) * 3
 
 
+def test_warped_vrt_nondefault_nodata(path_rgb_byte_tif):
+    """A VirtualVRT has expected nondefault nodata values."""
+    with rasterio.open(path_rgb_byte_tif) as src:
+        vrt = WarpedVRT(src, crs=DST_CRS, src_nodata=None, nodata=None)
+        assert vrt.dst_crs == CRS.from_string(DST_CRS)
+        assert vrt.src_nodata is None
+        assert vrt.dst_nodata is None
+        assert vrt.tolerance == 0.125
+        assert vrt.resampling == Resampling.nearest
+        assert vrt.warp_extras == {"init_dest": "NO_DATA"}
+        assert vrt.mask_flag_enums == ([MaskFlags.all_valid],) * 3
+
+
 @requires_gdal21(reason="Nodata deletion requires GDAL 2.1+")
 def test_warped_vrt_add_alpha(path_rgb_byte_tif):
     """A VirtualVRT has the expected VRT properties."""


### PR DESCRIPTION
We've changed the constructor's nodata defaults to use a flag that is neither None nor a float.

Passing `src_nodata=None` and/or `nodata=None` unlocks a missing feature or avoids a bug, depending on how you look at it. Accepting the default preserves the existing behavior, inheritance of the nodata values from the VRT's source dataset.

Resolves #1503