### PR TITLE
Metadata namespaces

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,9 @@ Deprecations:
 
 New features:
 
+- Added a new ``tag_namespaces()`` method datasets that returns names of
+  metadata namespaces that can be passed to the existing ``tags()`` method
+  (#1740).
 - Zoom levels can be automatically computed by rio-overview (#511).
 - An alternative endpoint for S3-compatible network storage can now be set when
   creating an instance of AWSSession (#1779). See GDAL's documentation of its

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -951,6 +951,26 @@ cdef class DatasetBase(object):
                 subs[idx][fld] = val.replace('"', '')
             return [subs[idx]['name'] for idx in sorted(subs.keys())]
 
+
+    def get_tag_ns(self, bidx=0):
+        """Returns the list of metadata domains.
+        
+        The optional bidx argument can be used to select a specific band.
+        """
+        cdef GDALMajorObjectH obj = NULL
+        if bidx > 0:
+            obj = self.band(bidx)
+        else:
+            obj = self._hds
+
+        namespaces = GDALGetMetadataDomainList(obj)
+        num_items = CSLCount(namespaces)
+        try:
+            return list([namespaces[i] for i in range(num_items)])
+        finally:
+            CSLDestroy(namespaces)
+
+
     def tags(self, bidx=0, ns=None):
         """Returns a dict containing copies of the dataset or band's
         tags.

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -952,10 +952,21 @@ cdef class DatasetBase(object):
             return [subs[idx]['name'] for idx in sorted(subs.keys())]
 
 
-    def get_tag_ns(self, bidx=0):
-        """Returns the list of metadata domains.
-        
-        The optional bidx argument can be used to select a specific band.
+    def tag_namespaces(self, bidx=0):
+        """Get a list of the dataset's metadata domains.
+
+        Returned items may be passed as `ns` to the tags method.
+
+        Parameters
+        ----------
+        bidx int, optional
+            Can be used to select a specific band, otherwise the
+            dataset's general metadata domains are returned.
+
+        Returns
+        -------
+        list of str
+
         """
         cdef GDALMajorObjectH obj = NULL
         if bidx > 0:
@@ -966,7 +977,7 @@ cdef class DatasetBase(object):
         namespaces = GDALGetMetadataDomainList(obj)
         num_items = CSLCount(namespaces)
         try:
-            return list([namespaces[i] for i in range(num_items)])
+            return list([namespaces[i] for i in range(num_items) if str(namespaces[i])])
         finally:
             CSLDestroy(namespaces)
 

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -232,6 +232,7 @@ cdef extern from "gdal.h" nogil:
     GDALDatasetH GDALCreateCopy(GDALDriverH driver, const char *path,
                                 GDALDatasetH hds, int strict, char **options,
                                 void *progress_func, void *progress_data)
+    char** GDALGetMetadataDomainList(GDALMajorObjectH obj)
     char** GDALGetMetadata(GDALMajorObjectH obj, const char *pszDomain)
     int GDALSetMetadata(GDALMajorObjectH obj, char **papszMD,
                         const char *pszDomain)

--- a/tests/test_tag_ns.py
+++ b/tests/test_tag_ns.py
@@ -1,16 +1,15 @@
-#-*- coding: utf-8 -*-
-import logging
-import sys
+# -*- coding: utf-8 -*-
 
 import rasterio
 
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+def test_get_tag_item():
+    """Should return the correct list of dataset tag namespaces."""
+    with rasterio.open('tests/data/cogeo.tif') as src:
+        assert src.tag_namespaces() == ['IMAGE_STRUCTURE', 'DERIVED_SUBDATASETS']
 
 
 def test_get_tag_item():
-    """Should return the correct list of tag namespaces."""
+    """Should return the correct list of band tag namespaces."""
     with rasterio.open('tests/data/cogeo.tif') as src:
-        assert src.get_tag_ns() == ['IMAGE_STRUCTURE', 'DERIVED_SUBDATASETS']
-
-    with rasterio.open('tests/data/cogeo.tif') as src:
-        assert src.get_tag_ns(bidx=1) == []
+        assert src.tag_namespaces(bidx=1) == []

--- a/tests/test_tag_ns.py
+++ b/tests/test_tag_ns.py
@@ -1,0 +1,16 @@
+#-*- coding: utf-8 -*-
+import logging
+import sys
+
+import rasterio
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+
+
+def test_get_tag_item():
+    """Should return the correct list of tag namespaces."""
+    with rasterio.open('tests/data/cogeo.tif') as src:
+        assert src.get_tag_ns() == ['IMAGE_STRUCTURE', 'DERIVED_SUBDATASETS']
+
+    with rasterio.open('tests/data/cogeo.tif') as src:
+        assert src.get_tag_ns(bidx=1) == []


### PR DESCRIPTION
New PR using @vincentsarago's code from #1740. The name of the method has been changed to `tag_namespaces`. The `get` is superfluous.