### PR TITLE
Add support for OpenStack Swift Object Storage(cloud optimized geotiff)

### DIFF
--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -236,7 +236,7 @@ class Env(object):
             pass
         else:
             cred_opts = self.session.get_credential_options()
-            self.options.update(**cred_opts) ## sshuair 设置gdal环境变量
+            self.options.update(**cred_opts)
             setenv(**cred_opts)
 
     def drivers(self):

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -236,7 +236,7 @@ class Env(object):
             pass
         else:
             cred_opts = self.session.get_credential_options()
-            self.options.update(**cred_opts)
+            self.options.update(**cred_opts) ## sshuair 设置gdal环境变量
             setenv(**cred_opts)
 
     def drivers(self):

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -18,13 +18,14 @@ SCHEMES = {
     'tar': 'tar',
     'zip': 'zip',
     'file': 'file',
-    'oss': 'oss'
+    'oss': 'oss',
+    'swift': 'swift'
 }
 
 CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss')])
+REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss', 'swift')])
 
 
 class Path(object):

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -17,13 +17,14 @@ SCHEMES = {
     's3': 's3',
     'tar': 'tar',
     'zip': 'zip',
-    'file': 'file'
+    'file': 'file',
+    'oss': 'oss'
 }
 
 CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3')])
+REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss')])
 
 
 class Path(object):

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -92,6 +92,9 @@ class Session(object):
         elif path.scheme == "s3" or "amazonaws.com" in path.path:
             return AWSSession
 
+        elif path.scheme == "oss" or "aliyuncs.com" in path.path:
+            return OSSSession
+
         # This factory can be extended to other cloud providers here.
         # elif path.scheme == "cumulonimbus":  # for example.
         #     return CumulonimbusSession(*args, **kwargs)

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -324,9 +324,7 @@ class OSSSession(Session):
 class SwiftSession(Session):
     """Configures access to secured resources stored in OpenStack Swift Object Storage.
     """
-    def __init__(
-                self, session=None, swift_storage_url=None, swift_auth_token=None, 
-                swift_auth_v1_url=None, swift_user=None, swift_key=None):
+    def __init__(self, session=None, swift_auth_v1_url=None, swift_user=None, swift_key=None):
         """Create new OpenStack Swift Object Storage Session,
         Note: if session is provided the others is not nessary, 
 
@@ -341,25 +339,15 @@ class SwiftSession(Session):
         """
         from swiftclient.client import Connection
 
-        if swift_storage_url and swift_auth_token:
-            self._creds = {
-                'swift_storage_url':swift_storage_url,
-                'swift_auth_token':swift_auth_token
-            }
-        elif session:
-            if session:
-                self._session = session
-            else:
-                self._session = Connection(
-                    authurl=swift_auth_v1_url,
-                    user=swift_user,
-                    key=swift_key
-                )
-            self._creds = {
-                "swift_storage_url": self._session.get_auth()[0],
-                "swift_auth_token": self._session.get_auth()[1],
-            }
-
+        if session:
+            self._session = session
+        else:
+            self._session = Connection(
+                authurl=swift_auth_v1_url,
+                user=swift_user,
+                key=swift_key
+            )
+        self._creds = self._session.get_auth()
     
     @classmethod
     def hascreds(cls, config):
@@ -382,7 +370,11 @@ class SwiftSession(Session):
     @property
     def credentials(self):
         """The session credentials as a dict"""
-        return self._creds
+        res = {}
+        if self._creds:
+            res['swift_storage_url'] = self._creds[0]
+            res['swift_auth_token'] = self._creds[1]
+        return res
 
     def get_credential_options(self):
         """Get credentials as GDAL configuration options

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -260,8 +260,21 @@ class AWSSession(Session):
 
 
 class OSSSession(Session):
+    """Configures access to secured resources stored in Alibaba Cloud OSS.
+    """
+    def __init__(self, oss_access_key_id, oss_secret_access_key, oss_endpoint='oss-us-east-1.aliyuncs.com'):
+        """Create new Alibaba Cloud OSS session
 
