### PR TITLE
Docs

### DIFF
--- a/docs/api/rasterio.path.rst
+++ b/docs/api/rasterio.path.rst
@@ -1,5 +1,5 @@
 rasterio.path module
-===================
+====================
 
 .. automodule:: rasterio.path
     :members:

--- a/docs/api/rasterio.rst
+++ b/docs/api/rasterio.rst
@@ -43,7 +43,6 @@ Submodules
    rasterio.shutil
    rasterio.tools
    rasterio.transform
-   rasterio.vfs
    rasterio.vrt
    rasterio.warp
    rasterio.windows

--- a/docs/api/rasterio.vfs.rst
+++ b/docs/api/rasterio.vfs.rst
@@ -1,7 +1,0 @@
-rasterio.vfs module
-===================
-
-.. automodule:: rasterio.vfs
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -243,7 +243,7 @@ Web Mercator (EPSG:3857),
 
     $ rio edit-info --crs EPSG:3857 example.tif
 
-set its `affine transformation matrix <https://github.com/mapbox/rasterio/blob/master/docs/georeferencing.rst#coordinate-transformation>`__,
+set its :ref:`affine transformation matrix <coordinate-transformation>`,
 
 .. code-block:: console
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -269,7 +269,7 @@ which can also be expressed as:
 
     $ rio edit-info --colorinterp RGBA example.tif
 
-See ``rasterio.enums.ColorInterp`` for a full list of supported color
+See :class:`rasterio.enums.ColorInterp` for a full list of supported color
 interpretations and the color docs for more information.
 
 
@@ -619,6 +619,8 @@ a raster dataset, do the following.
     $ echo "[-78.0, 23.0, -76.0, 25.0]" | rio transform - --dst-crs tests/data/RGB.byte.tif --precision 2
     [192457.13, 2546667.68, 399086.97, 2765319.94]
 
+
+.. _warp:
 
 warp
 ----

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -10,7 +10,7 @@ to use a ready-made command as opposed to implementing similar functionality
 as a python script.
 
 The rio program is developed using the `Click <http://click.pocoo.org/>`__
-framwork.  Its plugin system allows external modules to share a common
+framework.  Its plugin system allows external modules to share a common
 namespace and handling of context variables.
 
 .. code-block:: console
@@ -685,7 +685,7 @@ See `click-plugins <https://github.com/click-contrib/click-plugins>`__ for more
 information on how to build these plugins in general.
 
 To use these plugins with rio, add the commands to the
-``rasterio.rio_plugins'`` entry point in your ``setup.py`` file, as described
+``rasterio.rio_plugins`` entry point in your ``setup.py`` file, as described
 `here <https://github.com/click-contrib/click-plugins#developing-plugins>`__
 and in ``rasterio/rio/main.py``.
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -9,7 +9,7 @@ cases are covered by CLI sub-commands and it is often more convenient
 to use a ready-made command as opposed to implementing similar functionality
 as a python script.
 
-The rio program is developed using the `Click <http://click.pocoo.org/>`__
+The rio program is developed using the `Click <http://click.palletsprojects.com/>`__
 framework.  Its plugin system allows external modules to share a common
 namespace and handling of context variables.
 
@@ -21,12 +21,14 @@ namespace and handling of context variables.
       Rasterio command line interface.
 
     Options:
-      -v, --verbose       Increase verbosity.
-      -q, --quiet         Decrease verbosity.
-      --aws-profile TEXT  Selects a profile from your shared AWS credentials file
-      --version           Show the version and exit.
+      -v, --verbose           Increase verbosity.
+      -q, --quiet             Decrease verbosity.
+      --aws-profile TEXT      Select a profile from the AWS credentials file
+      --aws-no-sign-requests  Make requests anonymously
+      --aws-requester-pays    Requester pays data transfer costs
+      --version               Show the version and exit.
       --gdal-version
-      --help              Show this message and exit.
+      --help                  Show this message and exit.
 
     Commands:
       blocks     Write dataset blocks as GeoJSON features.
@@ -514,7 +516,7 @@ rm
 
 New in 1.0
 
-Invoking the shell's '$ rm <path>' on a dataset can be used to
+Invoking the shell's ``$ rm <path>`` on a dataset can be used to
 delete a dataset referenced by a file path, but it won't handle
 deleting side car files.  This command is aware of datasets and
 their sidecar files.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -6,7 +6,7 @@ This document explains how to use Rasterio to read existing files and to create
 new files. Some advanced topics are glossed over to be covered in more detail
 elsewhere in Rasterio's documentation. Only the GeoTIFF format is used here,
 but the examples do apply to other raster data formats. It is presumed that
-Rasterio has been `installed <./installation>`__.
+Rasterio has been :doc:`installed <installation>`.
 
 Opening a dataset in reading mode
 ---------------------------------

--- a/docs/topics/configuration.rst
+++ b/docs/topics/configuration.rst
@@ -58,7 +58,7 @@ Rasterio
         with rasterio.open('data/stefan_full_greyalpha.tif') as dataset:
            # Suite of code accessing dataset ``ds`` follows...
 
