### PR TITLE
Add support for OpenStack Swift Object Storage(cloud optimized geotiff)  with tests

### DIFF
--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -20,12 +20,13 @@ SCHEMES = {
     'file': 'file',
     'oss': 'oss',
     'gs': 'gs',
+    'swift': 'swift',
 }
 
 CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss', 'gs')])
+REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss', 'gs', 'swift')])
 
 
 class Path(object):

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -20,13 +20,12 @@ SCHEMES = {
     'file': 'file',
     'oss': 'oss',
     'gs': 'gs',
-    'swift': 'swift',
 }
 
 CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 
 # TODO: extend for other cloud plaforms.
-REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss', 'gs', 'swift')])
+REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss', 'gs',)])
 
 
 class Path(object):

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -94,6 +94,9 @@ class Session(object):
         elif path.scheme == "oss" or "aliyuncs.com" in path.path:
             return OSSSession
 
+        elif path.scheme == "swift":
+            return SwiftSession
+            
         # This factory can be extended to other cloud providers here.
         # elif path.scheme == "cumulonimbus":  # for example.
         #     return CumulonimbusSession(*args, **kwargs)
@@ -366,5 +369,96 @@ class GSSession(Session):
         -------
         dict
 
+        """
+        return {k.upper(): v for k, v in self.credentials.items()}
+
+
+class SwiftSession(Session):
+    """Configures access to secured resources stored in OpenStack Swift Object Storage.
+    """
+    def __init__(self, session=None, 
+                swift_storage_url=None, swift_auth_token=None, 
+                swift_auth_v1_url=None, swift_user=None, swift_key=None):
+        """Create new OpenStack Swift Object Storage Session.   
+        Three methods are possible:  
+            1. Create session by the swiftclient library.
+            2. The SWIFT_STORAGE_URL and SWIFT_AUTH_TOKEN (this method is recommended by GDAL docs).  
+            3. The SWIFT_AUTH_V1_URL, SWIFT_USER and SWIFT_KEY (This depends on the swiftclient library).  
+
+        Parameters
+        ----------
+        session: optional
+            A swiftclient connection object
+        swift_storage_url:
+            the storage URL
+        swift_auth_token:
+            the value of the x-auth-token authorization token
+        swift_storage_url: string, optional
+            authentication URL
+        swift_user: string, optional
+            user name to authenticate as
+        swift_key: string, optional
+            key/password to authenticate with
+
+        Examples
+        --------
+        >>> import rasterio
+        >>> from rasterio.session import SwiftSession
+        >>> fp = 'swift://testcontainer/test_cog.tif'
+        >>> conn = Connection(authurl='http://127.0.0.1:7777/auth/v1.0', user='test:tester', key='testing')
+        >>> session = SwiftSession(conn)
+        >>> with rasterio.Env(session):
+        >>>     with rasterio.open(fp) as src:
+        >>>         print(src.profile)
+
+        """
+        if swift_storage_url and swift_auth_token:
+            self._creds = {
+                "swift_storage_url": swift_storage_url,
+                "swift_auth_token": swift_auth_token
+            }
+        else:
+            from swiftclient.client import Connection
+
+            if session:
+                self._session = session
+            else:
+                self._session = Connection(
+                    authurl=swift_auth_v1_url,
+                    user=swift_user,
+                    key=swift_key
+                )
+            self._creds = {
+                "swift_storage_url": self._session.get_auth()[0],
+                "swift_auth_token": self._session.get_auth()[1]
+            }
+            
+    
+    @classmethod
+    def hascreds(cls, config):
+        """Determine if the given configuration has proper credentials
+        Parameters
+        ----------
+        cls : class
+            A Session class.
+        config : dict
+            GDAL configuration as a dict.
+        Returns
+        -------
+        bool
+        """
+        return 'SWIFT_STORAGE_URL' in config and 'SWIFT_AUTH_TOKEN' in config
+
+    @property
+    def credentials(self):
+        """The session credentials as a dict"""
+        return self._creds
+
+
+    def get_credential_options(self):
+        """Get credentials as GDAL configuration options
+        Returns
+        -------
+        dict
         """
         return {k.upper(): v for k, v in self.credentials.items()}

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -96,7 +96,7 @@ class Session(object):
 
         elif path.scheme == "swift":
             return SwiftSession
-            
+
         # This factory can be extended to other cloud providers here.
         # elif path.scheme == "cumulonimbus":  # for example.
         #     return CumulonimbusSession(*args, **kwargs)
@@ -433,7 +433,6 @@ class SwiftSession(Session):
                 "swift_auth_token": self._session.get_auth()[1]
             }
             
-    
     @classmethod
     def hascreds(cls, config):
         """Determine if the given configuration has proper credentials
