### PR TITLE
Add anonymous Env in DatasetBase.__enter__ if needed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Next
+----
+
+- On entering a dataset context (DatasetBase.__enter__) a new anonymous GDAL
+  environment is created if needed and is entered. This makes `with
+  rasterio.open(...) as dataset:` roughly equivalent to `with
+  rasterio.open(...) as dataset, Env():`. This helps prevent bugs when datasets
+  are created and then used later or are used in different scopes.
+
 1.0.13 (2018-12-14)
 -------------------
 

--- a/rasterio/_base.pxd
+++ b/rasterio/_base.pxd
@@ -27,6 +27,7 @@ cdef class DatasetBase:
     cdef public object _offsets
     cdef public object _read
     cdef public object _gcps
+    cdef public object _env
     cdef GDALDatasetH handle(self) except NULL
     cdef GDALRasterBandH band(self, int bidx) except NULL
 

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -11,7 +11,7 @@ from rasterio._io import (
     DatasetReaderBase, DatasetWriterBase, BufferedDatasetWriterBase,
     MemoryFileBase)
 from rasterio.windows import WindowMethodsMixin
-from rasterio.env import ensure_env
+from rasterio.env import ensure_env, env_ctx_if_needed
 from rasterio.transform import TransformMethodsMixin
 from rasterio.path import UnparsedPath
 
@@ -136,9 +136,12 @@ class MemoryFile(MemoryFileBase):
                           nodata=nodata, **kwargs)
 
     def __enter__(self):
+        self._env = env_ctx_if_needed()
+        self._env.__enter__()
         return self
 
     def __exit__(self, *args, **kwargs):
+        self._env.__exit__()
         self.close()
 
 

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -6,6 +6,7 @@ import rasterio
 from rasterio._warp import WarpedVRTReaderBase
 from rasterio.dtypes import _gdal_typename
 from rasterio.enums import MaskFlags
+from rasterio.env import env_ctx_if_needed
 from rasterio.path import parse_path, vsi_path
 from rasterio.transform import TransformMethodsMixin
 from rasterio.windows import WindowMethodsMixin
@@ -56,10 +57,13 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
             self.closed and 'closed' or 'open', self.name, self.mode)
 
     def __enter__(self):
+        self._env = env_ctx_if_needed()
+        self._env.__enter__()
         self.start()
         return self
 
     def __exit__(self, *args, **kwargs):
+        self._env.__exit__()
         self.close()
 
     def __del__(self):


### PR DESCRIPTION
Prevents bugs when datasets are opened and passed to other functions.