### PR TITLE
Runner fixture

### DIFF
--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,13 +1,10 @@
 from pkg_resources import iter_entry_points
 
-from click.testing import CliRunner
-
 import rasterio
 from rasterio.rio.main import main_group
 
 
-def test_version():
-    runner = CliRunner()
+def test_version(runner):
     result = runner.invoke(main_group, ['--version'])
     assert result.exit_code == 0
     assert rasterio.__version__ in result.output

--- a/tests/test_data_paths.py
+++ b/tests/test_data_paths.py
@@ -2,7 +2,6 @@
 
 import os.path
 
-from click.testing import CliRunner
 import pytest
 
 import rasterio
@@ -37,8 +36,7 @@ def test_proj_data_has_data():
 
 @requires_gdal_lt_3
 @pytest.mark.wheel
-def test_env_gdal_data():
-    runner = CliRunner()
+def test_env_gdal_data(runner):
     result = runner.invoke(main_group, ['env', '--gdal-data'])
     assert result.exit_code == 0
     assert result.output.strip() == os.path.join(os.path.dirname(rasterio.__file__), 'gdal_data')
@@ -46,8 +44,7 @@ def test_env_gdal_data():
 
 @requires_gdal_lt_3
 @pytest.mark.wheel
-def test_env_proj_data():
-    runner = CliRunner()
+def test_env_proj_data(runner):
     result = runner.invoke(main_group, ['env', '--proj-data'])
     assert result.exit_code == 0
     assert result.output.strip() == os.path.join(os.path.dirname(rasterio.__file__), 'proj_data')

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -2,7 +2,6 @@ import sys
 import os
 import logging
 import numpy as np
-from click.testing import CliRunner
 
 import rasterio
 from rasterio.rio.main import main_group
@@ -114,9 +113,8 @@ def test_clip_overwrite_with_option(runner, tmpdir):
 
 # Tests: format and type conversion, --format and --dtype
 
