### PR TITLE
Add support for signed 8 bit images

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -22,7 +22,7 @@ except ImportError:  # pragma: no cover
 from rasterio._base import gdal_version
 from rasterio.drivers import is_blacklisted
 from rasterio.dtypes import (
-    bool_, ubyte, uint8, uint16, int16, uint32, int32, float32, float64,
+    bool_, ubyte, sbyte, uint8, int8, uint16, int16, uint32, int32, float32, float64,
     complex_, check_dtype)
 from rasterio.env import ensure_env_with_credentials, Env
 from rasterio.errors import RasterioIOError

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1101,6 +1101,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             else:
                 gdal_dtype = dtypes.dtype_rev.get(self._init_dtype)
 
+            if self._init_dtype == 'int8':
+                options = CSLSetNameValue(options, 'PIXELTYPE', 'SIGNEDBYTE')
+
             # Create a GDAL dataset handle.
             try:
 

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -12,6 +12,7 @@ do something like this:
 
 bool_ = 'bool'
 ubyte = uint8 = 'uint8'
+sbyte = int8 = 'int8'
 uint16 = 'uint16'
 int16 = 'int16'
 uint32 = 'uint32'
@@ -41,6 +42,7 @@ dtype_fwd = {
 
 dtype_rev = dict((v, k) for k, v in dtype_fwd.items())
 dtype_rev['uint8'] = 1
+dtype_rev['int8'] = 1
 
 typename_fwd = {
     0: 'Unknown',
@@ -59,6 +61,7 @@ typename_fwd = {
 typename_rev = dict((v, k) for k, v in typename_fwd.items())
 
 dtype_ranges = {
+    'int8': (-128, 127),
     'uint8': (0, 255),
     'uint16': (0, 65535),
     'int16': (-32768, 32767),

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -33,14 +33,14 @@ def test_validate_dtype_str(tmpdir):
             dtype='Int16')
 
 
-def test_validate_dtype_int8(tmpdir, basic_image):
+def test_validate_dtype_float128(tmpdir, basic_image):
     """Raise TypeError if dtype is unsupported by GDAL."""
-    name = str(tmpdir.join('int8.tif'))
-    basic_image_int8 = basic_image.astype('int8')
-    height, width = basic_image_int8.shape
+    name = str(tmpdir.join('float128.tif'))
+    basic_image_f128 = basic_image.astype('float128')
+    height, width = basic_image_f128.shape
     with pytest.raises(TypeError):
         rasterio.open(name, 'w', driver='GTiff', width=width, height=height,
-                      count=1, dtype=basic_image_int8.dtype)
+                      count=1, dtype=basic_image_f128.dtype)
 
 
 def test_validate_count_None(tmpdir):
@@ -99,6 +99,20 @@ def test_write_ubyte(tmpdir):
         s.write(a, indexes=1)
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=127.000, Maximum=127.000, Mean=127.000, StdDev=0.000" in info
+
+
+@pytest.mark.gdalbin
+def test_write_sbyte(tmpdir):
+    name = str(tmpdir.mkdir("sub").join("test_write_sbyte.tif"))
+    a = np.ones((100, 100), dtype=rasterio.sbyte) * -33
+    with rasterio.open(
+            name, 'w',
+            driver='GTiff', width=100, height=100, count=1,
+            dtype=a.dtype) as s:
+        s.write(a, indexes=1)
+    info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
+    assert "Minimum=-33.000, Maximum=-33.000, Mean=-33.000, StdDev=0.000" in info
+    assert 'SIGNEDBYTE' in info
 
 
 @pytest.mark.gdalbin


### PR DESCRIPTION
Signed 8-bit images are somewhat "second-class" in GDAL, but it can read/write them nevertheless.

Even though GDAL only has unsigned `GDT_Byte` raster data type, signed vs unsigned
images can be differentiated via `PIXELTYPE` property. It is set to `SIGNEDBYTE`
for signed 8-bit file. This is how GDAL's native python binding compute `numpy.dtype` from dataset object:

https://github.com/OSGeo/gdal/blob/90dde4a3fc0d89373a62000ae14e424fc41f7306/gdal/swig/python/osgeo/gdal_array.py#L299-L300

Similarly, on output side, setting option `PIXELTYPE='SIGNEDBYTE'` when creating file with `GDT_Byte` dtype will generate signed int8 image.
