### PR TITLE
Allow for variable-width padding on masks

### DIFF
--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -66,8 +66,8 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
     if crop and invert:
         raise ValueError("crop and invert cannot both be True.")
 
-    pad_x = pad_width
-    pad_y = pad_width
+    pad_x = pad
+    pad_y = pad
 
     north_up = dataset.transform.e <= 0
     rotated = dataset.transform.b != 0 or dataset.transform.d != 0

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -45,6 +45,9 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
     pad : bool (opt)
         If True, the features will be padded in each direction by
         one half of a pixel prior to cropping dataset. Defaults to False.
+    pad_width : float (opt)
+        If pad is set (to maintain back-compatibility), this will be the
+        pixel-size width of the padding around the mask.
 
     Returns
     -------
@@ -67,7 +70,7 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
         raise ValueError("crop and invert cannot both be True.")
 
     if crop and pad:
-        pad_x = pad_width
+        pad_x = pad_width # pad by 1/2 of pixel size
         pad_y = pad_width
     else:
         pad_x = 0

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -46,7 +46,7 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
         If True, the features will be padded in each direction by
         one half of a pixel prior to cropping dataset. Defaults to False.
     pad_width : float (opt)
-        If pad is set (to maintain back-compatibility), this will be the
+        If pad is set (to maintain back-compatibility), then this will be the
         pixel-size width of the padding around the mask.
 
     Returns
@@ -70,7 +70,7 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
         raise ValueError("crop and invert cannot both be True.")
 
     if crop and pad:
-        pad_x = pad_width # pad by 1/2 of pixel size
+        pad_x = pad_width
         pad_y = pad_width
     else:
         pad_x = 0

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -112,7 +112,7 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
 
 
 def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
-         filled=True, crop=False, pad=False, indexes=None):
+         filled=True, crop=False, pad=False, pad_width=0.5, indexes=None):
     """Creates a masked or filled array using input shapes.
     Pixels are masked or set to nodata outside the input shapes, unless
     `invert` is `True`.
@@ -181,7 +181,7 @@ def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
 
     shape_mask, transform, window = raster_geometry_mask(
         dataset, shapes, all_touched=all_touched, invert=invert, crop=crop,
-        pad=pad)
+        pad=pad, pad_width=pad_width)
 
     if indexes is None:
         out_shape = (dataset.count, ) + shape_mask.shape

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
-                         crop=False, pad=0):
+                         crop=False, pad=False, pad_width=0.5):
     """Create a mask from shapes, transform, and optional window within original
     raster.
 
@@ -66,8 +66,12 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
     if crop and invert:
         raise ValueError("crop and invert cannot both be True.")
 