-    def __init__(self, oss_access_key_id=None, oss_secret_access_key=None, oss_endpoint=None):
+        Parameters
+        ----------
+        oss_access_key_id: string
+            An access key id
+        oss_secret_access_key: string
+            An secret access key
+        oss_endpoint: string, default 'oss-us-east-1.aliyuncs.com'
+            the region attached to the bucket
+        """
+
         self._creds = {
             "oss_access_key_id": oss_access_key_id,
             "oss_secret_access_key": oss_secret_access_key,
@@ -270,15 +283,35 @@ class OSSSession(Session):
     
     @classmethod
     def hascreds(cls, config):
+        """Determine if the given configuration has proper credentials
+
+        Parameters
+        ----------
+        cls : class
+            A Session class.
+        config : dict
+            GDAL configuration as a dict.
+
+        Returns
+        -------
+        bool
+
+        """
         return 'OSS_ACCESS_KEY_ID' in config and 'OSS_SECRET_ACCESS_KEY' in config
 
     @property
     def credentials(self):
-        """the auth credentials as dict
-        """
+        """The session credentials as a dict"""
         return self._creds
 
     def get_credential_options(self):
+        """Get credentials as GDAL configuration options
+
+        Returns
+        -------
+        dict
+
+        """
         return {k.upper(): v for k, v in self.credentials.items()}
 
     

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -95,7 +95,7 @@ class Session(object):
         elif path.scheme == "oss" or "aliyuncs.com" in path.path:
             return OSSSession
 
-        elif path.scheme == "swift":   #TODO(sshuair), not necessary
+        elif path.scheme == "swift":
             return SwiftSession
 
         # This factory can be extended to other cloud providers here.

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -257,3 +257,29 @@ class AWSSession(Session):
             return {'AWS_NO_SIGN_REQUEST': 'YES'}
         else:
             return {k.upper(): v for k, v in self.credentials.items()}
+
+
+class OSSSession(Session):
+
+    def __init__(self, oss_access_key_id=None, oss_secret_access_key=None, oss_endpoint=None):
+        self._creds = {
+            "oss_access_key_id": oss_access_key_id,
+            "oss_secret_access_key": oss_secret_access_key,
+            "oss_endpoint": oss_endpoint
+        }
+    
+    @classmethod
+    def hascreds(cls, config):
+        return 'OSS_ACCESS_KEY_ID' in config and 'OSS_SECRET_ACCESS_KEY' in config
+
+    @property
+    def credentials(self):
+        """the auth credentials as dict
+        """
+        return self._creds
+
+    def get_credential_options(self):
+        return {k.upper(): v for k, v in self.credentials.items()}
+
+    
+

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -320,21 +320,23 @@ class OSSSession(Session):
         """
         return {k.upper(): v for k, v in self.credentials.items()}
 
-    
+
 class SwiftSession(Session):
     """Configures access to secured resources stored in OpenStack Swift Object Storage.
     """
     def __init__(self, session=None, swift_auth_v1_url=None, swift_user=None, swift_key=None):
-        """Create new OpenStack Swift Object Storage Session,
-        Note: if session is provided the others is not nessary, 
+        """Create new OpenStack Swift Object Storage Session. 
+        This depends on the swiftclient library.
 
         Parameters
         ----------
-        swift_storage_url: string
+        session: optional
+            A swiftclient connection object
+        swift_storage_url: string, optional
             authentication URL
-        swift_user: string
+        swift_user: string, optional
             user name to authenticate as
