### PR TITLE
Use CPLParseKeyValue on metadata items

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Next
+----
+
+- Use GDAL's string parsing to get metadata item keys and values, which
+  accommodates uncommon "KEY:VALUE" forms.
+
 1.0.22 (2019-03-20)
 -------------------
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -948,6 +948,8 @@ cdef class DatasetBase(object):
         cdef GDALMajorObjectH obj = NULL
         cdef char **metadata = NULL
         cdef const char *domain = NULL
+        cdef char *key = NULL
+        cdef char *val = NULL
 
         if bidx > 0:
             obj = self.band(bidx)
@@ -959,7 +961,14 @@ cdef class DatasetBase(object):
 
         metadata = GDALGetMetadata(obj, domain)
         num_items = CSLCount(metadata)
-        return dict(metadata[i].split('=', 1) for i in range(num_items))
+
+        tag_items = []
+        for i in range(num_items):
+            val = CPLParseNameValue(metadata[i], &key)
+            tag_items.append((key[:], val[:]))
+            CPLFree(key)
+
+        return dict(tag_items)
 
 
     def get_tag_item(self, ns, dm=None, bidx=0, ovr=None):

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -50,6 +50,7 @@ cdef extern from "cpl_string.h" nogil:
     char **CSLSetNameValue(char **list, char *name, char *val)
     void CSLDestroy(char **list)
     char **CSLMerge(char **first, char **second)
+    const char* CPLParseNameValue(const char *pszNameValue, char **ppszKey)
 
 
 cdef extern from "cpl_vsi.h" nogil:


### PR DESCRIPTION
This gets us support for uncommon `KEY:VALUE` metadata and makes rasterio more like gdalinfo.