### PR TITLE
band_one is not defined in the walkthrough

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -194,7 +194,7 @@ dataset's upper left corner, do the following.
     >>> row, col = dataset.index(x, y)
     >>> row, col
     (1666, 3333)
-    >>> band_one[row, col]
+    >>> band1[row, col]
     7566
 
 To get the spatial coordinates of a pixel, use the dataset's ``xy()`` method.


### PR DESCRIPTION
band1 is defined earlier in the walkthrough but band_one is not. Calling band_one[row, col] results in an error. Changed band_one to band1.