-        swift_key: string, 
+        swift_key: string, optional
             key/password to authenticate with
         """
         from swiftclient.client import Connection

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -13,7 +13,7 @@ from rasterio.env import Env, defenv, delenv, getenv, setenv, ensure_env, ensure
 from rasterio.env import GDALVersion, require_gdal_version
 from rasterio.errors import EnvError, RasterioIOError, GDALVersionError
 from rasterio.rio.main import main_group
-from rasterio.session import AWSSession
+from rasterio.session import AWSSession, OSSSession
 
 from .conftest import requires_gdal21
 
@@ -757,3 +757,16 @@ def test_nested_credentials(monkeypatch):
         gdalenv = fake_opener('s3://foo/bar')
         assert gdalenv['AWS_ACCESS_KEY_ID'] == 'foo'
         assert gdalenv['AWS_SECRET_ACCESS_KEY'] == 'bar'
+        
+
+def test_oss_session_credentials(gdalenv):
+    """Create an Env with a oss session."""
+    oss_session = OSSSession(
+        oss_access_key_id='id', 
+        oss_secret_access_key='key', 
+        oss_endpoint='null-island-1')
+    with rasterio.env.Env(session=oss_session) as s:
+        s.credentialize()
+        assert getenv()['OSS_ACCESS_KEY_ID'] == 'id'
+        assert getenv()['OSS_SECRET_ACCESS_KEY'] == 'key'
+        assert getenv()['OSS_ENDPOINT'] == 'null-island-1'

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from rasterio.session import DummySession, AWSSession, Session
+from rasterio.session import DummySession, AWSSession, Session, OSSSession
 
 
 def test_dummy_session():
@@ -114,3 +114,22 @@ def test_requester_pays():
     sesh = AWSSession(aws_access_key_id='foo', aws_secret_access_key='bar', requester_pays=True)
     assert sesh._session
     assert sesh.get_credential_options()['AWS_REQUEST_PAYER'] == 'requester'
+
+
+def test_oss_session_class():
+    """OSSSession works"""
+    oss_session = OSSSession(
+        oss_access_key_id='id', 
+        oss_secret_access_key='key', 
+        oss_endpoint='null-island-1')
+    assert oss_session._creds
+    assert oss_session.get_credential_options()['OSS_ACCESS_KEY_ID'] == 'id'
+    assert oss_session.get_credential_options()['OSS_SECRET_ACCESS_KEY'] == 'key'
+
+
+def test_session_factory_oss_kwargs():
+    """Get an OSSSession for oss:// paths with keywords"""
+    sesh = Session.from_path("oss://lol/wut", oss_access_key_id='foo', oss_secret_access_key='bar')
+    assert isinstance(sesh, OSSSession)
+    assert sesh.get_credential_options()['OSS_ACCESS_KEY_ID'] == 'foo'
+    assert sesh.get_credential_options()['OSS_SECRET_ACCESS_KEY'] == 'bar'

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -119,12 +119,12 @@ def test_requester_pays():
 def test_oss_session_class():
     """OSSSession works"""
     oss_session = OSSSession(
-        oss_access_key_id='id', 
-        oss_secret_access_key='key', 
+        oss_access_key_id='foo', 
+        oss_secret_access_key='bar', 
         oss_endpoint='null-island-1')
     assert oss_session._creds
-    assert oss_session.get_credential_options()['OSS_ACCESS_KEY_ID'] == 'id'
-    assert oss_session.get_credential_options()['OSS_SECRET_ACCESS_KEY'] == 'key'
+    assert oss_session.get_credential_options()['OSS_ACCESS_KEY_ID'] == 'foo'
+    assert oss_session.get_credential_options()['OSS_SECRET_ACCESS_KEY'] == 'bar'
 
 
 def test_session_factory_oss_kwargs():


### PR DESCRIPTION
Due to the `Swift Client Connection` has to connect with online server to get the `SWIFT_STORAGE_URL` and ` SWIFT_AUTH_TOKEN `,  it's difficult to add tests for SwiftSession and Eev.

Any suggestions?

some sample code:
```python
def test_open_private_swift_file_method1():
    import os
    fp = 'swift://swift/GF2_PMS1_E113.8_N39.4_20150804_L1A0001350893-MSS1.tif'
    session = SwiftSession(swift_auth_v1_url='http://host:port/auth/v1.0',
                           swift_user= 'test:tester', swift_key='testing')
    with rasterio.Env(session):
        with rasterio.open(fp) as src:
            print(src.profile)

def test_open_private_swift_file_method2():
    fp = 'swift://swift/GF2_PMS1_E113.8_N39.4_20150804_L1A0001350893-MSS1.tif'
    from swiftclient.client import Connection
    conn = Connection(
                authurl='http://host:port/auth/v1.0'
                user='test:tester',
                key='testing'
            )
    session = SwiftSession(conn)
    with rasterio.Env(session):
        with rasterio.open(fp) as src:
            print(src.profile)

test_open_private_swift_file_method1()
test_open_private_swift_file_method2()
```

the output results:
```shell
(base)  ~/github/rasterio >/Users/sshuair/anaconda3/bin/python /Users/sshuair/github/rasterio/tests/test_1sshuair.py
{'driver': 'GTiff', 'dtype': 'uint16', 'nodata': 0.0, 'width': 8630, 'height': 8421, 'count': 4, 'crs': CRS({'init': 'epsg:3857'}), 'transform': Affine(4.122035175057999, 0.0, 12653688.228050806,
       0.0, -4.122035175057999, 4792137.62563168), 'blockxsize': 256, 'blockysize': 256, 'tiled': True, 'interleave': 'pixel'}
{'driver': 'GTiff', 'dtype': 'uint16', 'nodata': 0.0, 'width': 8630, 'height': 8421, 'count': 4, 'crs': CRS({'init': 'epsg:3857'}), 'transform': Affine(4.122035175057999, 0.0, 12653688.228050806,
       0.0, -4.122035175057999, 4792137.62563168), 'blockxsize': 256, 'blockysize': 256, 'tiled': True, 'interleave': 'pixel'}

```