-The object returned when you call ``rasterio.Env()`` is a context manager.  It
+The object returned when you call :class:`rasterio.Env()` is a context manager.  It
 handles the GDAL configuration for a specific block of code and resets the
 configuration when the block exits for any reason, success or failure. The
 Rasterio ``with rasterio.Env()`` pattern organizes GDAL configuration into single

--- a/docs/topics/georeferencing.rst
+++ b/docs/topics/georeferencing.rst
@@ -37,6 +37,8 @@ argument.
    >>> with rasterio.open('/tmp/foo.tif', 'w', crs='EPSG:3857', **profile) as dst:
    ...     pass # write data to this Web Mercator projection dataset.
 
+.. _coordinate-transformation:
+
 Coordinate Transformation
 -------------------------
 

--- a/docs/topics/image_options.rst
+++ b/docs/topics/image_options.rst
@@ -6,7 +6,7 @@ These options come in two flavors:
 
     * **Configuration options** are used to alter the default behavior of GDAL
       and OGR and are generally treated as global environment variables by GDAL. These
-      are set through a ``rasterio.Env()`` context block in Python.
+      are set through a :class:`rasterio.Env()` context block in Python.
 
     * **Creation options** are passed into the driver at dataset creation time as
       keyword arguments to ``rasterio.open(mode='w')``.
@@ -18,7 +18,7 @@ GDAL options are typically set as environment variables. While
 environment variables will influence the behavior of ``rasterio``, we
 highly recommended avoiding them in favor of defining behavior programatically.
 
-The preferred way to set options for rasterio is via ``rasterio.Env()``.
+The preferred way to set options for rasterio is via :class:`rasterio.Env()`.
 Options set on entering the context are deleted on exit.
 
 .. code-block:: python
@@ -51,7 +51,7 @@ Some of the common GeoTIFF creation options include:
   * ``PHOTOMETRIC`` to define the band's color interpretation
 
 To specify these creation options in python code, you pass them as keyword arguments
-to the ``rasterio.open()`` command in write mode.
+to the :func:`rasterio.open()` command in write mode.
 
 .. code-block:: python
 

--- a/docs/topics/masks.rst
+++ b/docs/topics/masks.rst
@@ -9,7 +9,7 @@ rows and columns as the dataset in which non-zero elements (typically 255) indic
 corresponding data elements are valid. Other elements are invalid, or *nodata*
 elements.
 
-The other kind of mask is Numpy's `masked array <http://docs.scipy.org/doc/numpy/reference/maskedarray.generic.html`_
+The other kind of mask is Numpy's `masked array <http://docs.scipy.org/doc/numpy/reference/maskedarray.generic.html>`__
 which has the inverse sense: `True` values in a masked array's mask indicate
 that the corresponding data elements are invalid. With care, you can safely
 navigate convert between the two mask types.

--- a/docs/topics/plotting.rst
+++ b/docs/topics/plotting.rst
@@ -17,10 +17,10 @@ two dimensional data can be accomplished directly with ``pyplot``.
 
 .. image:: http://farm6.staticflickr.com/5032/13938576006_b99b23271b_o_d.png
 
-Rasterio also provides ``rasterio.plot.show`` to perform common tasks such as
+Rasterio also provides :func:`rasterio.plot.show` to perform common tasks such as
 displaying multi-band images as RGB and labeling the axes with proper geo-referenced extents.
 
-The first argument to ``show`` represent the data source to be plotted. This can be one of
+The first argument to :func:`~rasterio.plot.show` represent the data source to be plotted. This can be one of
 
    * A dataset object opened in 'r' mode
    * A single band of a source, represented by a ``(src, band_index)`` tuple
@@ -42,7 +42,7 @@ you can pass in a transform in order to get extent labels.
 .. image:: ../img/rgb.jpg
 
 and similarly for single band plots. Note that you can pass in ``cmap`` to
-specify a matplotlib color ramp. Any kwargs passed to ``show`` will passed
+specify a matplotlib color ramp. Any kwargs passed to :func:`~rasterio.plot.show`  will be passed
 through to the underlying pyplot functions.
 
 .. code-block:: python
@@ -87,7 +87,7 @@ For single-band rasters, there is also an option to generate contours.
 
 .. image:: ../img/contours.jpg
 
-Rasterio also provides a ``plot.show_hist`` function for generating histograms of
+Rasterio also provides a :func:`~rasterio.plot.show_hist` function for generating histograms of
 single or multiband rasters:
 
 .. code-block:: python
@@ -100,7 +100,7 @@ single or multiband rasters:
 
 .. image:: ../img/hist.jpg
 
-The ``show_hist`` function also takes an ``ax`` argument to allow subplot configurations
+The :func:`~rasterio.plot.show_hist` function also takes an ``ax`` argument to allow subplot configurations
 
 .. code-block:: python
 

--- a/docs/topics/profiles.rst
+++ b/docs/topics/profiles.rst
@@ -3,7 +3,7 @@ Profiles and Writing Files
 
 How to use profiles when opening files.
 
