### PR TITLE
WIP: Add RPC transformer using GDALCreateRPCTransfomer

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -18,7 +18,7 @@ from rasterio._err cimport exc_wrap_pointer, exc_wrap_int
 from rasterio._shim cimport open_dataset, osr_get_name, osr_set_traditional_axis_mapping_strategy
 
 from rasterio.compat import string_types
-from rasterio.control import GroundControlPoint
+from rasterio.control import GroundControlPoint, RPC
 from rasterio import dtypes
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
@@ -228,6 +228,7 @@ cdef class DatasetBase(object):
         self._scales = ()
         self._offsets = ()
         self._gcps = None
+        self._rpcs = None
         self._read = False
 
         self._set_attrs_from_dataset_handle()
@@ -1256,6 +1257,27 @@ cdef class DatasetBase(object):
         def __set__(self, value):
             gcps, crs = value
             self._set_gcps(gcps, crs)
+
+    def get_rpcs(self):
+        """Get RPCs if exists"""
+        return RPC.from_gdal(self.tags(ns='RPC'))
+
+    def _set_rpcs(self, values):
+        raise DatasetAttributeError("read-only attribute")
+
+    property rpcs:
+        """RPC metadata mapping geodetic coordinates in EPSG:4326 to pixel coordinates
+
+        rpcs : RPC instance containing dict of coefficients.
+        """
+        def __get__(self):
+            if not self._rpcs:
+                self._rpcs = self.get_rpcs()
+            return self._rpcs
+
+        def __set__(self, value):
+            rpcs = value.to_gdal()
+            self._set_rpcs(rpcs)
 
     property files:
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -555,7 +555,7 @@ cdef class DatasetBase(object):
         raise DatasetAttributeError("read-only attribute")
 
     def _set_all_units(self, value):
