### PR TITLE
Exploit VRT complex source scale ratio 0 optimization

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,14 @@ Changes
 1.0.12 (TBD)
 ------------
 
+- The _boundless_vrt_doc function's background layer no longer needs an
+  in-memory dataset and the performance regression noted in #1499 has been
+  reversed. We've also found a performance improvement in masked boundless
+  reads in the case that the source data is entirely valid.
+- The signature of the private _boundless_vrt_doc function in rasterio.vrt has
+  changed. Its background keyword argument now takes an int or float, a new
+  masked keyword argument has been added, and the function returns a unicode
+  str instead of ascii-encoded bytes.
 - The copy and copyfiles functions of rasterio.shutil now raise an exception
   when the source and destination paths identify the same dataset (#1569).
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -367,23 +367,15 @@ cdef class DatasetReaderBase(DatasetBase):
         else:
 
             if fill_value is not None:
-                dtype = self.dtypes[0]
-                bg_path = UnparsedPath('/vsimem/bg{}.tif'.format(uuid.uuid4()))
-                with DatasetWriterBase(
-                        bg_path, 'w',
-                        driver='GTiff', count=self.count, height=3, width=3,
-                        dtype=dtype, crs=None, transform=Affine.identity() * Affine.translation(1, 1)) as bg_dataset:
-                    bg_dataset.write(
-                        np.full((self.count, 3, 3), fill_value, dtype=dtype))
-                bg_dataset = DatasetReaderBase(bg_path)
+                nodataval = fill_value
             else:
-                bg_dataset = None
+                nodataval = ndv
 
             vrt_doc = _boundless_vrt_doc(
-                self, nodata=ndv, background=bg_dataset,
+                self, nodata=nodataval, background=nodataval,
                 width=max(self.width, window.width) + 1,
                 height=max(self.height, window.height) + 1,
-                transform=self.window_transform(window)).decode('ascii')
+                transform=self.window_transform(window))
 
             if not gdal_version().startswith('1'):
                 vrt_kwds = {'driver': 'VRT'}
@@ -396,57 +388,42 @@ cdef class DatasetReaderBase(DatasetBase):
                     indexes, out, Window(0, 0, window.width, window.height),
                     None, resampling=resampling)
 
-                if masked and all_valid:
-                    blank_path = UnparsedPath('/vsimem/blank-{}.tif'.format(uuid.uuid4()))
-                    transform = Affine.translation(self.transform.xoff, self.transform.yoff) * (Affine.scale(self.width / 3, self.height / 3) * (Affine.translation(-self.transform.xoff, -self.transform.yoff) * self.transform))
-                    with DatasetWriterBase(
-                            blank_path, 'w',
-                            driver='GTiff', count=self.count, height=3, width=3,
-                            dtype='uint8', crs=self.crs, transform=transform) as blank_dataset:
-                        blank_dataset.write(
-                            np.ones((self.count, 3, 3), dtype='uint8'))
+                if masked:
 
-                    with DatasetReaderBase(blank_path) as blank_dataset:
+                    # Below we use another VRT to compute the valid data mask
+                    # in this special case where all source pixels are valid.
+                    if all_valid:
+
                         mask_vrt_doc = _boundless_vrt_doc(
-                            blank_dataset, nodata=0,
+                            self, nodata=0,
                             width=max(self.width, window.width) + 1,
                             height=max(self.height, window.height) + 1,
-                            transform=self.window_transform(window)).decode('ascii')
+                            transform=self.window_transform(window),
+                            masked=True)
 
                         with DatasetReaderBase(UnparsedPath(mask_vrt_doc), **vrt_kwds) as mask_vrt:
                             mask = np.zeros(out.shape, 'uint8')
                             mask = ~mask_vrt._read(
                                 indexes, mask, Window(0, 0, window.width, window.height), None).astype('bool')
 
-                            kwds = {'mask': mask}
-                            # Set a fill value only if the read bands share a
-                            # single nodata value.
-                            if fill_value is not None:
-                                kwds['fill_value'] = fill_value
-                            elif len(set(nodatavals)) == 1:
-                                if nodatavals[0] is not None:
-                                    kwds['fill_value'] = nodatavals[0]
 
-                            out = np.ma.array(out, **kwds)
-
-                elif masked:
-                    mask = np.zeros(out.shape, 'uint8')
-                    mask = ~vrt._read(
-                        indexes, mask, Window(0, 0, window.width, window.height), None, masks=True).astype('bool')
+                    else:
+                        mask = np.zeros(out.shape, 'uint8')
+                        mask = ~vrt._read(
+                            indexes, mask, Window(0, 0, window.width, window.height), None, masks=True).astype('bool')
 
                     kwds = {'mask': mask}
+
                     # Set a fill value only if the read bands share a
                     # single nodata value.
                     if fill_value is not None:
                         kwds['fill_value'] = fill_value
