### PR TITLE
Get linear units

### DIFF
--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -56,11 +56,9 @@ cdef class _CRS(object):
     @property
     def linear_units(self):
         """Get linear units of the CRS
-
         Returns
         -------
         str
-
         """
         cdef char *units_c = NULL
         cdef double fmeter
@@ -72,6 +70,29 @@ cdef class _CRS(object):
         else:
             units_b = units_c
             return units_b.decode('utf-8')
+
+    @property
+    def linear_units_factor(self):
+        """Get linear units and the conversion factor to meters of the CRS
+
+        Returns
+        -------
+        tuple
+
+        """
+        cdef char *units_c = NULL
+        cdef double to_meters
+
+        try:
+            if self.is_projected:
+                to_meters = OSRGetLinearUnits(self._osr, &units_c)
+            else:
+                raise CRSError("{}".format("Linear units factor is not defined for non projected CRS"))
+        except CPLE_BaseError as exc:
+            raise CRSError("{}".format(exc))
+        else:
+            units_b = units_c
+            return (units_b.decode('utf-8'), to_meters)
 
     def __eq__(self, other):
         cdef OGRSpatialReferenceH osr_s = NULL

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -236,6 +236,22 @@ class CRS(collections.Mapping):
             return False
 
     @property
+    def linear_units_factor(self):
+        """The linear units of the CRS and the conversion factor to meters.
+
+        The first element of the tuple is a string, its possible values
+        include "metre" and "US survey foot".
+        The second element of the tuple is a float that represent the conversion
+        factor of the raster units to meters.
+
+        Returns
+        -------
+        tuple
+
+        """
+        return self._crs.linear_units_factor
+
+    @property
     def linear_units(self):
         """The linear units of the CRS
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -458,6 +458,18 @@ def test_pickle(factory, arg):
 def test_linear_units():
     """CRS linear units can be had"""
     assert CRS.from_epsg(3857).linear_units == 'metre'
+    assert CRS.from_epsg(2261).linear_units == 'US survey foot'
+    assert CRS.from_epsg(4326).linear_units == 'unknown'
+
+
+def test_linear_units_factor():
+    """CRS linear units can be had"""
+    assert CRS.from_epsg(3857).linear_units_factor[0] == 'metre'
+    assert CRS.from_epsg(3857).linear_units_factor[1] == 1.0
+    assert CRS.from_epsg(2261).linear_units_factor[0] == 'US survey foot'
+    assert CRS.from_epsg(2261).linear_units_factor[1] == pytest.approx(0.3048006096012192)
+    with pytest.raises(CRSError):
+        CRS.from_epsg(4326).linear_units_factor
 
 
 def test_crs_copy():


### PR DESCRIPTION
Added a property to the CRS class that return a tuple with the raster unit and the conversion factor to meters, if the CRS is a projected one.