-def test_format(tmpdir):
+def test_format(tmpdir, runner):
     outputname = str(tmpdir.join('test.jpg'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['convert', 'tests/data/RGB.byte.tif', outputname, '--format', 'JPEG'])
@@ -125,9 +123,8 @@ def test_format(tmpdir):
         assert src.driver == 'JPEG'
 
 
-def test_format_short(tmpdir):
+def test_format_short(tmpdir, runner):
     outputname = str(tmpdir.join('test.jpg'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['convert', 'tests/data/RGB.byte.tif', outputname, '-f', 'JPEG'])
@@ -136,9 +133,8 @@ def test_format_short(tmpdir):
         assert src.driver == 'JPEG'
 
 
-def test_output_opt(tmpdir):
+def test_output_opt(tmpdir, runner):
     outputname = str(tmpdir.join('test.jpg'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['convert', 'tests/data/RGB.byte.tif', '-o', outputname, '-f', 'JPEG'])
@@ -147,9 +143,8 @@ def test_output_opt(tmpdir):
         assert src.driver == 'JPEG'
 
 
-def test_dtype(tmpdir):
+def test_dtype(tmpdir, runner):
     outputname = str(tmpdir.join('test.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['convert', 'tests/data/RGB.byte.tif', outputname, '--dtype', 'uint16'])
@@ -158,10 +153,9 @@ def test_dtype(tmpdir):
         assert src.dtypes == tuple(['uint16'] * 3)
 
 
-def test_dtype_rescaling_uint8_full(tmpdir):
+def test_dtype_rescaling_uint8_full(tmpdir, runner):
     """Rescale uint8 [0, 255] to uint8 [0, 255]"""
     outputname = str(tmpdir.join('test.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['convert', 'tests/data/RGB.byte.tif', outputname, '--scale-ratio', '1.0'])
@@ -179,10 +173,9 @@ def test_dtype_rescaling_uint8_full(tmpdir):
             assert round(band.mean() - expected['mean'], 6) == 0.0
 
 
-def test_dtype_rescaling_uint8_half(tmpdir):
+def test_dtype_rescaling_uint8_half(tmpdir, runner):
     """Rescale uint8 [0, 255] to uint8 [0, 127]"""
     outputname = str(tmpdir.join('test.tif'))
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'convert', 'tests/data/RGB.byte.tif', outputname, '--scale-ratio', '0.5'])
     assert result.exit_code == 0
@@ -192,11 +185,10 @@ def test_dtype_rescaling_uint8_half(tmpdir):
             assert round(band.max() - 127, 6) == 0.0
 
 
-def test_dtype_rescaling_uint16(tmpdir):
+def test_dtype_rescaling_uint16(tmpdir, runner):
     """Rescale uint8 [0, 255] to uint16 [0, 4095]"""
     # NB: 255 * 16 is 4080, we don't actually get to 4095.
     outputname = str(tmpdir.join('test.tif'))
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'convert', 'tests/data/RGB.byte.tif', outputname, '--dtype', 'uint16',
         '--scale-ratio', '16'])
@@ -207,10 +199,9 @@ def test_dtype_rescaling_uint16(tmpdir):
             assert round(band.max() - 4080, 6) == 0.0
 
 
-def test_dtype_rescaling_float64(tmpdir):
+def test_dtype_rescaling_float64(tmpdir, runner):
     """Rescale uint8 [0, 255] to float64 [-1, 1]"""
     outputname = str(tmpdir.join('test.tif'))
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'convert', 'tests/data/RGB.byte.tif', outputname, '--dtype', 'float64',
         '--scale-ratio', str(2.0 / 255), '--scale-offset', '-1.0'])
@@ -221,9 +212,8 @@ def test_dtype_rescaling_float64(tmpdir):
             assert round(band.max() - 1.0, 6) == 0.0
 
 
-def test_rgb(tmpdir):
+def test_rgb(tmpdir, runner):
     outputname = str(tmpdir.join('test.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['convert', 'tests/data/RGB.byte.tif', outputname, '--rgb'])

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -4,7 +4,6 @@
 import json
 
 import click
-from click.testing import CliRunner
 import pytest
 
 import rasterio
@@ -39,26 +38,23 @@ class MockOption:
         self.name = name
 
 
-def test_delete_nodata_exclusive_opts(data):
+def test_delete_nodata_exclusive_opts(data, runner):
     """--unset-nodata and --nodata can't be used together"""
-    runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--unset-nodata', '--nodata', '0'])
     assert result.exit_code == 2
 
 
-def test_delete_crs_exclusive_opts(data):
+def test_delete_crs_exclusive_opts(data, runner):
     """--unset-crs and --crs can't be used together"""
-    runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--unset-crs', '--crs', 'epsg:4326'])
     assert result.exit_code == 2
 
 
-def test_edit_nodata_err(data):
-    runner = CliRunner()
+def test_edit_nodata_err(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(main_group,
                            ['edit-info', inputfile, '--nodata', '-1'])
@@ -66,17 +62,15 @@ def test_edit_nodata_err(data):
 
 
 @requires_gdal21
-def test_delete_nodata(data):
+def test_delete_nodata(data, runner):
     """Delete a dataset's nodata value"""
-    runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--unset-nodata'])
     assert result.exit_code == 0
 
 
-def test_edit_nodata(data):
-    runner = CliRunner()
+def test_edit_nodata(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--nodata', '255'])
@@ -85,16 +79,14 @@ def test_edit_nodata(data):
         assert src.nodata == 255.0
 
 
-def test_edit_crs_err(data):
-    runner = CliRunner()
+def test_edit_crs_err(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--crs', 'LOL:WUT'])
     assert result.exit_code == 2
 
 
-def test_edit_crs_epsg(data):
-    runner = CliRunner()
+def test_edit_crs_epsg(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--crs', 'EPSG:32618'])
@@ -103,8 +95,7 @@ def test_edit_crs_epsg(data):
         assert src.crs == {'init': 'epsg:32618'}
 
 
-def test_edit_crs_proj4(data):
-    runner = CliRunner()
+def test_edit_crs_proj4(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--crs', '+init=epsg:32618'])
@@ -113,8 +104,7 @@ def test_edit_crs_proj4(data):
         assert src.crs == {'init': 'epsg:32618'}
 
 
-def test_edit_crs_obj(data):
-    runner = CliRunner()
+def test_edit_crs_obj(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group,
@@ -124,24 +114,21 @@ def test_edit_crs_obj(data):
         assert src.crs.to_dict() == {'init': 'epsg:32618'}
 
 
-def test_edit_transform_err_not_json(data):
-    runner = CliRunner()
+def test_edit_transform_err_not_json(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--transform', 'LOL'])
     assert result.exit_code == 2
 
 
-def test_edit_transform_err_bad_array(data):
-    runner = CliRunner()
+def test_edit_transform_err_bad_array(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(
         main_group, ['edit-info', inputfile, '--transform', '[1,2]'])
     assert result.exit_code == 2
 
 
-def test_edit_transform_affine(data):
-    runner = CliRunner()
+def test_edit_transform_affine(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     input_t = '[300.038, 0.0, 101985.0, 0.0, -300.042, 2826915.0]'
     result = runner.invoke(
@@ -152,8 +139,7 @@ def test_edit_transform_affine(data):
             assert round(a, 6) == round(b, 6)
 
 
-def test_edit_transform_gdal(data):
-    runner = CliRunner()
+def test_edit_transform_gdal(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     gdal_geotransform = '[101985.0, 300.038, 0.0, 2826915.0, 0.0, -300.042]'
     result = runner.invoke(main_group, [
@@ -163,8 +149,7 @@ def test_edit_transform_gdal(data):
     assert gdal_geotransform in result.output
 
 
-def test_edit_tags(data):
-    runner = CliRunner()
+def test_edit_tags(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(main_group, [
         'edit-info', inputfile, '--tag', 'lol=1', '--tag', 'wut=2'])
@@ -175,9 +160,8 @@ def test_edit_tags(data):
 
 
 @requires_gdal21(reason="decription setting requires GDAL 2.1+")
-def test_edit_band_description(data):
+def test_edit_band_description(data, runner):
     """Edit band descriptions"""
-    runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(main_group, [
         'edit-info', inputfile, '--bidx', '3', '--description',
@@ -188,9 +172,8 @@ def test_edit_band_description(data):
         assert src.descriptions[2] == 'this is another test'
 
 
-def test_edit_units(data):
+def test_edit_units(data, runner):
     """Edit units"""
-    runner = CliRunner()
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(main_group, [
         'edit-info', inputfile, '--bidx', '1', '--units', 'DN'],
@@ -201,9 +184,7 @@ def test_edit_units(data):
         assert src.units[0] == 'DN'
 
 
-def test_edit_crs_like(data):
-    runner = CliRunner()
-
+def test_edit_crs_like(data, runner):
     # Set up the file to be edited.
     inputfile = str(data.join('RGB.byte.tif'))
     with rasterio.open(inputfile, 'r+') as dst:
@@ -226,9 +207,7 @@ def test_edit_crs_like(data):
         assert src.nodata == 1.0
 
 
-def test_edit_nodata_like(data):
-    runner = CliRunner()
-
+def test_edit_nodata_like(data, runner):
     # Set up the file to be edited.
     inputfile = str(data.join('RGB.byte.tif'))
     with rasterio.open(inputfile, 'r+') as dst:
@@ -251,9 +230,7 @@ def test_edit_nodata_like(data):
         assert src.nodata == 0.0
 
 
-def test_edit_all_like(data):
-    runner = CliRunner()
-
+def test_edit_all_like(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     with rasterio.open(inputfile, 'r+') as dst:
         dst.crs = {'init': 'epsg:32617'}
@@ -320,7 +297,6 @@ def test_all_callback_None(data):
 ))
 def test_colorinterp_wrong_band_count(runner, path_3band_no_colorinterp, setci):
     """Provide the wrong band count."""
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'edit-info', path_3band_no_colorinterp,
         '--colorinterp', setci])
@@ -333,9 +309,8 @@ def test_colorinterp_wrong_band_count(runner, path_3band_no_colorinterp, setci):
     ('RGB', (ColorInterp.red, ColorInterp.green, ColorInterp.blue)),
     ('red,green,blue', (ColorInterp.red, ColorInterp.green, ColorInterp.blue)),
 ])
-def test_colorinterp_rgb(setci, expected, path_3band_no_colorinterp):
+def test_colorinterp_rgb(setci, expected, path_3band_no_colorinterp, runner):
     """Set 3 band color interpretation."""
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'edit-info', path_3band_no_colorinterp,
         '--colorinterp', setci])
@@ -349,9 +324,8 @@ def test_colorinterp_rgb(setci, expected, path_3band_no_colorinterp):
     ('RGBA', (ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.alpha)),
     ('red,green,blue,alpha', (ColorInterp.red, ColorInterp.green, ColorInterp.blue, ColorInterp.alpha)),
 ])
-def test_colorinterp_4band(setci, expected, path_4band_no_colorinterp):
+def test_colorinterp_4band(setci, expected, path_4band_no_colorinterp, runner):
     """Set 4 band color interpretation."""
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'edit-info', path_4band_no_colorinterp,
         '--colorinterp', setci])
@@ -360,9 +334,8 @@ def test_colorinterp_4band(setci, expected, path_4band_no_colorinterp):
         assert src.colorinterp == expected
 
 
-def test_colorinterp_bad_instructions():
+def test_colorinterp_bad_instructions(runner):
     """Can't combine shorthand and normal band instructions."""
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'edit-info', 'path-to-something',
         '--colorinterp', 'RGB,alpha'])
@@ -370,9 +343,8 @@ def test_colorinterp_bad_instructions():
     assert "color interpretation 'RGB' is invalid"
 
 
-def test_colorinterp_like(path_4band_no_colorinterp, path_rgba_byte_tif):
+def test_colorinterp_like(path_4band_no_colorinterp, path_rgba_byte_tif, runner):
     """Set color interpretation from a ``--like`` image."""
-    runner = CliRunner()
     result = runner.invoke(main_group, [
         'edit-info', path_4band_no_colorinterp,
         '--like', path_rgba_byte_tif,

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -8,7 +8,6 @@ import pytest
 
 import rasterio
 from rasterio.enums import ColorInterp
-from rasterio.env import GDALVersion
 from rasterio.rio.edit_info import (
     all_handler, crs_handler, tags_handler, transform_handler,
     colorinterp_handler)
@@ -274,19 +273,19 @@ def test_like_handler_err(param):
         PARAM_HANDLER[param](ctx, MockOption(param), '?')
 
 
-def test_all_callback_pass(data):
+def test_all_callback_pass():
     ctx = MockContext()
     ctx.obj['like'] = {'transform': 'foo'}
     assert all_handler(ctx, None, None) is None
 
 
-def test_all_callback(data):
+def test_all_callback():
     ctx = MockContext()
     ctx.obj['like'] = {'transform': 'foo'}
     assert all_handler(ctx, None, True) == {'transform': 'foo'}
 
 
-def test_all_callback_None(data):
+def test_all_callback_None():
     ctx = MockContext()
     assert all_handler(ctx, None, None) is None
 
@@ -388,47 +387,47 @@ def test_colorinterp_like_all(
             ColorInterp.alpha)
 
 
-def test_transform_callback_pass(data):
+def test_transform_callback_pass():
     """Always return None if the value is None"""
     ctx = MockContext()
     ctx.obj['like'] = {'transform': 'foo'}
     assert transform_handler(ctx, MockOption('transform'), None) is None
 
 
-def test_transform_callback_err(data):
+def test_transform_callback_err():
     ctx = MockContext()
     ctx.obj['like'] = {'transform': 'foo'}
     with pytest.raises(click.BadParameter):
         transform_handler(ctx, MockOption('transform'), '?')
 
 
-def test_transform_callback(data):
+def test_transform_callback():
     ctx = MockContext()
     ctx.obj['like'] = {'transform': 'foo'}
     assert transform_handler(ctx, MockOption('transform'), 'like') == 'foo'
 
 
-def test_crs_callback_pass(data):
+def test_crs_callback_pass():
     """Always return None if the value is None."""
     ctx = MockContext()
     ctx.obj['like'] = {'crs': 'foo'}
     assert crs_handler(ctx, MockOption('crs'), None) is None
 
 
-def test_crs_callback(data):
+def test_crs_callback():
     ctx = MockContext()
     ctx.obj['like'] = {'crs': 'foo'}
     assert crs_handler(ctx, MockOption('crs'), 'like') == 'foo'
 
 
-def test_tags_callback_err(data):
+def test_tags_callback_err():
     ctx = MockContext()
     ctx.obj['like'] = {'tags': {'foo': 'bar'}}
     with pytest.raises(click.BadParameter):
         tags_handler(ctx, MockOption('tags'), '?') == {'foo': 'bar'}
 
 
-def test_tags_callback(data):
+def test_tags_callback():
     ctx = MockContext()
     ctx.obj['like'] = {'tags': {'foo': 'bar'}}
     assert tags_handler(ctx, MockOption('tags'), 'like') == {'foo': 'bar'}

--- a/tests/test_rio_gcp.py
+++ b/tests/test_rio_gcp.py
@@ -1,8 +1,5 @@
-import json
 import logging
 import sys
-
-import pytest
 
 from rasterio.rio.main import main_group
 
@@ -17,6 +14,7 @@ def test_feature_seq(runner):
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 3
     assert '-78' in result.output
+
 
 def test_collection(runner):
     """GeoJSON collections can be had, optionally"""

--- a/tests/test_rio_gcp.py
+++ b/tests/test_rio_gcp.py
@@ -2,7 +2,6 @@ import json
 import logging
 import sys
 
-from click.testing import CliRunner
 import pytest
 
 from rasterio.rio.main import main_group
@@ -11,18 +10,16 @@ from rasterio.rio.main import main_group
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def test_feature_seq():
+def test_feature_seq(runner):
     """GeoJSON sequence w/out RS is the default"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['gcps', 'tests/data/white-gemini-iv.vrt'])
     assert result.exit_code == 0
     assert result.output.count('"Feature"') == 3
     assert '-78' in result.output
 
-def test_collection():
+def test_collection(runner):
     """GeoJSON collections can be had, optionally"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--collection'])
     assert result.exit_code == 0
@@ -30,44 +27,39 @@ def test_collection():
     assert '-78' in result.output
 
 
-def test_feature_seq_indent_rs():
+def test_feature_seq_indent_rs(runner):
     """Indentation of a feature sequence succeeds with ascii RS option"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['gcps', 'tests/data/white-gemini-iv.vrt', '--indent', '2', '--rs'])
     assert result.exit_code == 0
 
 
-def test_feature_seq_indent_no_rs():
+def test_feature_seq_indent_no_rs(runner):
     """Indentation of a feature sequence fails without ascii RS option"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--indent', '2'])
     assert result.exit_code == 2
 
 
-def test_projected():
+def test_projected(runner):
     """Projected GeoJSON is an option"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--projected'])
     assert result.exit_code == 0
     assert '-78' not in result.output
 
 
-def test_feature_precision():
+def test_feature_precision(runner):
     """Coordinate rounding is an option"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--projected', '--precision', '1'])
     assert result.exit_code == 0
     assert '"x": 116792.0' in result.output
 
 
-def test_collection_precision():
+def test_collection_precision(runner):
     """Coordinate rounding is an option"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--collection', '--projected', '--precision', '1'])
     assert result.exit_code == 0
@@ -75,9 +67,8 @@ def test_collection_precision():
     assert '"x": 116792.0' in result.output
 
 
-def test_collection_geographic_precision():
+def test_collection_geographic_precision(runner):
     """Unrounded coordinates are an option"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['gcps', 'tests/data/white-gemini-iv.vrt', '--collection', '--projected'])
     assert result.exit_code == 0

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -2,10 +2,8 @@ import json
 
 import pytest
 
-import numpy as np
 import rasterio
 from rasterio.rio.main import main_group
-from rasterio.env import GDALVersion
 
 from .conftest import requires_gdal21, requires_gdal23
 

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -1,6 +1,5 @@
 import json
 
-from click.testing import CliRunner
 import pytest
 
 import numpy as np
@@ -15,8 +14,7 @@ with rasterio.Env() as env:
     HAVE_NETCDF = 'NetCDF' in env.drivers().keys()
 
 
-def test_env():
-    runner = CliRunner()
+def test_env(runner):
     result = runner.invoke(main_group, [
         'env',
         '--formats'
@@ -25,9 +23,8 @@ def test_env():
     assert 'GTiff' in result.output
 
 
-def test_info_err():
+def test_info_err(runner):
     """Trying to get info of a directory raises an exception"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['info', 'tests'])
     assert result.exit_code != 0
@@ -36,8 +33,7 @@ def test_info_err():
     assert 'not' in result.output and ' a valid input file' in result.output
 
 
-def test_info():
-    runner = CliRunner()
+def test_info(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif'])
     assert result.exit_code == 0
@@ -55,44 +51,39 @@ def test_info():
     assert info['crs'] is None
 
 
-def test_info_units():
+def test_info_units(runner):
     """Find a units item"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif'])
     assert result.exit_code == 0
     assert '"units": [null, null, null]' in result.output
 
 
-def test_info_indexes():
+def test_info_indexes(runner):
     """Find an indexes item"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif'])
     assert result.exit_code == 0
     assert '"indexes": [1, 2, 3]' in result.output
 
 
-def test_info_descriptions():
+def test_info_descriptions(runner):
     """Find description items"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif'])
     assert result.exit_code == 0
     assert '"descriptions"' in result.output
 
 
-def test_info_mask_flags():
+def test_info_mask_flags(runner):
     """Find description items"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif'])
     assert result.exit_code == 0
     assert '"mask_flags": [["nodata"], ["nodata"], ["nodata"]]' in result.output
 
 
-def test_info_verbose():
-    runner = CliRunner()
+def test_info_verbose(runner):
     result = runner.invoke(main_group, [
         '-v',
         'info',
@@ -101,8 +92,7 @@ def test_info_verbose():
     assert result.exit_code == 0
 
 
-def test_info_quiet():
-    runner = CliRunner()
+def test_info_quiet(runner):
     result = runner.invoke(main_group, [
         '-q',
         'info',
@@ -111,8 +101,7 @@ def test_info_quiet():
     assert result.exit_code == 0
 
 
-def test_info_gcps():
-    runner = CliRunner()
+def test_info_gcps(runner):
     result = runner.invoke(main_group, [
         'info',
         'tests/data/white-gemini-iv.vrt'
@@ -120,56 +109,49 @@ def test_info_gcps():
     assert result.exit_code == 0
 
 
-def test_info_count():
-    runner = CliRunner()
+def test_info_count(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif', '--count'])
     assert result.exit_code == 0
     assert result.output == '3\n'
 
 
-def test_info_nodatavals():
-    runner = CliRunner()
+def test_info_nodatavals(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif', '--bounds'])
     assert result.exit_code == 0
     assert result.output == '101985.0 2611485.0 339315.0 2826915.0\n'
 
 
-def test_info_tags():
-    runner = CliRunner()
+def test_info_tags(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif', '--tags'])
     assert result.exit_code == 0
     assert result.output == '{"AREA_OR_POINT": "Area"}\n'
 
 
-def test_info_res():
-    runner = CliRunner()
+def test_info_res(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif', '--res'])
     assert result.exit_code == 0
     assert result.output.startswith('300.037')
 
 
-def test_info_lnglat():
-    runner = CliRunner()
+def test_info_lnglat(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif', '--lnglat'])
     assert result.exit_code == 0
     assert result.output.startswith('-77.757')
 
 
-def test_mo_info():
-    runner = CliRunner()
+def test_mo_info(runner):
     result = runner.invoke(main_group, ['info', 'tests/data/RGB.byte.tif'])
     assert result.exit_code == 0
     assert '"res": [300.037' in result.output
     assert '"lnglat": [-77.757' in result.output
 
 
-def test_info_stats():
-    runner = CliRunner()
+def test_info_stats(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif', '--tell-me-more'])
     assert result.exit_code == 0
@@ -178,8 +160,7 @@ def test_info_stats():
     assert '"mean": 44.4344' in result.output
 
 
-def test_info_stats_only():
-    runner = CliRunner()
+def test_info_stats_only(runner):
     result = runner.invoke(
         main_group,
         ['info', 'tests/data/RGB.byte.tif', '--stats', '--bidx', '2'])
@@ -187,23 +168,20 @@ def test_info_stats_only():
     assert result.output.startswith('1.000000 255.000000 66.02')
 
 
-def test_info_colorinterp():
-    runner = CliRunner()
+def test_info_colorinterp(runner):
     result = runner.invoke(main_group, ['info', 'tests/data/alpha.tif'])
     assert result.exit_code == 0
     assert '"colorinterp": ["red", "green", "blue", "alpha"]' in result.output
 
 
-def test_transform_err():
-    runner = CliRunner()
+def test_transform_err(runner):
     result = runner.invoke(main_group, [
         'transform'
     ], "[-78.0]")
     assert result.exit_code == 1
 
 
-def test_transform_point():
-    runner = CliRunner()
+def test_transform_point(runner):
     result = runner.invoke(main_group, [
         'transform',
         '--dst-crs', 'EPSG:32618',
@@ -213,8 +191,7 @@ def test_transform_point():
     assert result.output.strip() == '[192457.13, 2546667.68]'
 
 
-def test_transform_point_dst_file():
-    runner = CliRunner()
+def test_transform_point_dst_file(runner):
     result = runner.invoke(main_group, [
         'transform',
         '--dst-crs', 'tests/data/RGB.byte.tif', '--precision', '2'
@@ -223,8 +200,7 @@ def test_transform_point_dst_file():
     assert result.output.strip() == '[192457.13, 2546667.68]'
 
 
-def test_transform_point_src_file():
-    runner = CliRunner()
+def test_transform_point_src_file(runner):
     result = runner.invoke(main_group, [
         'transform',
         '--src-crs',
@@ -235,8 +211,7 @@ def test_transform_point_src_file():
     assert result.output.strip() == '[-78.0, 23.0]'
 
 
-def test_transform_point_2():
-    runner = CliRunner()
+def test_transform_point_2(runner):
     result = runner.invoke(main_group, [
         'transform',
         '[-78.0, 23.0]',
@@ -247,8 +222,7 @@ def test_transform_point_2():
     assert result.output.strip() == '[192457.13, 2546667.68]'
 
 
-def test_transform_point_multi():
-    runner = CliRunner()
+def test_transform_point_multi(runner):
     result = runner.invoke(main_group, [
         'transform',
         '--dst-crs', 'EPSG:32618',
@@ -259,8 +233,7 @@ def test_transform_point_multi():
         '[192457.13, 2546667.68]\n[192457.13, 2546667.68]')
 
 
-def test_bounds_defaults():
-    runner = CliRunner()
+def test_bounds_defaults(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif'
@@ -269,8 +242,7 @@ def test_bounds_defaults():
     assert 'FeatureCollection' in result.output
 
 
-def test_bounds_err():
-    runner = CliRunner()
+def test_bounds_err(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests'
@@ -278,8 +250,7 @@ def test_bounds_err():
     assert result.exit_code == 1
 
 
-def test_bounds_feature():
-    runner = CliRunner()
+def test_bounds_feature(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -289,8 +260,7 @@ def test_bounds_feature():
     assert result.output.count('Polygon') == 1
 
 
-def test_bounds_obj_bbox():
-    runner = CliRunner()
+def test_bounds_obj_bbox(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -301,8 +271,7 @@ def test_bounds_obj_bbox():
     assert result.output.strip() == '[-78.96, 23.56, -76.57, 25.55]'
 
 
-def test_bounds_compact():
-    runner = CliRunner()
+def test_bounds_compact(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -314,8 +283,7 @@ def test_bounds_compact():
     assert result.output.strip() == '[-78.96,23.56,-76.57,25.55]'
 
 
-def test_bounds_indent():
-    runner = CliRunner()
+def test_bounds_indent(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -327,8 +295,7 @@ def test_bounds_indent():
     assert len(result.output.split('\n')) == 7
 
 
-def test_bounds_obj_bbox_mercator():
-    runner = CliRunner()
+def test_bounds_obj_bbox_mercator(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -341,8 +308,7 @@ def test_bounds_obj_bbox_mercator():
         '[-8789636.708, 2700489.278, -8524281.514, 2943560.235]')
 
 
-def test_bounds_obj_bbox_projected():
-    runner = CliRunner()
+def test_bounds_obj_bbox_projected(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -355,8 +321,7 @@ def test_bounds_obj_bbox_projected():
         '[101985.0, 2611485.0, 339315.0, 2826915.0]')
 
 
-def test_bounds_crs_bbox():
-    runner = CliRunner()
+def test_bounds_crs_bbox(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -369,8 +334,7 @@ def test_bounds_crs_bbox():
         '[101985.0, 2611485.0, 339315.0, 2826915.0]')
 
 
-def test_bounds_seq():
-    runner = CliRunner()
+def test_bounds_seq(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -394,8 +358,7 @@ def test_bounds_seq():
     assert '\x1e' not in result.output
 
 
-def test_bounds_seq_rs():
-    runner = CliRunner()
+def test_bounds_seq_rs(runner):
     result = runner.invoke(main_group, [
         'bounds',
         'tests/data/RGB.byte.tif',
@@ -411,28 +374,24 @@ def test_bounds_seq_rs():
         '\x1e[-78.96, 23.56, -76.57, 25.55]\n')
 
 
-def test_insp():
-    runner = CliRunner()
+def test_insp(runner):
     result = runner.invoke(main_group, ['insp', 'tests/data/RGB.byte.tif'])
     assert result.exit_code == 0
 
 
-def test_insp_err():
-    runner = CliRunner()
+def test_insp_err(runner):
     result = runner.invoke(main_group, ['insp', 'tests'])
     assert result.exit_code != 0
 
 
-def test_info_checksums():
-    runner = CliRunner()
+def test_info_checksums(runner):
     result = runner.invoke(
         main_group, ['info', 'tests/data/RGB.byte.tif', '--tell-me-more'])
     assert result.exit_code == 0
     assert '"checksum": [25420, 29131, 37860]' in result.output
 
 
-def test_info_checksums_only():
-    runner = CliRunner()
+def test_info_checksums_only(runner):
     result = runner.invoke(
         main_group,
         ['info', 'tests/data/RGB.byte.tif', '--checksum', '--bidx', '2'])
@@ -443,8 +402,7 @@ def test_info_checksums_only():
 @requires_gdal21(reason="NetCDF requires GDAL 2.1+")
 @pytest.mark.skipif(not HAVE_NETCDF,
                     reason="GDAL not compiled with NetCDF driver.")
-def test_info_subdatasets():
-    runner = CliRunner()
+def test_info_subdatasets(runner):
     result = runner.invoke(
         main_group,
         ['info', 'netcdf:tests/data/RGB.nc', '--subdatasets'])
@@ -453,11 +411,10 @@ def test_info_subdatasets():
     assert result.output.startswith('netcdf:tests/data/RGB.nc:Band1')
 
 
-def test_info_no_credentials(tmpdir, monkeypatch):
+def test_info_no_credentials(tmpdir, monkeypatch, runner):
     credentials_file = tmpdir.join('credentials')
     monkeypatch.setenv('AWS_SHARED_CREDENTIALS_FILE', str(credentials_file))
     monkeypatch.delenv('AWS_ACCESS_KEY_ID', raising=False)
-    runner = CliRunner()
     result = runner.invoke(
         main_group,
         ['info', 'tests/data/RGB.byte.tif'])
@@ -466,8 +423,7 @@ def test_info_no_credentials(tmpdir, monkeypatch):
 
 @requires_gdal23(reason="Unsigned S3 requests require GDAL ~= 2.3")
 @pytest.mark.network
-def test_info_aws_unsigned():
+def test_info_aws_unsigned(runner):
     """Unsigned access to public dataset works (see #1637)"""
-    runner = CliRunner()
     result = runner.invoke(main_group, ['--aws-no-sign-requests', 'info', 's3://landsat-pds/L8/139/045/LC81390452014295LGN00/LC81390452014295LGN00_B1.TIF'])
     assert result.exit_code == 0

--- a/tests/test_rio_main.py
+++ b/tests/test_rio_main.py
@@ -2,7 +2,6 @@ import logging
 import sys
 
 from packaging.version import parse
-import pytest
 
 from rasterio.rio.main import main_group
 
@@ -10,13 +9,13 @@ from rasterio.rio.main import main_group
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def test_version(data, runner):
+def test_version(runner):
     result = runner.invoke(main_group, ['--version'])
     assert result.exit_code == 0
     assert parse(result.output.strip())
 
 
-def test_gdal_version(data, runner):
+def test_gdal_version(runner):
     result = runner.invoke(main_group, ['--gdal-version'])
     assert result.exit_code == 0
     assert parse(result.output.strip())

--- a/tests/test_rio_main.py
+++ b/tests/test_rio_main.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 
-from click.testing import CliRunner
 from packaging.version import parse
 import pytest
 
@@ -11,15 +10,13 @@ from rasterio.rio.main import main_group
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def test_version(data):
-    runner = CliRunner()
+def test_version(data, runner):
     result = runner.invoke(main_group, ['--version'])
     assert result.exit_code == 0
     assert parse(result.output.strip())
 
 
-def test_gdal_version(data):
-    runner = CliRunner()
+def test_gdal_version(data, runner):
     result = runner.invoke(main_group, ['--gdal-version'])
     assert result.exit_code == 0
     assert parse(result.output.strip())

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -6,7 +6,6 @@ import os
 import logging
 
 import affine
-from click.testing import CliRunner
 import numpy as np
 from pytest import fixture
 import pytest
@@ -100,7 +99,7 @@ def test_data_dir_3(tmpdir):
     return tmpdir
 
 
-def test_merge_with_colormap(test_data_dir_1):
+def test_merge_with_colormap(test_data_dir_1, runner):
     outputname = str(test_data_dir_1.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_1.listdir()]
     inputs.sort()
@@ -109,7 +108,6 @@ def test_merge_with_colormap(test_data_dir_1):
         with rasterio.open(inputname, 'r+') as src:
             src.write_colormap(1, {0: (255, 0, 0, 255), 255: (0, 0, 0, 255)})
 
-    runner = CliRunner()
     result = runner.invoke(main_group, ['merge'] + inputs + [outputname])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
@@ -122,11 +120,10 @@ def test_merge_with_colormap(test_data_dir_1):
 
 @requires_gdal22(
     reason="This test is sensitive to pixel values and requires GDAL 2.2+")
-def test_merge_with_nodata(test_data_dir_1):
+def test_merge_with_nodata(test_data_dir_1, runner):
     outputname = str(test_data_dir_1.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_1.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(main_group, ['merge'] + inputs + [outputname])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
@@ -140,22 +137,20 @@ def test_merge_with_nodata(test_data_dir_1):
 
 
 @pytest.mark.filterwarnings("ignore:Input file's nodata value")
-def test_merge_error(test_data_dir_1):
+def test_merge_error(test_data_dir_1, runner):
     """A nodata value outside the valid range results in an error"""
     outputname = str(test_data_dir_1.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_1.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['merge'] + inputs + [outputname] + ['--nodata', '-1'])
     assert result.exit_code
 
 
-def test_merge_bidx(test_data_dir_3):
+def test_merge_bidx(test_data_dir_3, runner):
     outputname = str(test_data_dir_3.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_3.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['merge'] + inputs + [outputname] + ['--bidx', '1'])
     assert result.exit_code == 0
@@ -168,11 +163,10 @@ def test_merge_bidx(test_data_dir_3):
 
 @requires_gdal22(
     reason="This test is sensitive to pixel values and requires GDAL 2.2+")
-def test_merge_without_nodata(test_data_dir_2):
+def test_merge_without_nodata(test_data_dir_2, runner):
     outputname = str(test_data_dir_2.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_2.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(main_group, ['merge'] + inputs + [outputname])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
@@ -185,9 +179,8 @@ def test_merge_without_nodata(test_data_dir_2):
         assert np.all(data == expected)
 
 
-def test_merge_output_exists(tmpdir):
+def test_merge_output_exists(tmpdir, runner):
     outputname = str(tmpdir.join('merged.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['merge', 'tests/data/RGB.byte.tif', outputname])
     assert result.exit_code == 0
@@ -198,9 +191,8 @@ def test_merge_output_exists(tmpdir):
         assert out.count == 3
 
 
-def test_merge_output_exists_without_nodata_fails(test_data_dir_2):
+def test_merge_output_exists_without_nodata_fails(test_data_dir_2, runner):
     """Fails without --overwrite"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'merge', str(test_data_dir_2.join('a.tif')),
@@ -208,9 +200,8 @@ def test_merge_output_exists_without_nodata_fails(test_data_dir_2):
     assert result.exit_code == 1
 
 
-def test_merge_output_exists_without_nodata(test_data_dir_2):
+def test_merge_output_exists_without_nodata(test_data_dir_2, runner):
     """Succeeds with --overwrite"""
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'merge', '--overwrite', str(test_data_dir_2.join('a.tif')),
@@ -218,16 +209,14 @@ def test_merge_output_exists_without_nodata(test_data_dir_2):
     assert result.exit_code == 0
 
 
-def test_merge_err():
-    runner = CliRunner()
+def test_merge_err(runner):
     result = runner.invoke(
         main_group, ['merge', 'tests'])
     assert result.exit_code == 1
 
 
-def test_format_jpeg(tmpdir):
+def test_format_jpeg(tmpdir, runner):
     outputname = str(tmpdir.join('stacked.jpg'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'merge', 'tests/data/RGB.byte.tif', outputname,
@@ -265,11 +254,10 @@ def test_data_dir_overlapping(tmpdir):
     return tmpdir
 
 
-def test_merge_overlapping(test_data_dir_overlapping):
+def test_merge_overlapping(test_data_dir_overlapping, runner):
     outputname = str(test_data_dir_overlapping.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_overlapping.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(main_group, ['merge'] + inputs + [outputname])
     assert result.exit_code == 0
     assert os.path.exists(outputname)
@@ -313,11 +301,10 @@ def test_data_dir_float(tmpdir):
 
 @requires_gdal22(
     reason="This test is sensitive to pixel values and requires GDAL 2.2+")
-def test_merge_float(test_data_dir_float):
+def test_merge_float(test_data_dir_float, runner):
     outputname = str(test_data_dir_float.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_float.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['merge'] + inputs + [outputname] + ['--nodata', '-1.5'])
     assert result.exit_code == 0
@@ -369,11 +356,10 @@ def tiffs(tmpdir):
     return tmpdir
 
 
-def test_merge_tiny_base(tiffs):
+def test_merge_tiny_base(tiffs, runner):
     outputname = str(tiffs.join('merged.tif'))
     inputs = [str(x) for x in tiffs.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(main_group, ['merge'] + inputs + [outputname])
     assert result.exit_code == 0
 
@@ -393,11 +379,10 @@ def test_merge_tiny_base(tiffs):
         assert data[0][3][0] == 40
 
 
-def test_merge_tiny_output_opt(tiffs):
+def test_merge_tiny_output_opt(tiffs, runner):
     outputname = str(tiffs.join('merged.tif'))
     inputs = [str(x) for x in tiffs.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(main_group, ['merge'] + inputs + ['-o', outputname])
     assert result.exit_code == 0
 
@@ -420,11 +405,10 @@ def test_merge_tiny_output_opt(tiffs):
     reason="This test is sensitive to pixel values and requires GDAL 2.2+")
 @pytest.mark.xfail(sys.version_info < (3,),
                    reason="Test is sensitive to rounding behavior")
-def test_merge_tiny_res_bounds(tiffs):
+def test_merge_tiny_res_bounds(tiffs, runner):
     outputname = str(tiffs.join('merged.tif'))
     inputs = [str(x) for x in tiffs.listdir()]
     inputs.sort()
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['merge'] + inputs + [outputname, '--res', 2, '--bounds', '1, 0, 5, 4'])
     assert result.exit_code == 0
@@ -442,7 +426,7 @@ def test_merge_tiny_res_bounds(tiffs):
         assert data[0, 1, 1] == 0
 
 
-def test_merge_rgb(tmpdir):
+def test_merge_rgb(tmpdir, runner):
     """Get back original image"""
     outputname = str(tmpdir.join('merged.tif'))
     inputs = [
@@ -450,7 +434,6 @@ def test_merge_rgb(tmpdir):
         'tests/data/rgb2.tif',
         'tests/data/rgb3.tif',
         'tests/data/rgb4.tif']
-    runner = CliRunner()
     result = runner.invoke(main_group, ['merge'] + inputs + [outputname])
     assert result.exit_code == 0
 

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -3,7 +3,6 @@
 
 import sys
 import os
-import logging
 
 import affine
 import numpy as np

--- a/tests/test_rio_overview.py
+++ b/tests/test_rio_overview.py
@@ -3,7 +3,6 @@ import sys
 
 import pytest
 
-import rasterio
 from rasterio.rio.main import main_group as cli
 from rasterio.rio.overview import get_maximum_overview_level
 

--- a/tests/test_rio_overview.py
+++ b/tests/test_rio_overview.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 
-from click.testing import CliRunner
 import pytest
 
 import rasterio
@@ -12,16 +11,14 @@ from rasterio.rio.overview import get_maximum_overview_level
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def test_err(data):
-    runner = CliRunner()
+def test_err(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(cli, ['overview', inputfile, '--build', 'a^2'])
     assert result.exit_code == 2
     assert "must match" in result.output
 
 
-def test_ls_none(data):
-    runner = CliRunner()
+def test_ls_none(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(cli, ['overview', inputfile, '--ls'])
     assert result.exit_code == 0
@@ -29,8 +26,7 @@ def test_ls_none(data):
     assert result.output == expected
 
 
-def test_build_ls(data):
-    runner = CliRunner()
+def test_build_ls(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(cli, ['overview', inputfile, '--build', '2,4,8'])
     assert result.exit_code == 0
@@ -40,8 +36,7 @@ def test_build_ls(data):
     assert result.output.endswith(expected)
 
 
-def test_build_pow_ls(data):
-    runner = CliRunner()
+def test_build_pow_ls(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(cli, ['overview', inputfile, '--build', '2^1..3'])
     assert result.exit_code == 0
@@ -51,8 +46,7 @@ def test_build_pow_ls(data):
     assert result.output.endswith(expected)
 
 
-def test_rebuild_ls(data):
-    runner = CliRunner()
+def test_rebuild_ls(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
 
     result = runner.invoke(
@@ -70,15 +64,13 @@ def test_rebuild_ls(data):
     assert result.output.endswith(expected)
 
 
-def test_no_args(data):
-    runner = CliRunner()
+def test_no_args(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(cli, ['overview', inputfile])
     assert result.exit_code == 2
 
 
-def test_build_auto_ls(data):
-    runner = CliRunner()
+def test_build_auto_ls(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     result = runner.invoke(cli, ['overview', inputfile, '--build', 'auto'])
     assert result.exit_code == 0

--- a/tests/test_rio_sample.py
+++ b/tests/test_rio_sample.py
@@ -1,9 +1,6 @@
 import logging
 import sys
 
-import click
-
-import rasterio
 from rasterio.rio.main import main_group
 
 

--- a/tests/test_rio_sample.py
+++ b/tests/test_rio_sample.py
@@ -2,7 +2,6 @@ import logging
 import sys
 
 import click
-from click.testing import CliRunner
 
 import rasterio
 from rasterio.rio.main import main_group
@@ -11,8 +10,7 @@ from rasterio.rio.main import main_group
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
-def test_sample_err():
-    runner = CliRunner()
+def test_sample_err(runner):
     result = runner.invoke(
         main_group,
         ['sample', 'bogus.tif'],
@@ -20,8 +18,7 @@ def test_sample_err():
     assert result.exit_code == 1
 
 
-def test_sample_stdin():
-    runner = CliRunner()
+def test_sample_stdin(runner):
     result = runner.invoke(
         main_group,
         ['sample', 'tests/data/RGB.byte.tif'],
@@ -31,8 +28,7 @@ def test_sample_stdin():
     assert result.output.strip() == '[18, 25, 14]\n[18, 25, 14]'
 
 
-def test_sample_arg():
-    runner = CliRunner()
+def test_sample_arg(runner):
     result = runner.invoke(
         main_group,
         ['sample', 'tests/data/RGB.byte.tif', "[220650.0, 2719200.0]"],
@@ -41,8 +37,7 @@ def test_sample_arg():
     assert result.output.strip() == '[18, 25, 14]'
 
 
-def test_sample_bidx():
-    runner = CliRunner()
+def test_sample_bidx(runner):
     result = runner.invoke(
         main_group,
         ['sample', 'tests/data/RGB.byte.tif', '--bidx', '1,2', "[220650.0, 2719200.0]"],
@@ -51,8 +46,7 @@ def test_sample_bidx():
     assert result.output.strip() == '[18, 25]'
 
 
-def test_sample_bidx2():
-    runner = CliRunner()
+def test_sample_bidx2(runner):
     result = runner.invoke(
         main_group,
         ['sample', 'tests/data/RGB.byte.tif', '--bidx', '1..2', "[220650.0, 2719200.0]"],
@@ -61,8 +55,7 @@ def test_sample_bidx2():
     assert result.output.strip() == '[18, 25]'
 
 
-def test_sample_bidx3():
-    runner = CliRunner()
+def test_sample_bidx3(runner):
     result = runner.invoke(
         main_group,
         ['sample', 'tests/data/RGB.byte.tif', '--bidx', '..2', "[220650.0, 2719200.0]"],
@@ -71,8 +64,7 @@ def test_sample_bidx3():
     assert result.output.strip() == '[18, 25]'
 
 
-def test_sample_bidx4():
-    runner = CliRunner()
+def test_sample_bidx4(runner):
     result = runner.invoke(
         main_group,
         ['sample', 'tests/data/RGB.byte.tif', '--bidx', '3', "[220650.0, 2719200.0]"],

--- a/tests/test_rio_stack.py
+++ b/tests/test_rio_stack.py
@@ -1,13 +1,10 @@
-from click.testing import CliRunner
-
 import rasterio
 from rasterio.rio.main import main_group
 from rasterio.rio.stack import stack
 
 
-def test_stack(tmpdir):
+def test_stack(tmpdir, runner):
     outputname = str(tmpdir.join('stacked.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, ['stack', 'tests/data/RGB.byte.tif', outputname])
     assert result.exit_code == 0
@@ -16,9 +13,8 @@ def test_stack(tmpdir):
         assert out.read(1).max() > 0
 
 
-def test_stack_list(tmpdir):
+def test_stack_list(tmpdir, runner):
     outputname = str(tmpdir.join('stacked.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'stack', 'tests/data/RGB.byte.tif', '--bidx', '1,2,3', outputname])
@@ -27,9 +23,8 @@ def test_stack_list(tmpdir):
         assert out.count == 3
 
 
-def test_stack_slice(tmpdir):
+def test_stack_slice(tmpdir, runner):
     outputname = str(tmpdir.join('stacked.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'stack',
@@ -41,9 +36,8 @@ def test_stack_slice(tmpdir):
         assert out.count == 3
 
 
-def test_stack_single_slice(tmpdir):
+def test_stack_single_slice(tmpdir, runner):
     outputname = str(tmpdir.join('stacked.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'stack',
@@ -55,9 +49,8 @@ def test_stack_single_slice(tmpdir):
         assert out.count == 3
 
 
-def test_format_jpeg(tmpdir):
+def test_format_jpeg(tmpdir, runner):
     outputname = str(tmpdir.join('stacked.jpg'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'stack', 'tests/data/RGB.byte.tif', outputname,
@@ -65,9 +58,8 @@ def test_format_jpeg(tmpdir):
     assert result.exit_code == 0
 
 
-def test_error(tmpdir):
+def test_error(tmpdir, runner):
     outputname = str(tmpdir.join('stacked.tif'))
-    runner = CliRunner()
     result = runner.invoke(
         main_group, [
             'stack', 'tests/data/RGB.byte.tif', outputname,

--- a/tests/test_rio_stack.py
+++ b/tests/test_rio_stack.py
@@ -1,6 +1,5 @@
 import rasterio
 from rasterio.rio.main import main_group
-from rasterio.rio.stack import stack
 
 
 def test_stack(tmpdir, runner):


### PR DESCRIPTION
This PR makes the use of the `runner` test fixture consistent throughout all tests instead of having some tests declare their own `runner = CliRunner()` inside the test function.
(see this comment https://github.com/mapbox/rasterio/pull/1836#issuecomment-559016620 for more info)

I also fixed basic linting warnings (unused imports and unused arguments) on the files that I edited for this PR, I hope you don't mind.