+
                     elif len(set(nodatavals)) == 1:
                         if nodatavals[0] is not None:
                             kwds['fill_value'] = nodatavals[0]
 
                     out = np.ma.array(out, **kwds)
-
-            if bg_dataset is not None:
-                bg_dataset.close()
 
         if return2d:
             out.shape = out.shape[1:]
@@ -601,7 +578,7 @@ cdef class DatasetReaderBase(DatasetBase):
                         blank_dataset, nodata=0,
                         width=max(self.width, window.width) + 1,
                         height=max(self.height, window.height) + 1,
-                        transform=self.window_transform(window)).decode('ascii')
+                        transform=self.window_transform(window))
 
                     with DatasetReaderBase(UnparsedPath(mask_vrt_doc), **vrt_kwds) as mask_vrt:
                         out = np.zeros(out.shape, 'uint8')
@@ -612,7 +589,7 @@ cdef class DatasetReaderBase(DatasetBase):
                 vrt_doc = _boundless_vrt_doc(
                     self, width=max(self.width, window.width) + 1,
                     height=max(self.height, window.height) + 1,
-                    transform=self.window_transform(window)).decode('ascii')
+                    transform=self.window_transform(window))
 
                 with DatasetReaderBase(UnparsedPath(vrt_doc), **vrt_kwds) as vrt:
 

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -71,21 +71,22 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
 
 def _boundless_vrt_doc(
         src_dataset, nodata=None, background=None, hidenodata=False,
-        width=None, height=None, transform=None):
+        width=None, height=None, transform=None, masked=False):
     """Make a VRT XML document.
 
     Parameters
     ----------
     src_dataset : Dataset
         The dataset to wrap.
-    background : Dataset, optional
-        A dataset that provides the optional VRT background. NB: this dataset
-        must have the same number of bands as the src_dataset.
+    background : int or float, optional
+        The background fill value for the boundless VRT.
+    masked : book
+        If True, the src_dataset is replaced by its valid data mask.
 
     Returns
     -------
-    bytes
-        An ascii-encoded string (an ElementTree detail)
+    str
+        An XML text string.
     """
 
     nodata = nodata or src_dataset.nodata
