### PR TITLE
Maintain traditional axis order strategy everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ env:
 
 matrix:
   allow_failures:
-    - env: GDALVERSION="3.0.1" PROJVERSION="6.1.1"
     - env: GDALVERSION="master" PROJVERSION="6.1.1"
 
 addons:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,13 @@ Changes
 1.0.25 (TBD)
 ------------
 
-- Add support for GDAL 3.x
+- Add support for using GDAL 3.x and PROJ 6 libraries (#1700, #1729). Please
+  note that new features of GDAL 3 and PROJ 6 are not intended to surface.
+  Geometries and coordinates returned from rasterio keep to the traditional GIS
+  axis order used by GDAL versions < 3. To do this, rasterio applies a new
+  private extension function named osr_set_traditional_axis_mapping_strategy to
+  every OGRSpatialReferenceH object that will be returned from methods in the
+  _CRS module.
 - We were using pytest incorrectly and pytest 5 caught us doing it. This is
   now fixed in commit b9f34ee.
 - A bug preventing creation of Env instances, and thus dataset opening, when

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -15,7 +15,7 @@ from rasterio._err import (
     GDALError, CPLE_BaseError, CPLE_IllegalArgError, CPLE_OpenFailedError,
     CPLE_NotSupportedError)
 from rasterio._err cimport exc_wrap_pointer, exc_wrap_int
-from rasterio._shim cimport open_dataset, osr_get_name
+from rasterio._shim cimport open_dataset, osr_get_name, osr_set_traditional_axis_mapping_strategy
 
 from rasterio.compat import string_types
 from rasterio.control import GroundControlPoint
@@ -1317,12 +1317,14 @@ cdef OGRSpatialReferenceH _osr_from_crs(object crs) except NULL:
         if retval:
             _safe_osr_release(osr)
             raise CRSError("Invalid CRS: {!r}".format(crs))
-        exc_wrap_int(OSRMorphFromESRI(osr))
     except CPLE_BaseError as exc:
         _safe_osr_release(osr)
         raise CRSError(str(exc))
-
-    return osr
+    else:
+        if not gdal_version().startswith("3"):
+            exc_wrap_int(OSRMorphFromESRI(osr))
+        osr_set_traditional_axis_mapping_strategy(osr)
+        return osr
 
 
 cdef _safe_osr_release(OGRSpatialReferenceH srs):

--- a/rasterio/_shim.pxd
+++ b/rasterio/_shim.pxd
@@ -6,4 +6,4 @@ cdef int io_band(GDALRasterBandH band, int mode, float xoff, float yoff, float w
 cdef int io_multi_band(GDALDatasetH hds, int mode, float xoff, float yoff, float width, float height, object data, Py_ssize_t[:] indexes, int resampling=*) except -1
 cdef int io_multi_mask(GDALDatasetH hds, int mode, float xoff, float yoff, float width, float height, object data, Py_ssize_t[:] indexes, int resampling=*) except -1
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs)
-
+cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs)

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -193,3 +193,6 @@ cdef int io_multi_mask(
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs):
     return ''
 
+
+cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
+    pass

--- a/rasterio/_shim20.pyx
+++ b/rasterio/_shim20.pyx
@@ -72,3 +72,7 @@ cdef int delete_nodata_value(GDALRasterBandH hBand) except 3:
 
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs):
     return ''
+
+
+cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
+    pass

--- a/rasterio/_shim21.pyx
+++ b/rasterio/_shim21.pyx
@@ -73,3 +73,6 @@ cdef int delete_nodata_value(GDALRasterBandH hBand) except 3:
 
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs):
     return ''
+
+cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
+    pass

--- a/rasterio/_shim30.pyx
+++ b/rasterio/_shim30.pyx
@@ -19,7 +19,12 @@ cdef extern from "gdal.h" nogil:
 
 
 cdef extern from "ogr_srs_api.h" nogil:
