### PR TITLE
Add collections.Iterable to compat

### DIFF
--- a/rasterio/compat.py
+++ b/rasterio/compat.py
@@ -12,7 +12,7 @@ if sys.version_info[0] >= 3:   # pragma: no cover
     import configparser
     from urllib.parse import urlparse
     from collections import UserDict
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
     from inspect import getfullargspec as getargspec
 else:  # pragma: no cover
     string_types = basestring,
@@ -23,4 +23,4 @@ else:  # pragma: no cover
     from urlparse import urlparse
     from UserDict import UserDict
     from inspect import getargspec
-    from collections import Mapping
+    from collections import Iterable, Mapping

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -10,7 +10,6 @@ used.
 
 """
 
-import collections
 import json
 import pickle
 

--- a/rasterio/rio/stack.py
+++ b/rasterio/rio/stack.py
@@ -1,14 +1,13 @@
 """$ rio stack"""
 
 
-import collections
 import logging
 
 import click
 from cligj import format_opt
 
 import rasterio
-from rasterio.compat import zip_longest
+from rasterio.compat import Iterable, zip_longest
 from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
 
@@ -104,7 +103,7 @@ def stack(ctx, files, output, driver, bidx, photometric, overwrite,
                             data = src.read(index)
                             dst.write(data, dst_idx)
                             dst_idx += 1
-                        elif isinstance(index, collections.Iterable):
+                        elif isinstance(index, Iterable):
                             data = src.read(index)
                             dst.write(data, range(dst_idx, dst_idx + len(index)))
                             dst_idx += len(index)

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -2,10 +2,11 @@
 
 from __future__ import division
 
-import collections
 import math
 
 from affine import Affine
+
+from rasterio.compat import Iterable
 
 
 IDENTITY = Affine.identity()
@@ -153,10 +154,10 @@ def xy(transform, rows, cols, offset='center'):
 
     single_col = False
     single_row = False
-    if not isinstance(cols, collections.Iterable):
+    if not isinstance(cols, Iterable):
         cols = [cols]
         single_col = True
-    if not isinstance(rows, collections.Iterable):
+    if not isinstance(rows, Iterable):
         rows = [rows]
         single_row = True
 
@@ -221,10 +222,10 @@ def rowcol(transform, xs, ys, op=math.floor, precision=None):
 
     single_x = False
     single_y = False
-    if not isinstance(xs, collections.Iterable):
+    if not isinstance(xs, Iterable):
         xs = [xs]
         single_x = True
-    if not isinstance(ys, collections.Iterable):
+    if not isinstance(ys, Iterable):
         ys = [ys]
         single_y = True
 

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -27,6 +27,7 @@ import attr
 from affine import Affine
 import numpy as np
 
+from rasterio.compat import Iterable
 from rasterio.errors import WindowError
 from rasterio.transform import rowcol, guard_transform
 
@@ -114,7 +115,7 @@ def iter_args(function):
     """
     @functools.wraps(function)
     def wrapper(*args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], collections.Iterable):
+        if len(args) == 1 and isinstance(args[0], Iterable):
             return function(*args[0])
         else:
             return function(*args)


### PR DESCRIPTION
This PR finishes eliminating the remaining python deprecation warnings that were thrown by the `collections` module (see https://github.com/mapbox/rasterio/issues/1742)

https://github.com/mapbox/rasterio/pull/1753 had addressed the `Mapping` class, but the `Iterable` class has the same behavior, so this PR addresses it.