@@ -454,7 +453,6 @@ class SwiftSession(Session):
         """The session credentials as a dict"""
         return self._creds
 
-
     def get_credential_options(self):
         """Get credentials as GDAL configuration options
         Returns
@@ -462,3 +460,4 @@ class SwiftSession(Session):
         dict
         """
         return {k.upper(): v for k, v in self.credentials.items()}
+        

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -94,7 +94,7 @@ class Session(object):
         elif path.scheme == "oss" or "aliyuncs.com" in path.path:
             return OSSSession
 
-        elif path.scheme == "swift":
+        elif path.path.startswith("/vsiswift/"):
             return SwiftSession
 
         # This factory can be extended to other cloud providers here.
@@ -404,7 +404,7 @@ class SwiftSession(Session):
         --------
         >>> import rasterio
         >>> from rasterio.session import SwiftSession
-        >>> fp = 'swift://testcontainer/test_cog.tif'
+        >>> fp = '/vsiswift/bucket/key.tif'
         >>> conn = Connection(authurl='http://127.0.0.1:7777/auth/v1.0', user='test:tester', key='testing')
         >>> session = SwiftSession(conn)
         >>> with rasterio.Env(session):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -20,7 +20,7 @@ from rasterio.env import Env, defenv, delenv, getenv, setenv, ensure_env, ensure
 from rasterio.env import GDALVersion, require_gdal_version
 from rasterio.errors import EnvError, RasterioIOError, GDALVersionError
 from rasterio.rio.main import main_group
-from rasterio.session import AWSSession, OSSSession
+from rasterio.session import AWSSession, OSSSession, SwiftSession
 
 from .conftest import requires_gdal21
 
@@ -823,3 +823,33 @@ def test_oss_session_credentials(gdalenv):
         assert getenv()['OSS_ACCESS_KEY_ID'] == 'id'
         assert getenv()['OSS_SECRET_ACCESS_KEY'] == 'key'
         assert getenv()['OSS_ENDPOINT'] == 'null-island-1'
+
+
+
+def test_swift_session_credentials(gdalenv):
+    """Create an Env with a oss session."""
+    swift_session = SwiftSession(
+        swift_storage_url='foo',
+        swift_auth_token='bar')
+    with rasterio.env.Env(session=swift_session) as s:
+        s.credentialize()
+        assert getenv()['SWIFT_STORAGE_URL'] == 'foo'
+        assert getenv()['SWIFT_AUTH_TOKEN'] == 'bar'
+
+
+def test_swift_session_by_user_key():
+    def mock_init(self, session=None, 
+                swift_storage_url=None, swift_auth_token=None, 
+                swift_auth_v1_url=None, swift_user=None, swift_key=None):
+        self._creds = {'SWIFT_STORAGE_URL':'foo',
+                       'SWIFT_AUTH_TOKEN':'bar'}
+
+    with mock.patch('rasterio.session.SwiftSession.__init__', new=mock_init):
+        swift_session = SwiftSession(
+            swift_auth_v1_url='foo',
+            swift_user='bar',
+            swift_key='key')
+        with rasterio.env.Env(session=swift_session) as s:
+            s.credentialize()
+            assert getenv()['SWIFT_STORAGE_URL'] == 'foo'
+            assert getenv()['SWIFT_AUTH_TOKEN'] == 'bar'

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -825,7 +825,6 @@ def test_oss_session_credentials(gdalenv):
         assert getenv()['OSS_ENDPOINT'] == 'null-island-1'
 
 
