### PR TITLE
Fix for #1807 rio bounds args conflict

### DIFF
--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -355,7 +355,7 @@ all_touched_opt = click.option(
 
 # Feature collection or feature sequence switch.
 sequence_opt = click.option(
-    '--sequence/--collection',
+    '--sequence/--no-sequence',
     default=True,
     help="Write a LF-delimited sequence of texts containing individual "
          "objects (the default) or write a single JSON text containing a "

--- a/tests/test_rio_bounds.py
+++ b/tests/test_rio_bounds.py
@@ -1,0 +1,31 @@
+import pytest
+
+import rasterio
+from rasterio.rio.main import main_group
+
+def test_bounds_sequence_single(runner, basic_image_file):
+    """
+    --sequence option should produce a feature collection for a single image.
+    """
+    result = runner.invoke(main_group, ['bounds', '--sequence', basic_image_file])
+
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 1
+
+def tests_bounds_sequence_multiple(runner, basic_image_file):
+    """
+    --sequence option should produce a feature collection for each image passed as argument.
+    """
+    result = runner.invoke(main_group, ['bounds', '--sequence', basic_image_file, basic_image_file])
+
+    assert result.output.count('"FeatureCollection"') == 2
+    assert result.output.count('"Feature"') == 2
+
+def test_bounds_no_sequence_multiple(runner, basic_image_file):
+    """
+    --no-sequence option should produce a single feature collection
+    """
+    result = runner.invoke(main_group, ['bounds', '--no-sequence', basic_image_file, basic_image_file])
+
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 2

--- a/tests/test_rio_shapes.py
+++ b/tests/test_rio_shapes.py
@@ -21,7 +21,7 @@ def bbox(*args):
 def test_shapes(runner, pixelated_image_file):
     with pytest.warns(None):
 
-        result = runner.invoke(main_group, ['shapes', '--collection', pixelated_image_file])
+        result = runner.invoke(main_group, ['shapes', '--no-sequence', pixelated_image_file])
 
         assert result.exit_code == 0
         assert result.output.count('"FeatureCollection"') == 1
@@ -33,7 +33,7 @@ def test_shapes(runner, pixelated_image_file):
 
 def test_shapes_invalid_bidx(runner, pixelated_image_file):
     result = runner.invoke(
-        main_group, ['shapes', '--collection', pixelated_image_file, '--bidx', 4])
+        main_group, ['shapes', '--no-sequence', pixelated_image_file, '--bidx', 4])
 
     assert result.exit_code == 1
     # Underlying exception message trapped by shapes
@@ -47,7 +47,7 @@ def test_shapes_sequence(runner, pixelated_image_file):
     with pytest.warns(None):
 
         result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--sequence'])
+            main_group, ['shapes', '--no-sequence', pixelated_image_file, '--sequence'])
 
         assert result.exit_code == 0
         assert result.output.count('"FeatureCollection"') == 0
@@ -59,7 +59,7 @@ def test_shapes_sequence_rs(runner, pixelated_image_file):
     """ --rs option should use the feature separator character. """
 
     result = runner.invoke(
-        main_group, ['shapes', '--collection', pixelated_image_file, '--sequence', '--rs'])
+        main_group, ['shapes', '--no-sequence', pixelated_image_file, '--sequence', '--rs'])
 
     assert result.exit_code == 0
     assert result.output.count('"FeatureCollection"') == 0
@@ -79,7 +79,7 @@ def test_shapes_with_nodata(runner, pixelated_image, pixelated_image_file):
         out.write(pixelated_image, indexes=1)
 
     result = runner.invoke(
-        main_group, ['shapes', '--collection', pixelated_image_file, '--with-nodata'])
+        main_group, ['shapes', '--no-sequence', pixelated_image_file, '--with-nodata'])
     assert result.exit_code == 0
     assert result.output.count('"FeatureCollection"') == 1
     assert result.output.count('"Feature"') == 5
@@ -92,7 +92,7 @@ def test_shapes_indent(runner, pixelated_image_file):
     with pytest.warns(None):
 
         result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--indent', 2])
+            main_group, ['shapes', '--no-sequence', pixelated_image_file, '--indent', 2])
 
         assert result.exit_code == 0
         assert result.output.count('"FeatureCollection"') == 1
@@ -105,7 +105,7 @@ def test_shapes_compact(runner, pixelated_image_file):
     with pytest.warns(None):
 
         result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--compact'])
+            main_group, ['shapes', '--no-sequence', pixelated_image_file, '--compact'])
 
         assert result.exit_code == 0
         assert result.output.count('"FeatureCollection"') == 1
@@ -117,7 +117,7 @@ def test_shapes_compact(runner, pixelated_image_file):
 def test_shapes_sampling(runner, pixelated_image_file):
     """ --sampling option should remove the single pixel features """
     result = runner.invoke(
-        main_group, ['shapes', '--collection', pixelated_image_file, '--sampling', 2])
+        main_group, ['shapes', '--no-sequence', pixelated_image_file, '--sampling', 2])
 
     assert result.exit_code == 0
     assert result.output.count('"FeatureCollection"') == 1
@@ -128,7 +128,7 @@ def test_shapes_precision(runner, pixelated_image_file):
     """ Output numbers should have no more than 1 decimal place """
 
     result = runner.invoke(
-        main_group, ['shapes', '--collection', pixelated_image_file, '--precision', 1])
+        main_group, ['shapes', '--no-sequence', pixelated_image_file, '--precision', 1])
 
     assert result.exit_code == 0
     assert result.output.count('"FeatureCollection"') == 1
@@ -148,7 +148,7 @@ def test_shapes_mask(runner, pixelated_image, pixelated_image_file):
 
     with pytest.warns(None):
         result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--mask'])
+            main_group, ['shapes', '--no-sequence', pixelated_image_file, '--mask'])
         assert result.exit_code == 0
         assert result.output.count('"FeatureCollection"') == 1
         assert result.output.count('"Feature"') == 1
@@ -172,7 +172,7 @@ def test_shapes_mask_sampling(runner, pixelated_image, pixelated_image_file):
 
         result = runner.invoke(
             main_group,
-            ['shapes', '--collection', pixelated_image_file, '--mask', '--sampling', 5])
+            ['shapes', '--no-sequence', pixelated_image_file, '--mask', '--sampling', 5])
 
         assert result.exit_code == 0
         assert result.output.count('"FeatureCollection"') == 1
@@ -197,7 +197,7 @@ def test_shapes_band1_as_mask(runner, pixelated_image, pixelated_image_file):
     with pytest.warns(None):
         result = runner.invoke(
             main_group,
-            ['shapes', '--collection', pixelated_image_file, '--band', '--bidx', '1', '--as-mask'])
+            ['shapes', '--no-sequence', pixelated_image_file, '--band', '--bidx', '1', '--as-mask'])
 
         assert result.exit_code == 0
         assert result.output.count('"FeatureCollection"') == 1


### PR DESCRIPTION
Addresses #1807 

From my manual testing I did not see any issues with simply changing the name of the optional argument, and tests passed once the old argument name was updated in relevant tests. I don't have enough experience with the rest of rio command line to know if there was any use cases that depended on the `--collection` flag 

Would a test to guard against regression be more appropriate under `test_rio_bounds.py` or `test_rio_helpers.py`?