### PR TITLE
Add support for Alibaba Cloud OSS file (Cloud Optimized GeoTIFF)

### DIFF
--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -236,7 +236,7 @@ class Env(object):
             pass
         else:
             cred_opts = self.session.get_credential_options()
-            self.options.update(**cred_opts) ## sshuair 设置gdal环境变量
+            self.options.update(**cred_opts)
             setenv(**cred_opts)
 
     def drivers(self):

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -236,7 +236,7 @@ class Env(object):
             pass
         else:
             cred_opts = self.session.get_credential_options()
-            self.options.update(**cred_opts)
+            self.options.update(**cred_opts) ## sshuair 设置gdal环境变量
             setenv(**cred_opts)
 
     def drivers(self):

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -17,13 +17,14 @@ SCHEMES = {
     's3': 's3',
     'tar': 'tar',
     'zip': 'zip',
-    'file': 'file'
+    'file': 'file',
+    'oss': 'oss'
 }
 
 CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3')])
+REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss')])
 
 
 class Path(object):

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -260,8 +260,21 @@ class AWSSession(Session):
 
 
 class OSSSession(Session):
+    """Configures access to secured resources stored in Alibaba Cloud OSS.
+    """
+    def __init__(self, oss_access_key_id, oss_secret_access_key, oss_endpoint='oss-us-east-1.aliyuncs.com'):
+        """Create new Alibaba Cloud OSS session
 
-    def __init__(self, oss_access_key_id=None, oss_secret_access_key=None, oss_endpoint=None):
+        Parameters
+        ----------
+        oss_access_key_id: string
+            An access key id
+        oss_secret_access_key: string
+            An secret access key
+        oss_endpoint: string, default 'oss-us-east-1.aliyuncs.com'
+            the region attached to the bucket
+        """
+
         self._creds = {
             "oss_access_key_id": oss_access_key_id,
             "oss_secret_access_key": oss_secret_access_key,
@@ -270,15 +283,35 @@ class OSSSession(Session):
     
     @classmethod
     def hascreds(cls, config):
+        """Determine if the given configuration has proper credentials
+
+        Parameters
+        ----------
+        cls : class
+            A Session class.
+        config : dict
+            GDAL configuration as a dict.
+
+        Returns
+        -------
+        bool
+
+        """
         return 'OSS_ACCESS_KEY_ID' in config and 'OSS_SECRET_ACCESS_KEY' in config
 
     @property
     def credentials(self):
-        """the auth credentials as dict
-        """
+        """The session credentials as a dict"""
         return self._creds
 
     def get_credential_options(self):
+        """Get credentials as GDAL configuration options
+
+        Returns
+        -------
+        dict
+
+        """
         return {k.upper(): v for k, v in self.credentials.items()}
 
     

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -257,3 +257,29 @@ class AWSSession(Session):
             return {'AWS_NO_SIGN_REQUEST': 'YES'}
         else:
             return {k.upper(): v for k, v in self.credentials.items()}
+
+
+class OSSSession(Session):
+
+    def __init__(self, oss_access_key_id=None, oss_secret_access_key=None, oss_endpoint=None):
+        self._creds = {
+            "oss_access_key_id": oss_access_key_id,
+            "oss_secret_access_key": oss_secret_access_key,
+            "oss_endpoint": oss_endpoint
+        }
+    
+    @classmethod
+    def hascreds(cls, config):
+        return 'OSS_ACCESS_KEY_ID' in config and 'OSS_SECRET_ACCESS_KEY' in config
+
+    @property
+    def credentials(self):
+        """the auth credentials as dict
+        """
+        return self._creds
+
+    def get_credential_options(self):
+        return {k.upper(): v for k, v in self.credentials.items()}
+
+    
+


### PR DESCRIPTION
Add OSSSession to support Alibaba Cloud OSS file.
usage:
```python
from rasterio.session import OSSSession

oss_access_key_id = "***********"
oss_secret_access_key = "************"
oss_endpoint = "oss-cn-huhehaote.aliyuncs.com"
session = OSSSession(oss_access_key_id, oss_secret_access_key, oss_endpoint)
with rasterio.Env(session):
    fp = 'oss://g-imagery-cog-test/rasterio/private-access.tif.cog'
    with rasterio.open(fp) as src:
        print(src.profile)
```