### PR TITLE
enable parsing of sentinel2 from the rio cli

### DIFF
--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -135,7 +135,10 @@ def parse_path(path):
 
         # if the scheme is not one of Rasterio's supported schemes, we
         # return an UnparsedPath.
-        if parts.scheme and not all(p in SCHEMES for p in parts.scheme.split('+')):
+        if path.startswith('SENTINEL2_L1C:'):
+            return UnparsedPath(path)
+            
+        elif parts.scheme and not all(p in SCHEMES for p in parts.scheme.split('+')):
             return UnparsedPath(path)
 
         else:


### PR DESCRIPTION
Currently it isn't possible to parse sentinel 2 using the rio cli tools such as `rio info` when using subdatasets. It is however possible to open these subdatasets in code using `with rasterio.open ...`.

This PR fixes this by adding a special case for sentinel 2 path of the form `SENTINEL2_L1C`. This requires a special case because of the use of `urlparse` which is unable to parse this scheme.