### PR TITLE
Clip convert overwrite

### DIFF
--- a/rasterio/rio/clip.py
+++ b/rasterio/rio/clip.py
@@ -48,10 +48,11 @@ projection_projected_opt = click.option(
 @format_opt
 @projection_geographic_opt
 @projection_projected_opt
+@options.overwrite_opt
 @options.creation_options
 @click.pass_context
 def clip(ctx, files, output, bounds, like, driver, projection,
-         creation_options):
+         overwrite, creation_options):
     """Clips a raster using projected or geographic bounds.
 
     \b
@@ -78,7 +79,7 @@ def clip(ctx, files, output, bounds, like, driver, projection,
 
     with ctx.obj['env']:
 
-        output, files = resolve_inout(files=files, output=output)
+        output, files = resolve_inout(files=files, output=output, overwrite=overwrite)
         input = files[0]
 
         with rasterio.open(input) as src:

--- a/rasterio/rio/convert.py
+++ b/rasterio/rio/convert.py
@@ -20,11 +20,12 @@ from rasterio.rio.helpers import resolve_inout
 @click.option('--scale-offset', type=float, default=None,
               help="Source to destination scaling offset.")
 @options.rgb_opt
+@options.overwrite_opt
 @options.creation_options
 @click.pass_context
 def convert(
         ctx, files, output, driver, dtype, scale_ratio, scale_offset,
-        photometric, creation_options):
+        photometric, overwrite, creation_options):
     """Copy and convert raster datasets to other data types and formats.
 
     Data values may be linearly scaled when copying by using the
@@ -50,7 +51,7 @@ def convert(
     """
     with ctx.obj['env']:
 
-        outputfile, files = resolve_inout(files=files, output=output)
+        outputfile, files = resolve_inout(files=files, output=output, overwrite=overwrite)
         inputfile = files[0]
 
         with rasterio.open(inputfile) as src:

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -84,6 +84,34 @@ def test_clip_like_disjunct(runner, tmpdir):
     assert '--like' in result.output
 
 
+def test_clip_overwrite_without_option(runner, tmpdir):
+    output = str(tmpdir.join('test.tif'))
+    result = runner.invoke(
+        main_group,
+        ['clip', 'tests/data/shade.tif', output, '--bounds', bbox(*TEST_BBOX)])
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main_group,
+        ['clip', 'tests/data/shade.tif', output, '--bounds', bbox(*TEST_BBOX)])
+    assert result.exit_code == 1
+    assert '--overwrite' in result.output
+
+
+def test_clip_overwrite_with_option(runner, tmpdir):
+    output = str(tmpdir.join('test.tif'))
+    result = runner.invoke(
+        main_group,
+        ['clip', 'tests/data/shade.tif', output, '--bounds', bbox(*TEST_BBOX)])
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main_group, [
+        'clip', 'tests/data/shade.tif', output, '--bounds', bbox(*TEST_BBOX),
+        '--overwrite'])
+    assert result.exit_code == 0
+
+
 # Tests: format and type conversion, --format and --dtype
 
 def test_format(tmpdir):
@@ -202,3 +230,31 @@ def test_rgb(tmpdir):
     assert result.exit_code == 0
     with rasterio.open(outputname) as src:
         assert src.colorinterp[0] == rasterio.enums.ColorInterp.red
+
+
+def test_convert_overwrite_without_option(runner, tmpdir):
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(
+        main_group,
+        ['convert', 'tests/data/RGB.byte.tif', '-o', outputname, '-f', 'JPEG'])
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main_group,
+        ['convert', 'tests/data/RGB.byte.tif', '-o', outputname, '-f', 'JPEG'])
+    assert result.exit_code == 1
+    assert '--overwrite' in result.output
+
+
+def test_convert_overwrite_with_option(runner, tmpdir):
+    outputname = str(tmpdir.join('test.tif'))
+    result = runner.invoke(
+        main_group,
+        ['convert', 'tests/data/RGB.byte.tif', '-o', outputname, '-f', 'JPEG'])
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        main_group, [
+        'convert', 'tests/data/RGB.byte.tif', '-o', outputname, '-f', 'JPEG',
+        '--overwrite'])
+    assert result.exit_code == 0


### PR DESCRIPTION
I have noticed that the `--overwrite` option was missing from `rio clip` and `rio convert`, even though they use the `resolve_inout` function internally.

This results in the following oddity:
```
$ rio convert tests/data/RGB.byte.tif t.tif -f JPEG
---> This works fine

$ rio convert tests/data/RGB.byte.tif t.tif -f JPEG
Error: Could not open file : file exists and won't be overwritten without use of the `--overwrite` option.
---> This is normal behavior as well

$ rio convert tests/data/RGB.byte.tif t.tif -f JPEG --overwrite
Usage: rio convert [OPTIONS] INPUTS... OUTPUT
Try "rio convert --help" for help.

Error: no such option: --overwrite
---> This is because @options.overwrite_opt is missing from rio convert
```

I have looked for all `rio` subcommands that used `resolve_inout` but that weren't decorated with `@options.overwrite_opt` and found only `clip` and `convert`, so the other ones should be fine.

Also, I've added tests that pass only after the fix, but only for the `clip` and `convert` subcommands. I've noticed that other subcommands that expose `--overwrite` do not have tests for this flag. If you feel that the tests I've added are not necessary, feel free to remove them!