-    pad_x = pad
-    pad_y = pad
+    if crop and pad:
+        pad_x = pad_width
+        pad_y = pad_width
+    else:
+        pad_x = 0
+        pad_y = 0
 
     north_up = dataset.transform.e <= 0
     rotated = dataset.transform.b != 0 or dataset.transform.d != 0

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
-                         crop=False, pad=False):
+                         crop=False, pad=0):
     """Create a mask from shapes, transform, and optional window within original
     raster.
 
@@ -66,15 +66,11 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
     if crop and invert:
         raise ValueError("crop and invert cannot both be True.")
 
-    if crop and pad:
-        pad_x = 0.5  # pad by 1/2 of pixel size
-        pad_y = 0.5
-    else:
-        pad_x = 0
-        pad_y = 0
+    pad_x = pad_width
+    pad_y = pad_width
 
     north_up = dataset.transform.e <= 0
-    rotated = dataset.transform.b != 0 or dataset.transform.d != 0 
+    rotated = dataset.transform.b != 0 or dataset.transform.d != 0
 
     try:
         window = geometry_window(dataset, shapes, north_up=north_up, rotated=rotated,
@@ -196,4 +192,3 @@ def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
         out_image = out_image.filled(nodata)
 
     return out_image, transform
-

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -120,7 +120,7 @@ def test_raster_geometrymask_crop_pad(basic_image_2x2, basic_image_file,
 
     with rasterio.open(basic_image_file) as src:
         geometrymask, transform, window = raster_geometry_mask(src, geometries,
-                                                            crop=True, pad=True)
+                                                            crop=True, pad=0.5)
 
     image = basic_image_2x2[1:5, 1:5] == 0  # invert because invert=False
 
@@ -244,7 +244,7 @@ def test_mask_pad(basic_image_2x2, basic_image_file, basic_geometry):
 
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file) as src:
-        masked, transform = mask(src, geometries, crop=True, pad=True)
+        masked, transform = mask(src, geometries, crop=True, pad=0.5)
 
     assert masked.shape == (1, 4, 4)
     assert np.array_equal(masked[0], basic_image_2x2[1:5, 1:5])
@@ -264,4 +264,3 @@ def test_mask_filled(basic_image, basic_image_2x2, basic_image_file,
     assert (type(masked) == np.ma.MaskedArray)
     assert np.array_equal(masked[0].mask, image.mask)
     assert np.array_equal(masked[0], image)
-

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -250,8 +250,8 @@ def test_mask_pad(basic_image_2x2, basic_image_file, basic_geometry):
     assert np.array_equal(masked[0], basic_image_2x2[1:5, 1:5])
 
 
-def test_mask_extra_padding(basic_image_2x2, basic_image_file, basic_geometry):
-    """Output should be cropped to extent of data"""
+def test_mask_with_extra_padding(basic_image_2x2, basic_image_file, basic_geometry):
+    """Output should have 2 extra pixels compared to the standard padded mask"""
 
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file) as src:
@@ -260,12 +260,23 @@ def test_mask_extra_padding(basic_image_2x2, basic_image_file, basic_geometry):
     assert masked.shape == (1, 7, 7)
     assert np.array_equal(masked[0], basic_image_2x2[0:7, 0:7])
 
+def test_mask_with_even_more_padding(basic_image_2x2, basic_image_file, basic_geometry):
+    """Output should contain 4 extra pixels on each side"""
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file) as src:
         masked, transform = mask(src, geometries, crop=True, pad=True, pad_width=4)
 
     assert masked.shape == (1, 9, 9)
     assert np.array_equal(masked[0], basic_image_2x2[0:9, 0:9])
+
+def test_mask_with_maximum_padding(basic_image_2x2, basic_image_file, basic_geometry):
+    """Output should not break if too much padding is requested"""
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, crop=True, pad=True, pad_width=10)
+
+    assert masked.shape == (1, 10, 10)
+    assert np.array_equal(masked[0], basic_image_2x2[0:10, 0:10])
 
 
 def test_mask_filled(basic_image, basic_image_2x2, basic_image_file,

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -244,10 +244,28 @@ def test_mask_pad(basic_image_2x2, basic_image_file, basic_geometry):
 
     geometries = [basic_geometry]
     with rasterio.open(basic_image_file) as src:
-        masked, transform = mask(src, geometries, crop=True, pad=0.5)
+        masked, transform = mask(src, geometries, crop=True, pad=True)
 
     assert masked.shape == (1, 4, 4)
     assert np.array_equal(masked[0], basic_image_2x2[1:5, 1:5])
+
+
+def test_mask_extra_padding(basic_image_2x2, basic_image_file, basic_geometry):
+    """Output should be cropped to extent of data"""
+
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, crop=True, pad=True, pad_width=2)
+
+    assert masked.shape == (1, 7, 7)
+    assert np.array_equal(masked[0], basic_image_2x2[0:7, 0:7])
+
+    geometries = [basic_geometry]
+    with rasterio.open(basic_image_file) as src:
+        masked, transform = mask(src, geometries, crop=True, pad=True, pad_width=4)
+
+    assert masked.shape == (1, 9, 9)
+    assert np.array_equal(masked[0], basic_image_2x2[0:9, 0:9])
 
 
 def test_mask_filled(basic_image, basic_image_2x2, basic_image_file,


### PR DESCRIPTION
This allows users to pad a mask by a variable width instead of force-defaulting to the fixed 0.5 width