### PR TITLE
Block size guards are not needed for untiled datasets

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,10 @@
 Changes
 =======
 
-Next
-----
+1.0.23 (TBD)
+------------
 
+- Block sizes are no longer guarded when creating untiled datasets (#1689).
 - CRS objects are now hashable and equivalent CRS objects have the same hash
   value (#1684).
 - Allow AWS regions to be specified no matter the signing of requests (#1670).

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1075,6 +1075,10 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         fname = name_b
 
         # Process dataset opening options.
+        # "tiled" affects the meaning of blocksize, so we need it
+        # before iterating.
+        tiled = bool(kwargs.get('tiled', False))
+
         for k, v in kwargs.items():
             # Skip items that are definitely *not* valid driver
             # options.
@@ -1084,9 +1088,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             k, v = k.upper(), str(v).upper()
 
             # Guard against block size that exceed image size.
-            if k == 'BLOCKXSIZE' and int(v) > width:
+            if k == 'BLOCKXSIZE' and tiled and int(v) > width:
                 raise ValueError("blockxsize exceeds raster width.")
-            if k == 'BLOCKYSIZE' and int(v) > height:
+            if k == 'BLOCKYSIZE' and tiled and int(v) > height:
                 raise ValueError("blockysize exceeds raster height.")
 
             key_b = k.encode('utf-8')

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -45,6 +45,7 @@ def test_dataset_compression(path_rgb_byte_tif, tag_value):
 
 def test_untiled_dataset_blocksize(tmp_path):
     """Blocksize is not relevant to untiled datasets (see #1689)"""
+    pytest.importorskip("pathlib")
     tmp_file = tmp_path / "test.tif"
     with rasterio.open(
             tmp_file, "w", driver="GTiff", count=1, height=13, width=13, dtype="uint8", crs="epsg:3857",
@@ -58,6 +59,7 @@ def test_untiled_dataset_blocksize(tmp_path):
 
 def test_tiled_dataset_blocksize_guard(tmp_path):
     """Tiled datasets with dimensions less than blocksize are not permitted"""
+    pytest.importorskip("pathlib")
     tmp_file = tmp_path / "test.tif"
     with pytest.raises(ValueError):
         rasterio.open(


### PR DESCRIPTION
Resolves #1689