-Like Python's built-in ``open()`` function, ``rasterio.open()`` has two primary
+Like Python's built-in ``open()`` function, :func:`rasterio.open()` has two primary
 arguments: a path (or URL) and an optional mode (``'r'``, ``'w'``, ``'r+'``, or
 ``'w+'``). In addition there are a number of keyword arguments, several of
 which are required when creating a new dataset:
@@ -43,7 +43,7 @@ good Rasterio usage.
        with rasterio.open('second.tif', 'w', **kwds) as dst_dataset:
            # Write data to the destination dataset.
 
-The ``rasterio.profiles`` module contains an example of a named profile that
+The :mod:`rasterio.profiles` module contains an example of a named profile that
 may be useful in applications:
 
 .. code-block:: python

--- a/docs/topics/reproject.rst
+++ b/docs/topics/reproject.rst
@@ -6,11 +6,11 @@ coordinate reference system and transform to the pixels of a source image with
 a different coordinate reference system and transform. This process is known as
 reprojection.
 
-Rasterio's ``rasterio.warp.reproject()`` is a geospatial-specific analog
+Rasterio's :func:`rasterio.warp.reproject()` is a geospatial-specific analog
 to SciPy's ``scipy.ndimage.interpolation.geometric_transform()`` [1]_.
 
 The code below reprojects between two arrays, using no pre-existing GIS
-datasets.  ``rasterio.warp.reproject()`` has two positional arguments: source
+datasets.  :func:`rasterio.warp.reproject()` has two positional arguments: source
 and destination.  The remaining keyword arguments parameterize the reprojection
 transform.
 
@@ -62,7 +62,7 @@ correct: https://a.tiles.mapbox.com/v3/sgillies.hfek2oko/page.html?secure=1#6/0.
 Estimating optimal output shape
 -------------------------------
 
-Rasterio provides a ``rasterio.warp.calculate_default_transform()`` function to
+Rasterio provides a :func:`rasterio.warp.calculate_default_transform()` function to
 determine the optimal resolution and transform for the destination raster.
 Given a source dataset in a known coordinate reference system, this 
 function will return a ``transform, width, height`` tuple which is calculated
@@ -74,13 +74,13 @@ Reprojecting a GeoTIFF dataset
 Reprojecting a GeoTIFF dataset from one coordinate reference system is a common
 use case.  Rasterio provides a few utilities to make this even easier:
 
-``transform_bounds()``
+:func:`~rasterio.warp.transform_bounds()`
 transforms the bounding coordinates of the source raster to the target
 coordinate reference system, densifiying points along the edges to account
 for non-linear transformations of the edges.
 
 
-``calculate_default_transform()``
+:func:`~rasterio.warp.calculate_default_transform()`
 transforms bounds to target coordinate system, calculates resolution if not
 provided, and returns destination transform and dimensions.
 
@@ -118,13 +118,12 @@ provided, and returns destination transform and dimensions.
 
 See ``rasterio/rio/warp.py`` for more complex examples of reprojection based on
 new bounds, dimensions, and resolution (as well as a command-line interface
-described
-`here <https://github.com/mapbox/rasterio/blob/master/docs/cli.rst#warp>`__).
+described :ref:`here <warp>`).
 
 
 
-It is also possible to use ``reproject()`` to create an output dataset zoomed
-out by a factor of 2.  Methods of the ``rasterio.Affine`` class help us generate
+It is also possible to use :func:`~rasterio.warp.reproject()` to create an output dataset zoomed
+out by a factor of 2.  Methods of the :class:`rasterio.Affine` class help us generate
 the output dataset's transform matrix and, thereby, its spatial extent.
 
 .. code-block:: python

--- a/docs/topics/reproject.rst
+++ b/docs/topics/reproject.rst
@@ -170,5 +170,5 @@ the output dataset's transform matrix and, thereby, its spatial extent.
 References
 ----------
 
-.. [1] http://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.interpolation.geometric_transform.html#scipy.ndimage.interpolation.geometric_transform
+.. [1] https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.geometric_transform.html#scipy.ndimage.geometric_transform
 

--- a/docs/topics/switch.rst
+++ b/docs/topics/switch.rst
@@ -2,7 +2,7 @@ Switching from GDAL's Python bindings
 =====================================
 
 This document is written specifically for users of GDAL's Python bindings
-(``osgeo.gdal``) who have read about Rasterio's `philosophy <intro.html>`__ and
+(``osgeo.gdal``) who have read about Rasterio's :doc:`philosophy <../intro>` and
 want to know what switching entails.  The good news is that switching may not
 be complicated. This document explains the key similarities and differences
 between these two Python packages and highlights the features of Rasterio that


### PR DESCRIPTION
This PR updates a few things in the documentation:

- Fixes a few broken links, typos, and missing module (`rasterio.vfs`)
- Updates the page on the command-line interface (`rio --help` output has changed a bit)
- Uses `rst` links, such as :func:\`rasterio.plot.show\`, to use the hyperlinking feature of `sphinx`. I have not done this exhaustively though, there are still some non-hyperlink references to `rasterio` functions left in the documentation.