@@ -118,55 +119,68 @@ def _boundless_vrt_doc(
         colorinterp.text = ci.name.capitalize()
 
         if background is not None:
-            simplesource = ET.SubElement(vrtrasterband, 'SimpleSource')
-            sourcefilename = ET.SubElement(simplesource, 'SourceFilename')
-            sourcefilename.attrib['relativeToVRT'] = "0"
-            sourcefilename.text = vsi_path(parse_path(background.name))
-            sourceband = ET.SubElement(simplesource, 'SourceBand')
+            complexsource = ET.SubElement(vrtrasterband, 'ComplexSource')
+            sourcefilename = ET.SubElement(complexsource, 'SourceFilename')
+            sourcefilename.attrib['relativeToVRT'] = '1'
+            sourcefilename.text = 'dummy.tif'  # vsi_path(parse_path(background.name))
+            sourceband = ET.SubElement(complexsource, 'SourceBand')
             sourceband.text = str(bidx)
-            sourceproperties = ET.SubElement(simplesource, 'SourceProperties')
+            sourceproperties = ET.SubElement(complexsource, 'SourceProperties')
             sourceproperties.attrib['RasterXSize'] = str(width)
             sourceproperties.attrib['RasterYSize'] = str(height)
             sourceproperties.attrib['dataType'] = _gdal_typename(dtype)
             sourceproperties.attrib['BlockYSize'] = str(block_shape[0])
             sourceproperties.attrib['BlockXSize'] = str(block_shape[1])
-            srcrect = ET.SubElement(simplesource, 'SrcRect')
+            srcrect = ET.SubElement(complexsource, 'SrcRect')
             srcrect.attrib['xOff'] = '0'
             srcrect.attrib['yOff'] = '0'
-            srcrect.attrib['xSize'] = str(background.width)
-            srcrect.attrib['ySize'] = str(background.height)
-            dstrect = ET.SubElement(simplesource, 'DstRect')
+            srcrect.attrib['xSize'] = '1'  # str(background.width)
+            srcrect.attrib['ySize'] = '1'  # str(background.height)
+            dstrect = ET.SubElement(complexsource, 'DstRect')
             dstrect.attrib['xOff'] = '0'
             dstrect.attrib['yOff'] = '0'
-            dstrect.attrib['xSize'] = str(width)
-            dstrect.attrib['ySize'] = str(height)
+            dstrect.attrib['xSize'] = '1'  # str(width)
+            dstrect.attrib['ySize'] = '1'  # str(height)
+            scaleratio = ET.SubElement(complexsource, 'ScaleRatio')
+            scaleratio.text = '0'
+            scaleoffset = ET.SubElement(complexsource, 'ScaleOffset')
+            scaleoffset.text = str(background)
 
-        simplesource = ET.SubElement(vrtrasterband, 'SimpleSource')
-        sourcefilename = ET.SubElement(simplesource, 'SourceFilename')
+        complexsource = ET.SubElement(vrtrasterband, 'ComplexSource')
+        sourcefilename = ET.SubElement(complexsource, 'SourceFilename')
         sourcefilename.attrib['relativeToVRT'] = "0"
         sourcefilename.text = vsi_path(parse_path(src_dataset.name))
-        sourceband = ET.SubElement(simplesource, 'SourceBand')
+        sourceband = ET.SubElement(complexsource, 'SourceBand')
         sourceband.text = str(bidx)
-        sourceproperties = ET.SubElement(simplesource, 'SourceProperties')
+        sourceproperties = ET.SubElement(complexsource, 'SourceProperties')
         sourceproperties.attrib['RasterXSize'] = str(width)
         sourceproperties.attrib['RasterYSize'] = str(height)
         sourceproperties.attrib['dataType'] = _gdal_typename(dtype)
         sourceproperties.attrib['BlockYSize'] = str(block_shape[0])
         sourceproperties.attrib['BlockXSize'] = str(block_shape[1])
-        srcrect = ET.SubElement(simplesource, 'SrcRect')
+        srcrect = ET.SubElement(complexsource, 'SrcRect')
         srcrect.attrib['xOff'] = '0'
         srcrect.attrib['yOff'] = '0'
         srcrect.attrib['xSize'] = str(src_dataset.width)
         srcrect.attrib['ySize'] = str(src_dataset.height)
-        dstrect = ET.SubElement(simplesource, 'DstRect')
+        dstrect = ET.SubElement(complexsource, 'DstRect')
         dstrect.attrib['xOff'] = str((src_dataset.transform.xoff - transform.xoff) / transform.a)
         dstrect.attrib['yOff'] = str((src_dataset.transform.yoff - transform.yoff) / transform.e)
         dstrect.attrib['xSize'] = str(src_dataset.width * src_dataset.transform.a / transform.a)
         dstrect.attrib['ySize'] = str(src_dataset.height * src_dataset.transform.e / transform.e)
 
         if src_dataset.nodata is not None:
-            nodata_elem = ET.SubElement(simplesource, 'NODATA')
+            nodata_elem = ET.SubElement(complexsource, 'NODATA')
             nodata_elem.text = str(src_dataset.nodata)
+
+        # Effectively replaces all values of the source dataset with
+        # 255.  Due to GDAL optimizations, the source dataset will not
+        # be read, so we get a performance improvement.
+        if masked:
+            scaleratio = ET.SubElement(complexsource, 'ScaleRatio')
+            scaleratio.text = '0'
+            scaleoffset = ET.SubElement(complexsource, 'ScaleOffset')
+            scaleoffset.text = '255'
 
     if all(MaskFlags.per_dataset in flags for flags in src_dataset.mask_flag_enums):
         maskband = ET.SubElement(vrtdataset, 'MaskBand')
@@ -197,4 +211,4 @@ def _boundless_vrt_doc(
         dstrect.attrib['xSize'] = str(src_dataset.width)
         dstrect.attrib['ySize'] = str(src_dataset.height)
 
-    return ET.tostring(vrtdataset)
+    return ET.tostring(vrtdataset).decode('ascii')

--- a/tests/test_vrt.py
+++ b/tests/test_vrt.py
@@ -7,8 +7,8 @@ import rasterio.vrt
 def test_boundless_vrt(path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as rgb:
         doc = rasterio.vrt._boundless_vrt_doc(rgb)
-        assert doc.startswith(b'<VRTDataset')
-        with rasterio.open(doc.decode('ascii')) as vrt:
+        assert doc.startswith('<VRTDataset')
+        with rasterio.open(doc) as vrt:
             assert rgb.count == vrt.count
             assert rgb.dtypes == vrt.dtypes
             assert rgb.mask_flag_enums == vrt.mask_flag_enums
@@ -17,8 +17,8 @@ def test_boundless_vrt(path_rgb_byte_tif):
 def test_boundless_msk_vrt(path_rgb_msk_byte_tif):
     with rasterio.open(path_rgb_msk_byte_tif) as msk:
         doc = rasterio.vrt._boundless_vrt_doc(msk)
-        assert doc.startswith(b'<VRTDataset')
-        with rasterio.open(doc.decode('ascii')) as vrt:
+        assert doc.startswith('<VRTDataset')
+        with rasterio.open(doc) as vrt:
             assert msk.count == vrt.count
             assert msk.dtypes == vrt.dtypes
             assert msk.mask_flag_enums == vrt.mask_flag_enums


### PR DESCRIPTION
Per conversation in https://github.com/OSGeo/gdal/issues/1135, GDAL doesn't read the VRT source dataset of a complex source when the scale ratio is set to 0. This makes a bunch of complicated code in rasterio._io obsolete and reverses a performance regression noted in #1499.