+
+    ctypedef enum OSRAxisMappingStrategy:
+        OAMS_TRADITIONAL_GIS_ORDER
+
     const char* OSRGetName(OGRSpatialReferenceH hSRS)
+    void OSRSetAxisMappingStrategy(OGRSpatialReferenceH hSRS, OSRAxisMappingStrategy)
 
 
 from rasterio._err cimport exc_wrap_pointer
@@ -78,3 +83,7 @@ cdef int delete_nodata_value(GDALRasterBandH hBand) except 3:
 
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs):
     return OSRGetName(hSrs)
+
+
+cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
+    OSRSetAxisMappingStrategy(hSrs, OAMS_TRADITIONAL_GIS_ORDER)

--- a/rasterio/rio/clip.py
+++ b/rasterio/rio/clip.py
@@ -9,6 +9,7 @@ from .helpers import resolve_inout
 from . import options
 import rasterio
 from rasterio.coords import disjoint_bounds
+from rasterio.crs import CRS
 from rasterio.windows import Window
 
 
@@ -83,7 +84,7 @@ def clip(ctx, files, output, bounds, like, driver, projection,
         with rasterio.open(input) as src:
             if bounds:
                 if projection == 'geographic':
-                    bounds = transform_bounds('epsg:4326', src.crs, *bounds)
+                    bounds = transform_bounds(CRS.from_epsg(4326), src.crs, *bounds)
                 if disjoint_bounds(bounds, src.bounds):
                     raise click.BadParameter('must overlap the extent of '
                                              'the input raster',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -604,3 +604,7 @@ requires_gdal22 = pytest.mark.skipif(
 requires_gdal_lt_3 = pytest.mark.skipif(
     gdal_version.__lt__('3.0'),
     reason="Requires GDAL 1.x/2.x")
+
+requires_gdal3 = pytest.mark.skipif(
+    not gdal_version.at_least('3.0'),
+    reason="Requires GDAL 3.0.x")

--- a/tests/test__crs.py
+++ b/tests/test__crs.py
@@ -119,6 +119,7 @@ def test_from_esri_wkt_no_fix(projection_string):
         assert 'DATUM["D_North_American_1983"' in crs.to_wkt()
 
 
+@requires_gdal_lt_3
 @pytest.mark.parametrize('projection_string', [ESRI_PROJECTION_STRING])
 def test_from_esri_wkt_fix_datum(projection_string):
     """Test ESRI CRS morphing with datum fixing"""
@@ -127,6 +128,7 @@ def test_from_esri_wkt_fix_datum(projection_string):
         assert 'DATUM["North_American_Datum_1983"' in crs.to_wkt()
 
 
+@requires_gdal_lt_3
 def test_to_esri_wkt_fix_datum():
     """Morph to Esri form"""
     assert 'DATUM["D_North_American_1983"' in _CRS.from_dict(init='epsg:26913').to_wkt(morph_to_esri_dialect=True)

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -336,6 +336,7 @@ def test_from_esri_wkt_no_fix(projection_string):
         assert 'DATUM["D_North_American_1983"' in crs.wkt
 
 
+@requires_gdal_lt_3
 @pytest.mark.parametrize('projection_string', [ESRI_PROJECTION_STRING])
 def test_from_esri_wkt_fix_datum(projection_string):
     """Test ESRI CRS morphing with datum fixing"""
@@ -344,6 +345,7 @@ def test_from_esri_wkt_fix_datum(projection_string):
         assert 'DATUM["North_American_Datum_1983"' in crs.wkt
 
 
+@requires_gdal_lt_3
 def test_to_esri_wkt_fix_datum():
     """Morph to Esri form"""
     assert 'DATUM["D_North_American_1983"' in CRS(init='epsg:26913').to_wkt(morph_to_esri_dialect=True)
@@ -464,3 +466,8 @@ def test_crs_hash():
 def test_crs_hash_unequal():
     """hashes of non-equivalent CRS are not equal"""
     assert hash(CRS.from_epsg(3857)) != hash(CRS.from_epsg(4326))
+
+
+def test_crs84():
+    """Create CRS from OGC code"""
+    assert "WGS 84" in CRS.from_user_input("urn:ogc:def:crs:OGC::CRS84").wkt

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -15,8 +15,7 @@ from rasterio.warp import SUPPORTED_RESAMPLING, GDAL2_RESAMPLING
 from rasterio.rio import warp
 from rasterio.rio.main import main_group
 
-
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+from .conftest import requires_gdal_lt_3
 
 
 def test_dst_crs_error(runner, tmpdir):
@@ -542,6 +541,7 @@ def test_warp_reproject_check_invert_true(runner, tmpdir):
         assert output.shape == output2.shape
 
 
+@requires_gdal_lt_3
 def test_warp_reproject_check_invert_false(runner, tmpdir):
     outputname = str(tmpdir.join('test.tif'))
     output2name = str(tmpdir.join('test2.tif'))

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -25,7 +25,7 @@ from rasterio.warp import (
 )
 from rasterio import windows
 
-from .conftest import requires_gdal22
+from .conftest import requires_gdal22, requires_gdal3, requires_gdal_lt_3
 
 
 gdal_version = GDALVersion.runtime()
@@ -46,7 +46,7 @@ def flatten_coords(coordinates):
 
 
 reproj_expected = (
-    ({"CHECK_WITH_INVERT_PROJ": False}, 7608), ({"CHECK_WITH_INVERT_PROJ": True}, 2216)
+    ({"CHECK_WITH_INVERT_PROJ": False}, 6644), ({"CHECK_WITH_INVERT_PROJ": True}, 6644)
 )
 
 
@@ -77,8 +77,8 @@ def default_reproject_params():
         top=70,
         width=80,
         height=80,
-        src_crs={"init": "epsg:4326"},
-        dst_crs={"init": "epsg:2163"},
+        src_crs=CRS.from_epsg(4326),
+        dst_crs=CRS.from_epsg(2163),
     )
 
 
@@ -90,12 +90,12 @@ def uninvertable_reproject_params():
         top=70,
         width=80,
         height=80,
-        src_crs={"init": "epsg:4326"},
-        dst_crs={"init": "epsg:26836"},
+        src_crs=CRS.from_epsg(4326),
+        dst_crs=CRS.from_epsg(26836),
     )
 
 
-WGS84_crs = {"init": "epsg:4326"}
+WGS84_crs = CRS.from_epsg(4326)
 
 
 def test_transform_src_crs_none():
@@ -152,14 +152,14 @@ def test_reproject_dst_crs_none():
 
 def test_transform():
     """2D and 3D."""
-    WGS84_crs = {"init": "epsg:4326"}
+    WGS84_crs = CRS.from_epsg(4326)
     WGS84_points = ([12.492269], [41.890169], [48.])
-    ECEF_crs = {"init": "epsg:4978"}
+    ECEF_crs = CRS.from_epsg(4978)
     ECEF_points = ([4642610.], [1028584.], [4236562.])
     ECEF_result = transform(WGS84_crs, ECEF_crs, *WGS84_points)
     assert np.allclose(np.array(ECEF_result), np.array(ECEF_points))
 
-    UTM33_crs = {"init": "epsg:32633"}
+    UTM33_crs = CRS.from_epsg(32633)
     UTM33_points = ([291952], [4640623])
     UTM33_result = transform(WGS84_crs, UTM33_crs, *WGS84_points[:2])
     assert np.allclose(np.array(UTM33_result), np.array(UTM33_points))
@@ -169,7 +169,7 @@ def test_transform_bounds():
     with rasterio.open("tests/data/RGB.byte.tif") as src:
         l, b, r, t = src.bounds
         assert np.allclose(
-            transform_bounds(src.crs, {"init": "epsg:4326"}, l, b, r, t),
+            transform_bounds(src.crs, CRS.from_epsg(4326), l, b, r, t),
             (
                 -78.95864996545055,
                 23.564991210854686,
@@ -202,7 +202,7 @@ def test_transform_bounds__esri_wkt():
         'PARAMETER["Vertical_Shift",0.0],'
         'PARAMETER["Direction",1.0],UNIT["Centimeter",0.01]]]')
     assert np.allclose(
-        transform_bounds({"init": "epsg:4326"},
+        transform_bounds(CRS.from_epsg(4326),
                          dst_projection_string,
                          left,
                          bottom,
@@ -219,8 +219,8 @@ def test_transform_bounds__esri_wkt():
 def test_transform_bounds_densify():
     # This transform is non-linear along the edges, so densification produces
     # a different result than otherwise
-    src_crs = {"init": "epsg:4326"}
-    dst_crs = {"init": "epsg:2163"}
+    src_crs = CRS.from_epsg(4326)
+    dst_crs = CRS.from_epsg(2163)
     assert np.allclose(
         transform_bounds(src_crs, dst_crs, -120, 40, -80, 64, densify_pts=0),
         (-1684649.41338, -350356.81377, 1684649.41338, 2234551.18559),
@@ -242,8 +242,8 @@ def test_transform_bounds_no_change():
 def test_transform_bounds_densify_out_of_bounds():
     with pytest.raises(ValueError):
         transform_bounds(
-            {"init": "epsg:4326"},
-            {"init": "epsg:32610"},
+            CRS.from_epsg(4326),
+            CRS.from_epsg(32610),
             -120,
             40,
             -80,
@@ -263,7 +263,7 @@ def test_calculate_default_transform():
     )
 
     with rasterio.open("tests/data/RGB.byte.tif") as src:
-        wgs84_crs = {"init": "epsg:4326"}
+        wgs84_crs = CRS.from_epsg(4326)
         dst_transform, width, height = calculate_default_transform(
             src.crs, wgs84_crs, src.width, src.height, *src.bounds
         )
@@ -286,7 +286,7 @@ def test_calculate_default_transform_single_resolution():
         )
         dst_transform, width, height = calculate_default_transform(
             src.crs,
-            {"init": "epsg:4326"},
+            CRS.from_epsg(4326),
             src.width,
             src.height,
             *src.bounds,
@@ -312,7 +312,7 @@ def test_calculate_default_transform_multiple_resolutions():
 
         dst_transform, width, height = calculate_default_transform(
             src.crs,
-            {"init": "epsg:4326"},
+            CRS.from_epsg(4326),
             src.width,
             src.height,
             *src.bounds,
@@ -338,7 +338,7 @@ def test_calculate_default_transform_dimensions():
 
         dst_transform, width, height = calculate_default_transform(
             src.crs,
-            {"init": "epsg:4326"},
+            CRS.from_epsg(4326),
             src.width,
             src.height,
             *src.bounds,
@@ -465,8 +465,11 @@ def test_reproject_out_of_bounds():
     assert not out.any()
 
 
+@requires_gdal3
 @pytest.mark.parametrize("options, expected", reproj_expected)
 def test_reproject_nodata(options, expected):
+    # Older combinations of GDAL and PROJ might have got this transformation wrong.
+    # Results look better with GDAL 3 and PROJ 6 but the expected values are off.
     nodata = 215
 
     with rasterio.Env(**options):
@@ -492,6 +495,7 @@ def test_reproject_nodata(options, expected):
         )
 
 
+@requires_gdal3
 @pytest.mark.parametrize("options, expected", reproj_expected)
 def test_reproject_nodata_nan(options, expected):
 
@@ -516,6 +520,7 @@ def test_reproject_nodata_nan(options, expected):
         assert np.isnan(out).sum() == (params.dst_width * params.dst_height - expected)
 
 
+@requires_gdal3
 @pytest.mark.parametrize("options, expected", reproj_expected)
 def test_reproject_dst_nodata_default(options, expected):
     """If nodata is not provided, destination will be filled with 0."""
@@ -1450,9 +1455,10 @@ def test_issue_1446():
     assert round(g["coordinates"][1], 1) == 4212702.1
 
 
+@requires_gdal_lt_3
 def test_issue_1446_b():
     """Confirm that lines aren't thrown as reported in #1446"""
-    src_crs = CRS({"init": "epsg:4326"})
+    src_crs = CRS.from_epsg(4326)
     dst_crs = CRS(
         {
             "proj": "sinu",
@@ -1480,7 +1486,7 @@ def test_issue_1076():
     fill_value = 42
     newarr = np.full((200, 300), fill_value=fill_value, dtype='int32')
 
-    src_crs = {'init': 'epsg:32632'}
+    src_crs = CRS.from_epsg(32632)
     src_transform = Affine(600.0, 0.0, 399960.0, 0.0, -600.0, 6100020.0)
     dst_transform = Affine(60.0, 0.0, 399960.0, 0.0, -60.0, 6100020.0)
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -469,7 +469,7 @@ def test_reproject_out_of_bounds():
 @pytest.mark.parametrize("options, expected", reproj_expected)
 def test_reproject_nodata(options, expected):
     # Older combinations of GDAL and PROJ might have got this transformation wrong.
-    # Results look better with GDAL 3 and PROJ 6 but the expected values are off.
+    # Results look better with GDAL 3.
     nodata = 215
 
     with rasterio.Env(**options):

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -189,7 +189,6 @@ def test_write_crs_transform(tmpdir):
         s.write(a, indexes=1)
     assert s.crs.to_epsg() == 32618
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
-    assert 'PROJCS["UTM Zone 18, Northern Hemisphere",' in info
     # make sure that pixel size is nearly the same as transform
     # (precision varies slightly by platform)
     assert re.search(r'Pixel Size = \(300.03792\d+,-300.04178\d+\)', info)
@@ -212,7 +211,6 @@ def test_write_crs_transform_affine(tmpdir):
 
     assert s.crs.to_epsg() == 32618
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
-    assert 'PROJCS["UTM Zone 18, Northern Hemisphere",' in info
     # make sure that pixel size is nearly the same as transform
     # (precision varies slightly by platform)
     assert re.search(r'Pixel Size = \(300.03792\d+,-300.04178\d+\)', info)
@@ -259,7 +257,7 @@ def test_write_crs_transform_3(tmpdir):
         s.write(a, indexes=1)
     assert s.crs.to_epsg() == 32618
     info = subprocess.check_output(["gdalinfo", name]).decode('utf-8')
-    assert 'PROJCS["UTM Zone 18, Northern Hemisphere",' in info
+    assert '"UTM Zone 18, Northern Hemisphere",' in info
     # make sure that pixel size is nearly the same as transform
     # (precision varies slightly by platform)
     assert re.search(r'Pixel Size = \(300.03792\d+,-300.04178\d+\)', info)


### PR DESCRIPTION
Had to root through the warping tests quite a bit this afternoon. I think the tests using the old projection for Maine were expecting wrong results from GDAL 2. Here's what the GDAL 2.4 output looked like using PROJ 4.9.3:

![Figure_2](https://user-images.githubusercontent.com/33697/61986793-e0229f80-afce-11e9-8370-b676f8259e98.png)

Here's the output using GDAL 3.0.1 and PROJ 6.1.1

![Figure_1](https://user-images.githubusercontent.com/33697/61986806-fdf00480-afce-11e9-9d23-fd9d40edb2fa.png)

This second one looks much more like a long/lat box projected to transverse mercator, no?

While focusing on the compatibility issues, I'd lost sight of the improvements offered by the new PROJ. Glad to see this :+1: 