### PR TITLE
Perform calculations on blocks determined by a working memory limit option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes
 1.0.23 (TBD)
 ------------
 
+- Break rio-calc output into chunks of user-specified size to constrain the
+  amount of memory used (#1668).
 - Attempts to set attributes of datasets opened in "r" mode now raise a custom
   DatasetAttributeError. This exception derives from both RasterioError and
   NotImplementedError, which maintains backwards compatibility (#1676).

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -134,9 +134,8 @@ def calc(ctx, command, files, output, name, dtype, masked, overwrite, mem_limit,
             # The actual work windows will be added in the second
             # iteration of the loop.
             work_windows = [(None, Window(0, 0, 16, 16))]
-            work_windows_itr = iter(work_windows)
 
-            for ij, window in work_windows_itr:
+            for ij, window in work_windows:
 
                 ctxkwds = OrderedDict()
 

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -87,7 +87,7 @@ def _chunk_output(width, height, count, itemsize, mem_limit=1):
 @options.dtype_opt
 @options.masked_opt
 @options.overwrite_opt
-@click.option("--mem-limit", type=int, default=64, help="Limit on size of scratch space, in MB.")
+@click.option("--mem-limit", type=int, default=64, help="Limit on memory used to perform calculations, in MB.")
 @options.creation_options
 @click.pass_context
 def calc(ctx, command, files, output, name, dtype, masked, overwrite, mem_limit, creation_options):
@@ -103,13 +103,13 @@ def calc(ctx, command, files, output, name, dtype, masked, overwrite, mem_limit,
 
     \b
         * (read i) evaluates to the i-th input dataset (a 3-D array).
-        * (read i j) evaluates to the j-th band of the i-th dataset (a 2-D
-          array).
-        * (take foo j) evaluates to the j-th band of a dataset named foo (see
-          help on the --name option above).
+        * (read i j) evaluates to the j-th band of the i-th dataset (a
+          2-D array).
+        * (take foo j) evaluates to the j-th band of a dataset named foo
+          (see help on the --name option above).
         * Standard numpy array operators (+, -, *, /) are available.
-        * When the final result is a list of arrays, a multi band output
-          file is written.
+        * When the final result is a list of arrays, a multiple band
+          output file is written.
         * When the final result is a single array, a single band output
           file is written.
 
@@ -119,15 +119,18 @@ def calc(ctx, command, files, output, name, dtype, masked, overwrite, mem_limit,
          $ rio calc "(+ 2 (* 0.95 (read 1)))" tests/data/RGB.byte.tif \\
          > /tmp/out.tif
 
-    Produces a 3-band GeoTIFF with all values scaled by 0.95 and
-    incremented by 2.
+    The command above produces a 3-band GeoTIFF with all values scaled
+    by 0.95 and incremented by 2.
 
     \b
         $ rio calc "(asarray (+ 125 (read 1)) (read 1) (read 1))" \\
         > tests/data/shade.tif /tmp/out.tif
 
-    Produces a 3-band RGB GeoTIFF, with red levels incremented by 125,
-    from the single-band input.
+    The command above produces a 3-band RGB GeoTIFF, with red levels
+    incremented by 125, from the single-band input.
+
+    The maximum amount of memory used to perform caculations defaults to
+    64 MB. This number can be increased to improve speed of calculation.
 
     """
     import numpy as np

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -1,5 +1,7 @@
 """$ rio calc"""
 
+from __future__ import division
+
 from collections import OrderedDict
 from distutils.version import LooseVersion
 import math

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -2,7 +2,7 @@ from click.testing import CliRunner
 import pytest
 
 import rasterio
-from rasterio.rio.calc import _get_work_windows
+from rasterio.rio.calc import _chunk_output
 from rasterio.rio.main import main_group
 
 
@@ -187,8 +187,8 @@ def test_positional_calculation_byindex(tmpdir):
 @pytest.mark.parametrize('count', [1, 3, 4])
 @pytest.mark.parametrize('itemsize', [1, 2, 8])
 @pytest.mark.parametrize('mem_limit', [1, 16, 64, 512])
-def test_get_work_windows(width, height, count, itemsize, mem_limit):
-    work_windows = _get_work_windows(width, height, count, itemsize, mem_limit=mem_limit)
+def test_chunk_output(width, height, count, itemsize, mem_limit):
+    work_windows = _chunk_output(width, height, count, itemsize, mem_limit=mem_limit)
     num_windows_rows = max([i for ((i, j), w) in work_windows]) + 1
     num_windows_cols = max([j for ((i, j), w) in work_windows]) + 1
     assert sum((w.width for ij, w in work_windows)) == width * num_windows_rows

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -189,7 +189,7 @@ def test_positional_calculation_byindex(tmpdir):
 @pytest.mark.parametrize('mem_limit', [1, 16, 64, 512])
 def test_get_work_windows(width, height, count, itemsize, mem_limit):
     work_windows = _get_work_windows(width, height, count, itemsize, mem_limit=mem_limit)
-    num_windows_rows = max(i for ((i, j), w) in work_windows) + 1
-    num_windows_cols = max(j for ((i, j), w) in work_windows) + 1
+    num_windows_rows = max([i for ((i, j), w) in work_windows]) + 1
+    num_windows_cols = max([j for ((i, j), w) in work_windows]) + 1
     assert sum((w.width for ij, w in work_windows)) == width * num_windows_rows
     assert sum((w.height for ij, w in work_windows)) == height * num_windows_cols


### PR DESCRIPTION
Resolves #1668

The gist: we have a new `--mem-limit` option which defaults to `64` (megabytes). For very large calculations, we divide the work into square-ish regions such that the calculation results of these regions are no larger than the memory limit. For example, to run `rio calc "(asarray (read 1 1), (* (read 1 2) 1.1), (read 1 3))"` (boosts the green band of an RGB image by 10%) on a 7000 x 7000 pixel 3-band uint8 dataset *without* chunking would require `--mem-limit=148`. With the default 64 MB memory limit, the work would be done in 4 chunks. 