### PR TITLE
First swing at resolving #1634

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changes
 1.0.19 (?)
 ----------
 
+- Add linear_units property to CRS (#1638).
 - Ensure that AWS_NO_SIGN_REQUESTS is sufficient for accessing public S3
   datasets and that import of boto3 is not required (#1637).
 - An out_dtype parameter has been added to DatasetReaderBase.read, enabling

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -53,6 +53,26 @@ cdef class _CRS(object):
         except CPLE_BaseError as exc:
             raise CRSError("{}".format(exc))
 
+    @property
+    def linear_units(self):
+        """Get linear units of the CRS
+
+        Returns
+        -------
+        str
+
+        """
+        cdef char *units_c = NULL
+        cdef double fmeter
+
+        try:
+            fmeter = OSRGetLinearUnits(self._osr, &units_c)
+        except CPLE_BaseError as exc:
+            raise CRSError("{}".format(exc))
+        else:
+            units_b = units_c
+            return units_b.decode('utf-8')
+
     def __eq__(self, other):
         cdef OGRSpatialReferenceH osr_s = NULL
         cdef OGRSpatialReferenceH osr_o = NULL

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -229,6 +229,19 @@ class CRS(collections.Mapping):
         except CRSError:
             return False
 
+    @property
+    def linear_units(self):
+        """The linear units of the CRS
+
+        Possible values include "metre" and "US survey foot".
+
+        Returns
+        -------
+        str
+
+        """
+        return self._crs.linear_units
+
     def to_string(self):
         """Convert CRS to a PROJ4 or WKT string
 

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -103,6 +103,7 @@ cdef extern from "ogr_srs_api.h" nogil:
     void OSRRelease(OGRSpatialReferenceH srs)
     int OSRSetFromUserInput(OGRSpatialReferenceH srs, const char *input)
     OGRErr OSRValidate(OGRSpatialReferenceH srs)
+    double OSRGetLinearUnits(OGRSpatialReferenceH srs, char **ppszName)
 
 cdef extern from "gdal.h" nogil:
 

--- a/tests/test__crs.py
+++ b/tests/test__crs.py
@@ -41,14 +41,14 @@ def test_from_dict():
     """Can create a _CRS from a dict"""
     crs = _CRS.from_dict({'init': 'epsg:3857'})
     assert crs.to_dict()['proj'] == 'merc'
-    assert 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]' in crs.to_wkt()
+    assert 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84"' in crs.to_wkt()
 
 
 def test_from_dict_keywords():
     """Can create a CRS from keyword args, ignoring unknowns"""
     crs = _CRS.from_dict(init='epsg:3857', foo='bar')
     assert crs.to_dict()['proj'] == 'merc'
-    assert 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]' in crs.to_wkt()
+    assert 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84"' in crs.to_wkt()
 
 
 def test_from_epsg():

--- a/tests/test__crs.py
+++ b/tests/test__crs.py
@@ -1,0 +1,148 @@
+"""crs module tests"""
+
+import json
+import logging
+import os
+import subprocess
+
+import pytest
+
+import rasterio
+from rasterio._crs import _CRS
+from rasterio.env import env_ctx_if_needed, Env
+from rasterio.errors import CRSError
+
+from .conftest import requires_gdal21, requires_gdal22
+
+
+# Items like "D_North_American_1983" characterize the Esri dialect
+# of WKT SRS.
+ESRI_PROJECTION_STRING = (
+    'PROJCS["USA_Contiguous_Albers_Equal_Area_Conic_USGS_version",'
+    'GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",'
+    'SPHEROID["GRS_1980",6378137.0,298.257222101]],'
+    'PRIMEM["Greenwich",0.0],'
+    'UNIT["Degree",0.0174532925199433]],'
+    'PROJECTION["Albers"],'
+    'PARAMETER["false_easting",0.0],'
+    'PARAMETER["false_northing",0.0],'
+    'PARAMETER["central_meridian",-96.0],'
+    'PARAMETER["standard_parallel_1",29.5],'
+    'PARAMETER["standard_parallel_2",45.5],'
+    'PARAMETER["latitude_of_origin",23.0],'
+    'UNIT["Meter",1.0],'
+    'VERTCS["NAVD_1988",'
+    'VDATUM["North_American_Vertical_Datum_1988"],'
+    'PARAMETER["Vertical_Shift",0.0],'
+    'PARAMETER["Direction",1.0],UNIT["Centimeter",0.01]]]')
+
+
+def test_from_dict():
+    """Can create a _CRS from a dict"""
+    crs = _CRS.from_dict({'init': 'epsg:3857'})
+    assert crs.to_dict()['proj'] == 'merc'
+    assert 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]' in crs.to_wkt()
+
+
+def test_from_dict_keywords():
+    """Can create a CRS from keyword args, ignoring unknowns"""
+    crs = _CRS.from_dict(init='epsg:3857', foo='bar')
+    assert crs.to_dict()['proj'] == 'merc'
+    assert 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]' in crs.to_wkt()
+
+
+def test_from_epsg():
+    """Can create a CRS from EPSG code"""
+    crs = _CRS.from_epsg(4326)
+    assert crs.to_dict()['proj'] == 'longlat'
+
+
+@pytest.mark.parametrize('code', [0, -1, float('nan'), 1.3])
+def test_from_epsg_error(code):
+    """Raise exception with invalid EPSG code"""
+    with pytest.raises(ValueError):
+        assert _CRS.from_epsg(code)
+
+
+@pytest.mark.parametrize('proj,expected', [({'init': 'epsg:4326'}, True), ({'init': 'epsg:3857'}, False)])
+def test_is_geographic(proj, expected):
+    """CRS is or is not geographic"""
+    assert _CRS.from_dict(proj).is_geographic is expected
+
+
+@pytest.mark.parametrize('proj,expected', [({'init': 'epsg:4326'}, False), ({'init': 'epsg:3857'}, True)])
+def test_is_projected(proj, expected):
+    """CRS is or is not projected"""
+    assert _CRS.from_dict(proj).is_projected is expected
+
+
+def test_equality():
+    """CRS are or are not equal"""
+    _CRS.from_epsg(4326) == _CRS.from_proj4('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
+
+
+def test_to_wkt():
+    """CRS converts to WKT"""
+    assert _CRS.from_dict({'init': 'epsg:4326'}).to_wkt().startswith('GEOGCS["WGS 84",DATUM')
+
+
+@pytest.mark.parametrize('proj_string', ['+init=epsg:4326', '+proj=longlat +datum=WGS84 +no_defs'])
+def test_to_epsg(proj_string):
+    """CRS has EPSG code"""
+    assert _CRS.from_proj4(proj_string).to_epsg() == 4326
+
+
+@pytest.mark.parametrize('proj_string', [ESRI_PROJECTION_STRING])
+def test_esri_wkt_to_epsg(proj_string):
+    """CRS has no EPSG code"""
+    assert _CRS.from_wkt(proj_string, morph_from_esri_dialect=True).to_epsg() is None
+
+
+def test_epsg_no_code_available():
+    """CRS has no EPSG code"""
+    lcc_crs = _CRS.from_proj4('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
+    assert lcc_crs.to_epsg() is None
+
+
+def test_from_wkt_invalid():
+    """Raise exception if input WKT is invalid"""
+    with pytest.raises(CRSError):
+        _CRS.from_wkt('bogus')
+
+
+@pytest.mark.parametrize('projection_string', [ESRI_PROJECTION_STRING])
+def test_from_esri_wkt_no_fix(projection_string):
+    """Test ESRI CRS morphing with no datum fixing"""
+    with Env():
+        crs = _CRS.from_wkt(projection_string)
+        assert 'DATUM["D_North_American_1983"' in crs.to_wkt()
+
+
+@pytest.mark.parametrize('projection_string', [ESRI_PROJECTION_STRING])
+def test_from_esri_wkt_fix_datum(projection_string):
+    """Test ESRI CRS morphing with datum fixing"""
+    with Env(GDAL_FIX_ESRI_WKT='DATUM'):
+        crs = _CRS.from_wkt(projection_string, morph_from_esri_dialect=True)
+        assert 'DATUM["North_American_Datum_1983"' in crs.to_wkt()
+
+
+def test_to_esri_wkt_fix_datum():
+    """Morph to Esri form"""
+    assert 'DATUM["D_North_American_1983"' in _CRS.from_dict(init='epsg:26913').to_wkt(morph_to_esri_dialect=True)
+
+
+def test_compound_crs():
+    """Parse compound WKT"""
+    wkt = """COMPD_CS["unknown",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433],AUTHORITY["EPSG","4326"]],VERT_CS["unknown",VERT_DATUM["unknown",2005],UNIT["metre",1.0,AUTHORITY["EPSG","9001"]],AXIS["Up",UP]]]"""
+    assert _CRS.from_wkt(wkt).to_wkt().startswith('COMPD_CS')
+
+
+def test_exception_proj4():
+    """Get the exception message we expect"""
+    with pytest.raises(CRSError):
+        _CRS.from_proj4("+proj=bogus")
+
+
+def test_linear_units():
+    """CRS linear units can be had"""
+    assert _CRS.from_epsg(3857).linear_units == 'metre'

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -440,3 +440,8 @@ def test_pickle(factory, arg):
     crs1 = factory(arg)
     crs2 = pickle.loads(pickle.dumps(crs1))
     assert crs2 == crs1
+
+
+def test_linear_units():
+    """CRS linear units can be had"""
+    assert CRS.from_epsg(3857).linear_units == 'metre'


### PR DESCRIPTION
What do you think @appanacca? Is getting the name of the linear units enough? There's a Python package named "pint" that provides normalization and unit conversion, so we don't necessarily need to expose the number of metres per unit.