### PR TITLE
WKT based CRS pickle protocol

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changes
 =======
 
+1.0.19 (?)
+----------
+
+- Restore pickle protocol for CRS, using WKT as state (#1625).
+- Support for signed 8-bit integer datasets ("int8" dtype) has been added
+  (#1595).
+
 1.0.18 (2019-02-07)
 -------------------
 

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -89,6 +89,12 @@ class CRS(collections.Mapping):
         other = CRS.from_user_input(other)
         return (self._crs == other._crs)
 
+    def __getstate__(self):
+        return self.wkt
+
+    def __setstate__(self, state):
+        self._crs = _CRS.from_wkt(state)
+
     def to_proj4(self):
         """Convert CRS to a PROJ4 string
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -436,7 +436,7 @@ def test_issue1620():
 
 @pytest.mark.parametrize('factory,arg', [(CRS.from_epsg, 3857), (CRS.from_dict, {'ellps': 'WGS84', 'proj': 'stere', 'lat_0': -90.0, 'lon_0': 0.0, 'x_0': 0.0, 'y_0': 0.0, 'lat_ts': -70, 'no_defs': True})])
 def test_pickle(factory, arg):
-    """A CRS is pickable"""
+    """A CRS is pickleable"""
     crs1 = factory(arg)
     crs2 = pickle.loads(pickle.dumps(crs1))
     assert crs2 == crs1

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import pickle
 import subprocess
 
 import pytest
@@ -431,3 +432,11 @@ def test_empty_crs_str():
 def test_issue1620():
     """Different forms of EPSG:3857 are equal"""
     assert CRS.from_wkt('PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]') == CRS.from_dict(init='epsg:3857')
+
+
+@pytest.mark.parametrize('factory,arg', [(CRS.from_epsg, 3857), (CRS.from_dict, {'ellps': 'WGS84', 'proj': 'stere', 'lat_0': -90.0, 'lon_0': 0.0, 'x_0': 0.0, 'y_0': 0.0, 'lat_ts': -70, 'no_defs': True})])
+def test_pickle(factory, arg):
+    """A CRS is pickable"""
+    crs1 = factory(arg)
+    crs2 = pickle.loads(pickle.dumps(crs1))
+    assert crs2 == crs1

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,3 +1,6 @@
+"""Profile tests"""
+
+import pickle
 import warnings
 
 import pytest
@@ -77,8 +80,8 @@ def test_blockysize_guard(tmpdir):
         rasterio.open(tiffname, 'w', **profile)
 
 
-def test_profile_overlay():
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+def test_profile_overlay(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as src:
         kwds = src.profile
     kwds.update(**default_gtiff_profile)
     assert kwds['tiled']
@@ -94,9 +97,9 @@ def test_dataset_profile_property_tiled(data):
         assert src.profile['tiled'] is True
 
 
-def test_dataset_profile_property_untiled(data):
+def test_dataset_profile_property_untiled(data, path_rgb_byte_tif):
     """An untiled dataset's profile has no block sizes"""
-    with rasterio.open('tests/data/RGB.byte.tif') as src:
+    with rasterio.open(path_rgb_byte_tif) as src:
         assert 'blockxsize' not in src.profile
         assert 'blockysize' not in src.profile
         assert src.profile['tiled'] is False
@@ -108,3 +111,14 @@ def test_profile_affine_set():
     profile['transform'] = 'foo'
     with pytest.raises(TypeError):
         profile['affine'] = 'bar'
+
+
+def test_profile_pickle():
+    """Standard profile can be pickled"""
+    assert pickle.loads(pickle.dumps(DefaultGTiffProfile())) == DefaultGTiffProfile()
+
+
+def test_dataset_profile_pickle(path_rgb_byte_tif):
+    """Dataset profiles can be pickled"""
+    with rasterio.open(path_rgb_byte_tif) as src:
+        assert pickle.loads(pickle.dumps(src.profile)) == src.profile


### PR DESCRIPTION
Resolves #1625 

What do you think of this @darrenleeweber? 

I have no plan for long-lived pickles as referred to in https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled:

>  If you plan to have long-lived objects that will see many versions of a class, it may be worthwhile to put a version number in the objects so that suitable conversions can be made by the class’s `__setstate__()` method.

We don't need them for multiprocessing.