### PR TITLE
Allow AWS region name to be specified in all cases

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changes
 Next
 ----
 
+- Allow AWS regions to be specified no matter the signing of requests (#1670).
 - Add links to API documentation from the Python quickstart guide.
 - Use "CRS.from_epsg({})" instead of "CRS.from_dict(init='epsg:{}')" as the
   representation for CRS objects that are completely described by an EPSG code.

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -42,7 +42,7 @@ import rasterio.path
 
 
 __all__ = ['band', 'open', 'pad', 'Env']
-__version__ = "1.0.22"
+__version__ = "1.0.23"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -199,8 +199,6 @@ class AWSSession(Session):
 
         if session:
             self._session = session
-        elif aws_unsigned:
-            self._session = None
         else:
             self._session = boto3.Session(
                 aws_access_key_id=aws_access_key_id,
@@ -258,7 +256,10 @@ class AWSSession(Session):
 
         """
         if self.unsigned:
-            return {'AWS_NO_SIGN_REQUEST': 'YES'}
+            opts = {'AWS_NO_SIGN_REQUEST': 'YES'}
+            if 'aws_region' in self.credentials:
+                opts['AWS_REGION'] = self.credentials['aws_region']
+            return opts
         else:
             return {k.upper(): v for k, v in self.credentials.items()}
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -42,9 +42,9 @@ def test_aws_session_class_session():
 def test_aws_session_class_unsigned():
     """AWSSession works"""
     pytest.importorskip("boto3")
-    sesh = AWSSession(aws_unsigned=True)
-    assert sesh._session is None
+    sesh = AWSSession(aws_unsigned=True, region_name='us-mountain-1')
     assert sesh.get_credential_options()['AWS_NO_SIGN_REQUEST'] == 'YES'
+    assert sesh.get_credential_options()['AWS_REGION'] == 'us-mountain-1'
 
 
 def test_aws_session_class_profile(tmpdir, monkeypatch):


### PR DESCRIPTION
Even if requests are unsigned.

Resolves #1670