### PR TITLE
Automatic overview level computation

### DIFF
--- a/rasterio/rio/overview.py
+++ b/rasterio/rio/overview.py
@@ -21,12 +21,12 @@ def build_handler(ctx, param, value):
                 value = [pow(int(base), k) for k in range(exp_min, exp_max + 1)]
             elif ',' in value:
                 value = [int(v) for v in value.split(',')]
-            elif int(value) == -1:
-                value = -1
+            elif value == "auto":
+                pass
             else:
                 raise Exception
         except Exception:
-            raise click.BadParameter(u"must match 'n,n,n,…', 'n^n..n', or '-1'.")
+            raise click.BadParameter(u"must match 'n,n,n,…', 'n^n..n', or 'auto'.")
     return value
 
 
@@ -58,10 +58,10 @@ def get_maximum_overview_level(src_dst, minsize=256):
 
 @click.command('overview', short_help="Construct overviews in an existing dataset.")
 @options.file_in_arg
-@click.option('--build', callback=build_handler, metavar=u"f1,f2,…|b^min..max|-1",
+@click.option('--build', callback=build_handler, metavar=u"f1,f2,…|b^min..max|auto",
               help="A sequence of decimation factors specified as "
                    "comma-separated list of numbers or a base and range of "
-                   "exponents, or -1 to automatically determine the maximum factor.")
+                   "exponents, or 'auto' to automatically determine the maximum factor.")
 @click.option('--ls', help="Print the overviews for each band.",
               is_flag=True, default=False)
 @click.option('--rebuild', help="Reconstruct existing overviews.",
@@ -86,10 +86,10 @@ def overview(ctx, input, build, ls, rebuild, resampling):
 
       rio overview --build 2^1..4
 
-    or -1 to automatically determine the maximum decimation level at
+    or 'auto' to automatically determine the maximum decimation level at
     which the smallest overview is smaller than 256 pixels in size.
 
-      rio overview --build -1
+      rio overview --build auto
 
     Note that overviews can not currently be removed and are not
     automatically updated when the dataset's primary bands are
@@ -127,7 +127,7 @@ def overview(ctx, input, build, ls, rebuild, resampling):
 
         elif build:
             with rasterio.open(input, 'r+') as dst:
-                if build == -1:
+                if build == "auto":
                     overview_level = get_maximum_overview_level(dst)
                     build = [2 ** j for j in range(1, overview_level + 1)]
                 dst.build_overviews(build, Resampling[resampling])

--- a/rasterio/rio/overview.py
+++ b/rasterio/rio/overview.py
@@ -30,14 +30,17 @@ def build_handler(ctx, param, value):
     return value
 
 
-def get_maximum_overview_level(src_dst, minsize=256):
+def get_maximum_overview_level(width, height, minsize=256):
     """
-    Calculate the maximum overview level.
+    Calculate the maximum overview level of a dataset at which
+    the smallest overview is smaller than `minsize`.
 
     Attributes
     ----------
-    src_dst : rasterio.io.DatasetReader
-        Rasterio io.DatasetReader object.
+    width : int
+        Width of the dataset.
+    height : int
+        Height of the dataset.
     minsize : int (default: 256)
         Minimum overview size.
 
@@ -49,7 +52,7 @@ def get_maximum_overview_level(src_dst, minsize=256):
     """
     overview_level = 0
     overview_factor = 1
-    while min(src_dst.width // overview_factor, src_dst.height // overview_factor) > minsize:
+    while min(width // overview_factor, height // overview_factor) > minsize:
         overview_factor *= 2
         overview_level += 1
 
@@ -128,7 +131,7 @@ def overview(ctx, input, build, ls, rebuild, resampling):
         elif build:
             with rasterio.open(input, 'r+') as dst:
                 if build == "auto":
-                    overview_level = get_maximum_overview_level(dst)
+                    overview_level = get_maximum_overview_level(dst.width, dst.height)
                     build = [2 ** j for j in range(1, overview_level + 1)]
                 dst.build_overviews(build, Resampling[resampling])
 

--- a/tests/test_rio_overview.py
+++ b/tests/test_rio_overview.py
@@ -79,7 +79,7 @@ def test_no_args(data):
 def test_build_auto_ls(data):
     runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
-    result = runner.invoke(cli, ['overview', inputfile, '--build', '-1'])
+    result = runner.invoke(cli, ['overview', inputfile, '--build', 'auto'])
     assert result.exit_code == 0
     result = runner.invoke(cli, ['overview', inputfile, '--ls'])
     assert result.exit_code == 0

--- a/tests/test_rio_overview.py
+++ b/tests/test_rio_overview.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 from click.testing import CliRunner
+import pytest
 
 import rasterio
 from rasterio.rio.main import main_group as cli
@@ -87,13 +88,15 @@ def test_build_auto_ls(data):
     assert result.output.endswith(expected)
 
 
-def test_max_overview(data):
-    inputfile = str(data.join('RGB.byte.tif'))
-
-    with rasterio.open(inputfile) as src:
-        overview_level = get_maximum_overview_level(src)
-    assert overview_level == 2
-
-    with rasterio.open(inputfile) as src:
-        overview_level = get_maximum_overview_level(src, minsize=128)
-    assert overview_level == 3
+@pytest.mark.parametrize(
+    "width, height, minsize, expected",
+    [
+        (256, 256, 256, 0),
+        (257, 257, 256, 1),
+        (1000, 1000, 128, 3),
+        (1000, 100, 128, 0)
+    ]
+)
+def test_max_overview(width, height, minsize, expected):
+    overview_level = get_maximum_overview_level(width, height, minsize)
+    assert overview_level == expected


### PR DESCRIPTION
This PR resolves #1511 

The `get_maximum_overview_level` function was taken from [rio-cogeo](https://github.com/cogeotiff/rio-cogeo/blob/fdda823e836bc9614f522ced349d5e1281fb8706/rio_cogeo/utils.py#L95-L118).

I have a few points on which I would need some guidance:
- In https://github.com/mapbox/rasterio/issues/1511#issuecomment-439127602 @vincentsarago was saying that he was interested in having the `get_maximum_overview_level` function public, for use in `rio_cogeo`. Is it fine where I have put it in `rasterio.rio.overview`, or does it better belong somewhere else in `rasterio`?

- I have taken the default `minsize=256` of [gdaladdo](https://gdal.org/programs/gdaladdo.html#cmdoption-gdaladdo-minsize), but in `rio_cogeo` @vincentsarago has a default of 512. Which best suits `rasterio`?

- Should `minsize` be exposed in `rio overview` or not? (currently it isn't)

- The way I have integrated the "automatic" behavior into `rio overview` is a bit wonky.
Ideally, it would have been triggered with `rio overview file.tiff --build` (i.e. no value on the `build` flag), but `click` does not support having a `const` value, per https://github.com/pallets/click/issues/549.
I have chosen as a convention that if `--build -1` is passed, the automatic overview level is used. In that case however, I cannot return the list of decimation factors in the `build_handler` callback because it requires access to the `input` file argument [which has not necessarily already been parsed by Click](https://stackoverflow.com/questions/46586831/how-can-i-use-an-python-click-argument-from-within-a-click-option-check-if-vari). Due to that, the handler returns `-1` and the decimation factors are determined inside the main function `overview()`.
If you feel there's a better way to do that, I'd be happy to change it!