### PR TITLE
Remove OSRFixup() from rasterio/gdal.pxi

### DIFF
--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -90,7 +90,6 @@ cdef extern from "ogr_srs_api.h" nogil:
     OGRSpatialReferenceH OSRClone(OGRSpatialReferenceH srs)
     int OSRExportToProj4(OGRSpatialReferenceH srs, char **params)
     int OSRExportToWkt(OGRSpatialReferenceH srs, char **params)
-    int OSRFixup(OGRSpatialReferenceH srs)
     const char *OSRGetAuthorityName(OGRSpatialReferenceH srs, const char *key)
     const char *OSRGetAuthorityCode(OGRSpatialReferenceH srs, const char *key)
     int OSRImportFromEPSG(OGRSpatialReferenceH srs, int code)


### PR DESCRIPTION
It is not used in and .pyx file, and no longer exists in GDAL 2.5