### PR TITLE
Fix plotting of RGB rasters

### DIFF
--- a/CITATION.txt
+++ b/CITATION.txt
@@ -1,7 +1,7 @@
 If you use Rasterio for any published work, please cite it using the reference
 below:
 
-@Misc{,
+@software{gillies_2019,
   author =    {Sean Gillies and others},
   organization = {Mapbox},
   title =     {Rasterio: geospatial raster I/O for {Python} programmers},

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,11 @@ versions 1.11.x through 2.4.x. Official binary packages for Linux and Mac OS X a
 available on PyPI. Unofficial binary packages for Windows are available through other
 channels.
 
-Rasterio 1.0.x is not compatible with GDAL versions 3.0.0 or greater.
+**GDAL Compatibility:** 
+
+* Rasterio ~= 1.1.0 requires GDAL >= 1.11, < 3.1
+* Rasterio ~= 1.0.25 requires GDAL >= 1.11, < 3.1
+* Rasterio ~= 1.0.0, < 1.0.25 requires GDAL >= 1.11, < 3.0
 
 Read the documentation for more details: https://rasterio.readthedocs.io/.
 

--- a/README.rst
+++ b/README.rst
@@ -277,7 +277,7 @@ For a Homebrew based Python environment, do the following.
     $ brew update
     $ brew install gdal
     $ pip install -U pip
-    $ pip install --no-use-wheel rasterio
+    $ pip install --no-binary rasterio
 
 Alternatively, you can install GDAL binaries from `kyngchaos
 <http://www.kyngchaos.com/software/frameworks#gdal_complete>`__.  You will then

--- a/docs/topics/resampling.rst
+++ b/docs/topics/resampling.rst
@@ -18,36 +18,35 @@ By reading from a raster source into an output array of a different size or by
 specifying an *out_shape* of a different size you are effectively resampling
 the data.
 
-Here is an example of upsampling by a factor of 2 using the bilinear resampling
-method.
+Here is an example of upsampling by a factor of 2 using the bilinear resampling 
+method. 
 
 .. code-block:: python
 
     import rasterio
     from rasterio.enums import Resampling
 
+    upscale_factor = 2
+
     with rasterio.open("example.tif") as dataset:
+        
+        # resample data to target shape
         data = dataset.read(
-            out_shape=(dataset.height * 2, dataset.width * 2, dataset.count),
+            out_shape=(
+                dataset.count, 
+                int(dataset.width * upscale_factor), 
+                int(dataset.height * upscale_factor)
+            ),
             resampling=Resampling.bilinear
         )
-
-Here is an example of downsampling by a factor of 2 using the average resampling
-method.
-
-.. code-block:: python
-
-    with rasterio.open("example.tif") as dataset:
-        data = dataset.read(
-            out_shape=(dataset.height / 2, dataset.width / 2, dataset.count),
-            resampling=Resampling.average
+        
+        # scale image transform
+        transform = dataset.transform * dataset.transform.scale(
+            (dataset.width / data.shape[-2]),
+            (dataset.height / data.shape[-1])
         )
 
-.. note::
-
-   After these resolution changing operations, the dataset's resolution and the
-   resolution components of its affine *transform* property no longer apply to
-   the new arrays.
+Downsampling to 1/2 of the resolution can be done with ``upscale_factor = 1/2``.
 
 
 Resampling Methods

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -93,10 +93,17 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
             arr = source.read(1, masked=True)
         else:
             try:
-                source_colorinterp = OrderedDict(zip(source.indexes, source.colorinterp))
+                # Lookup table for the color space in the source file. This will allow us to re-order it
+                # to RGB if needed
+                source_colorinterp = OrderedDict(zip(source.colorinterp, source.indexes))
                 colorinterp = rasterio.enums.ColorInterp
+
+                # Gather the indexes of the RGB channels in that order
                 rgb_indexes = [source_colorinterp[ci] for ci in
                                (colorinterp.red, colorinterp.green, colorinterp.blue)]
+
+                # Read the image in the proper order so the numpy array will have the colors in the
+                # order expected by matplotlib (RGB)
                 arr = source.read(rgb_indexes, masked=True)
                 arr = reshape_as_image(arr)
 


### PR DESCRIPTION
Fixes #1650 . Modified the plotting of rasters with R, G and B channels: now we read the data in the order expected by matplotlib so the displayed image has the correct colors.