### PR TITLE
replace broken resampling example with working one

### DIFF
--- a/docs/topics/resampling.rst
+++ b/docs/topics/resampling.rst
@@ -18,36 +18,35 @@ By reading from a raster source into an output array of a different size or by
 specifying an *out_shape* of a different size you are effectively resampling
 the data.
 
-Here is an example of upsampling by a factor of 2 using the bilinear resampling
-method.
+Here is an example of upsampling by a factor of 2 using the bilinear resampling 
+method. 
 
 .. code-block:: python
 
     import rasterio
     from rasterio.enums import Resampling
 
+    scaling = 2
+
     with rasterio.open("example.tif") as dataset:
+        
+        # resample data to target shape
         data = dataset.read(
-            out_shape=(dataset.height * 2, dataset.width * 2, dataset.count),
+            out_shape=(
+                dataset.count, 
+                int(dataset.width * scaling), 
+                int(dataset.height * scaling)
+            ),
             resampling=Resampling.bilinear
         )
-
-Here is an example of downsampling by a factor of 2 using the average resampling
-method.
-
-.. code-block:: python
-
-    with rasterio.open("example.tif") as dataset:
-        data = dataset.read(
-            out_shape=(dataset.height / 2, dataset.width / 2, dataset.count),
-            resampling=Resampling.average
+        
+        # scale image transform
+        transform = dataset.transform * dataset.transform.scale(
+            (dataset.width / data.shape[-2]),
+            (dataset.height / data.shape[-1])
         )
 
-.. note::
-
-   After these resolution changing operations, the dataset's resolution and the
-   resolution components of its affine *transform* property no longer apply to
-   the new arrays.
+Downsampling to 1/2 of the resolution can be done with ``scaling = 1/2``.
 
 
 Resampling Methods

--- a/docs/topics/resampling.rst
+++ b/docs/topics/resampling.rst
@@ -26,7 +26,7 @@ method.
     import rasterio
     from rasterio.enums import Resampling
 
-    scaling = 2
+    upscale_factor = 2
 
     with rasterio.open("example.tif") as dataset:
         
@@ -34,8 +34,8 @@ method.
         data = dataset.read(
             out_shape=(
                 dataset.count, 
-                int(dataset.width * scaling), 
-                int(dataset.height * scaling)
+                int(dataset.width * upscale_factor), 
+                int(dataset.height * upscale_factor)
             ),
             resampling=Resampling.bilinear
         )
@@ -46,7 +46,7 @@ method.
             (dataset.height / data.shape[-1])
         )
 
-Downsampling to 1/2 of the resolution can be done with ``scaling = 1/2``.
+Downsampling to 1/2 of the resolution can be done with ``upscale_factor = 1/2``.
 
 
 Resampling Methods


### PR DESCRIPTION
Fixes #1732.

As @00krishna pointed out in the issue, the current example in the docs for up-/downsampling is broken. The code has some bugs and is missing the important information how to scale the transform after using decimated read.

Here is a similarly simple example that works.

The approach used here and in the original example (decimated read) is fine for upsampling (increasing resolution by a factor). For downsampling, I would normally want to control the target image `transform`, so I would use a `WarpedVRT` instead to be sure that image size and transform match - unless the image dimensions (height and width) are evenly divisible by the resampling factor.

However, in order not to complicate the docs on this issue too much, I suggest to just show decimated read here. The example code should work safely for both cases (in Python 3).