-        raise DatasetAttributeError("read-only attribute") 
+        raise DatasetAttributeError("read-only attribute")
 
     property descriptions:
         """Descriptions for each dataset band

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -620,9 +620,9 @@ cdef class DatasetReaderBase(DatasetBase):
                     # that looks more like the source's band 1 when doing
                     # this kind of boundless read. It looks like
                     # hmask = GDALGetMaskBand(band) may be returning the
-                    # a pointer to the band instead of the mask band in 
+                    # a pointer to the band instead of the mask band in
                     # this case.
-                    # 
+                    #
                     # Temporary solution: convert all non-zero pixels to
                     # 255 and log that we have done so.
 
@@ -1199,6 +1199,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         if transform is not None:
             self._transform = transform.to_gdal()
         self._gcps = None
+        self._rpcs = None
         self._init_gcps = gcps
         self._closed = True
         self._dtypes = []
@@ -1670,6 +1671,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
 
         # Invalidate cached value.
         self._gcps = None
+
+    def _set_rpcs(self, rpcs):
+        self.update_tags(ns='RPC', **rpcs)
 
 
 cdef class InMemoryRaster:

--- a/rasterio/_transform.pyx
+++ b/rasterio/_transform.pyx
@@ -6,13 +6,79 @@ include "gdal.pxi"
 import warnings
 
 from rasterio._err import GDALError
+from rasterio._err cimport exc_wrap_pointer
 from rasterio.errors import NotGeoreferencedWarning
+
+def _rpc_transformer(rpcs, xs, ys, zs, transform_direction=1, **kwargs):
+    cdef int i
+    cdef char **papszMD = NULL
+    cdef char **options = NULL
+    cdef GDALRPCInfo rpcinfo
+    cdef int src_count
+    cdef double *x = NULL
+    cdef double *y = NULL
+    cdef double *z = NULL
+    cdef void *pTransformArg = NULL
+    cdef int bReversed = 0
+    cdef int bDstToSrc = transform_direction
+    cdef double dfPixErrThreshold = 0.0
+    cdef int *success_ptr = NULL
+
+    src_count = len(xs)
+    n = len(xs)
+    x = <double *>CPLMalloc(n * sizeof(double))
+    y = <double *>CPLMalloc(n * sizeof(double))
+    z = <double *>CPLMalloc(n * sizeof(double))
+
+    for i in range(n):
+        x[i] = xs[i]
+        y[i] = ys[i]
+        z[i] = zs[i]
+
+    success_ptr = <int *>CPLMalloc(n * sizeof(int))
+
+
+    for key, val in rpcs.items():
+        key = key.upper().encode('utf-8')
+        val = str(val).upper().encode('utf-8')
+        papszMD = CSLSetNameValue(
+            papszMD, <const char *>key, <const char *>val)
+
+    for key, val in kwargs.items():
+        key = key.upper().encode('utf-8')
+        val = str(val).upper().encode('utf-8')
+        options = CSLSetNameValue(
+            options, <const char *>key, <const char *>val)
+    try:
+        GDALExtractRPCInfo(papszMD, &rpcinfo)
+        pTransformArg = exc_wrap_pointer(GDALCreateRPCTransformer(&rpcinfo, bReversed, dfPixErrThreshold, options))
+        err = GDALRPCTransform(pTransformArg, bDstToSrc, src_count, x, y, z, success_ptr)
+        if err == GDALError.failure:
+            warnings.warn(
+            "Could not transform points using RPCs",
+            NotGeoreferencedWarning)
+        res_xs = [0] * n
+        res_ys = [0] * n
+        res_zs = [0] * n
+        for i in range(n):
+            res_xs[i] = x[i]
+            res_ys[i] = y[i]
+            res_zs[i] = z[i]
+        return (res_xs, res_ys)
+    finally:
+        CPLFree(x)
+        CPLFree(y)
+        CPLFree(z)
+        CPLFree(success_ptr)
+        GDALDestroyRPCTransformer(pTransformArg)
+        CPLFree(options)
+        CPLFree(papszMD)
 
 def _transform_from_gcps(gcps):
     cdef double gt[6]
 
     cdef GDAL_GCP *gcplist = <GDAL_GCP *>CPLMalloc(len(gcps) * sizeof(GDAL_GCP))
-    
+
     try:
         for i, obj in enumerate(gcps):
             ident = str(i).encode('utf-8')

--- a/rasterio/_transform.pyx
+++ b/rasterio/_transform.pyx
@@ -38,7 +38,6 @@ def _rpc_transformer(rpcs, xs, ys, zs=None, transform_direction=1, **kwargs):
 
     success_ptr = <int *>CPLMalloc(n * sizeof(int))
 
-
     for key, val in rpcs.items():
         key = key.upper().encode('utf-8')
         val = str(val).upper().encode('utf-8')
@@ -65,15 +64,16 @@ def _rpc_transformer(rpcs, xs, ys, zs=None, transform_direction=1, **kwargs):
             res_xs[i] = x[i]
             res_ys[i] = y[i]
             res_zs[i] = z[i]
-        return (res_xs, res_ys)
     finally:
         CPLFree(x)
         CPLFree(y)
         CPLFree(z)
         CPLFree(success_ptr)
         GDALDestroyRPCTransformer(pTransformArg)
-        CPLFree(options)
-        CPLFree(papszMD)
+        CSLDestroy(options)
+        CSLDestroy(papszMD)
+
+    return (res_xs, res_ys)
 
 def _transform_from_gcps(gcps):
     cdef double gt[6]

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -714,6 +714,7 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         self._descriptions = ()
         self._crs = None
         self._gcps = None
+        self._rpcs = None
         self._read = False
 
         # The various `dst_*` parameters are deprecated and will be
@@ -860,7 +861,7 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
         if add_alpha:
 
             # Adding an alpha band when the source has one is trouble.
-            # It will result in suprisingly unmasked data. We will 
+            # It will result in suprisingly unmasked data. We will
             # raise an exception instead.
             if src_alpha_band:
                 raise WarpOptionsError(

--- a/rasterio/control.py
+++ b/rasterio/control.py
@@ -60,9 +60,10 @@ class GroundControlPoint(object):
                 'properties': self.asdict()}
 
 class RPC(dict):
+    """Dict structure to store Rational Polynomial Coefficients.
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    Provide methods to serialize and deserialize to gdal formatted metadata.
+    """
 
     def to_gdal(self):
         out = {}

--- a/rasterio/control.py
+++ b/rasterio/control.py
@@ -1,6 +1,7 @@
 """Ground control points"""
 
 import uuid
+from rasterio.compat import Iterable
 
 
 class GroundControlPoint(object):
@@ -57,3 +58,32 @@ class GroundControlPoint(object):
         return {'id': self.id, 'type': 'Feature',
                 'geometry': {'type': 'Point', 'coordinates': tuple(coords)},
                 'properties': self.asdict()}
+
+class RPC(dict):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def to_gdal(self):
+        out = {}
+
+        for key, val in self.items():
+            if isinstance(val, Iterable):
+                out[key] = ' '.join(map(str, val))
+            else:
+                out[key] = str(val)
+
+        return out
+
+    @classmethod
+    def from_gdal(cls, rpcs):
+        out = {}
+
+        for key, val in rpcs.items():
+            vals = val.split()
+            if len(vals) > 1:
+                out[key] = [float(v) for v in vals]
+            else:
+                out[key] = float(vals[0])
+
+        return cls(out)

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -187,6 +187,30 @@ cdef extern from "gdal.h" nogil:
         double dfGCPY
         double dfGCPZ
 
+    ctypedef struct GDALRPCInfo:
+        double dfLINE_OFF
+        double dfSAMP_OFF
+        double dfLAT_OFF
+        double dfLONG_OFF
+        double dfHEIGHT_OFF
+
+        double dfLINE_SCALE
+        double dfSAMP_SCALE
+        double dfLAT_SCALE
+        double dfLONG_SCALE
+        double dfHEIGHT_SCALE
+
+        double adfLINE_NUM_COEFF[20]
+        double adfLINE_DEN_COEFF[20]
+        double adfSAMP_NUM_COEFF[20]
+        double adfSAMP_DEN_COEFF[20]
+
+        double dfMIN_LONG
+        double dfMIN_LAT
+        double dfMAX_LONG
+        double dfMAX_LAT
+
+    int GDALExtractRPCInfo(char **papszMD, GDALRPCInfo * )
     void GDALAllRegister()
     void GDALDestroyDriverManager()
     int GDALGetDriverCount()
@@ -490,6 +514,13 @@ cdef extern from "gdalwarper.h" nogil:
 
 
 cdef extern from "gdal_alg.h" nogil:
+    void *GDALCreateRPCTransformer( GDALRPCInfo *psRPC, int bReversed,
+                          double dfPixErrThreshold,
+                          char **papszOptions )
+    void GDALDestroyRPCTransformer( void *pTransformArg )
+    int GDALRPCTransform(void *pTransformArg, int bDstToSrc,
+                         int nPointCount, double *x, double *y, double *z,
+                         int *panSuccess )
 
     int GDALPolygonize(GDALRasterBandH band, GDALRasterBandH mask_band,
                        OGRLayerH layer, int fidx, char **options,

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -3,6 +3,7 @@
 from __future__ import division
 
 import math
+from functools import wraps
 
 from affine import Affine
 
@@ -128,7 +129,7 @@ def array_bounds(height, width, transform):
     return w, s, e, n
 
 
-def xy(transform, rows, cols, offset='center'):
+def xy(transform, rows, cols, offset='center', rpcs=None):
     """Returns the x and y coordinates of pixels at `rows` and `cols`.
     The pixel's center is returned by default, but a corner can be returned
     by setting `offset` to one of `ul, ur, ll, lr`.