-
 def test_swift_session_credentials(gdalenv):
     """Create an Env with a oss session."""
     swift_session = SwiftSession(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -191,10 +191,8 @@ def test_swift_session_by_user_key():
 
 
 def test_session_factory_swift_kwargs():
-    """Get an SwiftSession for oss:// paths with keywords"""
-    sesh = Session.from_path("swift://lol/wut", swift_storage_url='foo', swift_auth_token='bar')
-    assert isinstance(sesh, SwiftSession)
-    assert sesh.get_credential_options()['SWIFT_STORAGE_URL'] == 'foo'
-    assert sesh.get_credential_options()['SWIFT_AUTH_TOKEN'] == 'bar'
+    """Get an SwiftSession for /vsiswift/bucket/key with keywords"""
+    sesh = Session.from_path("/vsiswift/lol/wut", swift_storage_url='foo', swift_auth_token='bar')
+    assert isinstance(sesh, DummySession)
 
     

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,11 @@
 
 import pytest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 from rasterio.session import DummySession, AWSSession, Session, OSSSession, GSSession, SwiftSession
 
 


### PR DESCRIPTION
Refer to #1543 
This PR based on the latest master branch, and add tests code with mock.

Three methods are possible is use:  
1.  Create session by the swiftclient library.
2.  The SWIFT_STORAGE_URL and SWIFT_AUTH_TOKEN (this method is recommended by GDAL docs).  
3.  The SWIFT_AUTH_V1_URL, SWIFT_USER and SWIFT_KEY (This depends on the [swiftclient library](https://github.com/openstack/python-swiftclient)).  


## examples
``` python
>>> import rasterio
>>> from rasterio.session import SwiftSession
>>>
>>> fp = 'swift://swift/test_cog.tif'
>>>
>>> def test_open_private_swift_file_session():
... #     1. Create session by the swiftclient library.
...     from swiftclient.client import Connection
...     conn = Connection( authurl='http://127.0.0.1:7777/auth/v1.0',user='test:tester',key='testing')
...
...     session = SwiftSession(conn)
...     with rasterio.Env(session):
...         with rasterio.open(fp) as src:
...             print(src.profile)
...
>>> test_open_private_swift_file_session()
{'driver': 'GTiff', 'dtype': 'uint8', 'nodata': None, 'width': 4497, 'height': 2828, 'count': 3, 'crs': CRS.from_epsg(4326), 'transform': Affine(9.457376940182188e-05, 0.0, 99.809579427,
       0.0, -9.459015664780757e-05, 25.34884699), 'blockxsize': 512, 'blockysize': 512, 'tiled': True, 'compress': 'jpeg', 'interleave': 'pixel', 'photometric': 'ycbcr'}
>>>
>>>
>>>
>>> def test_open_private_swift_file_token():
... #     2. The SWIFT_STORAGE_URL and SWIFT_AUTH_TOKEN (this method is recommended by GDAL docs).
...     swift_storage_url = 'http://127.0.0.1:7777/v1/AUTH_test'
...     swift_auth_token = 'AUTH_tkf79d9930a3eb4a6dbe43699f19a6399a'
...     session = SwiftSession(swift_storage_url=swift_storage_url, swift_auth_token=swift_auth_token)
...     with rasterio.Env(session):
...         with rasterio.open(fp) as src:
...             print(src.profile)
...
>>> test_open_private_swift_file_token()
{'driver': 'GTiff', 'dtype': 'uint8', 'nodata': None, 'width': 4497, 'height': 2828, 'count': 3, 'crs': CRS.from_epsg(4326), 'transform': Affine(9.457376940182188e-05, 0.0, 99.809579427,
       0.0, -9.459015664780757e-05, 25.34884699), 'blockxsize': 512, 'blockysize': 512, 'tiled': True, 'compress': 'jpeg', 'interleave': 'pixel', 'photometric': 'ycbcr'}
>>>
>>>
>>> def test_open_private_swift_file_user_key():
... # 3. The SWIFT_AUTH_V1_URL, SWIFT_USER and SWIFT_KEY (This depends on the swiftclient library).
...     swift_auth_v1_url = 'http://127.0.0.1:7777/auth/v1.0'
...     swift_user = 'test:tester'
...     swift_key = 'testing'
...     session = SwiftSession(swift_auth_v1_url=swift_auth_v1_url, swift_user=swift_user, swift_key=swift_key)
...     with rasterio.Env(session):
...         with rasterio.open(fp) as src:
...             print(src.profile)
...
>>> test_open_private_swift_file_user_key()
{'driver': 'GTiff', 'dtype': 'uint8', 'nodata': None, 'width': 4497, 'height': 2828, 'count': 3, 'crs': CRS.from_epsg(4326), 'transform': Affine(9.457376940182188e-05, 0.0, 99.809579427,
       0.0, -9.459015664780757e-05, 25.34884699), 'blockxsize': 512, 'blockysize': 512, 'tiled': True, 'compress': 'jpeg', 'interleave': 'pixel', 'photometric': 'ycbcr'}
>>>
```