### PR TITLE
Warn on rasterizing invalid / empty geometries instead of failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
   - "if [ \"$GDALVERSION\" == \"master\" -o $(gdal-config --version) == \"$GDALVERSION\" ]; then echo \"Using gdal $GDALVERSION\"; else echo \"NOT using gdal $GDALVERSION as expected; aborting\"; exit 1; fi"
   - "python -m pip wheel -r requirements-dev.txt"
   - "python -m pip install -r requirements-dev.txt"
-  - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install --upgrade --force-reinstall -e .[test,plot]"
+  - "GDAL_CONFIG=$GDALINST/gdal-$GDALVERSION/bin/gdal-config python -m pip install --upgrade --force-reinstall --no-use-pep517 -e .[test,plot]"
   - "python -m pip install coveralls>=1.1"
   - "rio --version"
   - "rio --gdal-version"

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -281,7 +281,7 @@ def rasterize(
         
         else:
             # invalid or empty geometries are skipped and raise a warning instead
-            warnings.warn('SKIPPING: Invalid or empty geometry at index {}'.format(index))
+            warnings.warn('Invalid or empty shape at index {} will not be rasterized.'.format(index))
 
     if not valid_shapes:
         raise ValueError('No valid geometry objects found for rasterize')

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -509,7 +509,7 @@ def test_rasterize_skip_invalid_geom(geojson_polygon, basic_image_2x2):
     """Rasterize operation should succeed for at least one valid geometry
     and should skip any invalid or empty geometries with an error."""
 
-    with pytest.warns(UserWarning, match="SKIPPING: Invalid or empty geometry at index"):
+    with pytest.warns(UserWarning, match="Invalid or empty shape"):
         out = rasterize([geojson_polygon, {'type': 'Polygon', 'coordinates': []}], out_shape=DEFAULT_SHAPE)
 
     assert np.array_equal(out, basic_image_2x2)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -114,7 +114,7 @@ def test_geometry_invalid_geom():
                 out_shape=DEFAULT_SHAPE,
                 transform=Affine.identity())
 
-        assert 'Invalid geometry' in exc_info.value.args[0]
+        assert 'No valid geometry objects found for rasterize' in exc_info.value.args[0]
 
 
 def test_geometry_mask_invalid_shape(basic_geometry):
@@ -500,6 +500,16 @@ def test_rasterize_invalid_geom():
             {'type': 'Invalid', 'coordinates': []}]}], out_shape=DEFAULT_SHAPE)
 
 
+def test_rasterize_skip_invalid_geom(geojson_polygon, basic_image_2x2):
+    """Rasterize operation should succeed for at least one valid geometry
+    and should skip any invalid or empty geometries with an error."""
+
+    with pytest.warns(UserWarning, match="SKIPPING: Invalid or empty geometry at index"):
+        out = rasterize([geojson_polygon, {'type': 'Polygon', 'coordinates': []}], out_shape=DEFAULT_SHAPE)
+
+    assert np.array_equal(out, basic_image_2x2)
+
+
 def test_rasterize_out_image(basic_geometry, basic_image_2x2):
     """Rasterize operation should succeed for an out image."""
     out = np.zeros(DEFAULT_SHAPE)
@@ -540,7 +550,7 @@ def test_rasterize_invalid_shapes():
     with pytest.raises(ValueError) as ex:
         rasterize([{'foo': 'bar'}], out_shape=DEFAULT_SHAPE)
 
-    assert 'Invalid geometry object' in str(ex.value)
+    assert 'No valid geometry objects found for rasterize' in str(ex.value)
 
 
 def test_rasterize_invalid_out_shape(basic_geometry):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -227,6 +227,11 @@ def test_geometry_window_no_overlap(path_rgb_byte_tif, basic_geometry):
             geometry_window(src, [basic_geometry], north_up=False)
 
 
+def test_is_valid_geo_interface(geojson_point):
+    """Properly formed Point object with geo interface is valid"""
+    assert is_valid_geom(MockGeoInterface(geojson_point))
+
+
 def test_is_valid_geom_point(geojson_point):
     """Properly formed GeoJSON Point is valid"""
     assert is_valid_geom(geojson_point)


### PR DESCRIPTION
Resolves #1675 

Instead of raising `ValueError` on first instance of an invalid geometry that a user tries to rasterize, we simply omit them from rasterization and omit warnings instead.  If there are no valid geometries after screening out invalid geometries, then an exception is raised.

This also adds support to the `is_valid_geom` function to work for both GeoJSON and objects with the geo interface.

Note: this also includes an additional flag for the `pip` install used in Travis-CI, to get builds working again.  The same issue is present on other recent builds from master. 