@@ -190,7 +191,7 @@ def xy(transform, rows, cols, offset='center'):
     return xs, ys
 
 
-def rowcol(transform, xs, ys, op=math.floor, precision=None):
+def rowcol(transform, xs, ys, op=math.floor, precision=None, rpcs=None):
     """
     Returns the rows and cols of the pixels containing (x, y) given a
     coordinate reference system.
@@ -235,10 +236,9 @@ def rowcol(transform, xs, ys, op=math.floor, precision=None):
     else:
         eps = 10.0 ** -precision * (1.0 - 2.0 * op(0.1))
 
-    invtransform = ~transform
-
     rows = []
     cols = []
+    invtransform = ~transform
     for x, y in zip(xs, ys):
         fcol, frow = invtransform * (x + eps, y - eps)
         cols.append(op(fcol))


### PR DESCRIPTION
Stemmed from #410, although with the realization that this does not address RPC usage for reprojection.

This PR provides an entry point to the `GDALGenImgProjTransformer2` object which can be used to create transform objects utilizing RPC metadata, as well as GCPs. Details can be found here https://gdal.org/api/gdal_alg.html#_CPPv432GDALCreateGenImgProjTransformer212GDALDatasetH12GDALDatasetHPPc

The intended use case of `GDALGenImgProjTransformer2` is to transform between pixel/line coordinates of two different datasets. Should one of `src` or `dst` but NULL/None, the transformation will instead be between pixel/line and geodetic coordinates.

My interest in bringing this functionality to rasterio is to be able to calculate line/pixel coordinates for  i.e. GeoJSON features for a RPC georeferenced SAR image. I'm not sure how useful this feature could be to the wider rasterio user base. This could then be a stepping off point for integrating RPC usage in reprojection.