### PR TITLE
Rewrite path parsing logic to handle "SENTINEL2_L1C:" paths

### DIFF
--- a/rasterio/compat.py
+++ b/rasterio/compat.py
@@ -15,6 +15,8 @@ if sys.version_info[0] >= 3:   # pragma: no cover
     from collections import UserDict
     from collections.abc import Iterable, Mapping
     from inspect import getfullargspec as getargspec
+    from pathlib import Path
+
 else:  # pragma: no cover
     warnings.warn("Python 2 compatibility will be removed after version 1.1", DeprecationWarning)
     string_types = basestring,
@@ -26,3 +28,5 @@ else:  # pragma: no cover
     from UserDict import UserDict
     from inspect import getargspec
     from collections import Iterable, Mapping
+    class Path(object):
+        pass

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -110,3 +110,7 @@ class OverviewCreationError(RasterioError):
 
 class DatasetAttributeError(RasterioError, NotImplementedError):
     """Raised when dataset attributes are misused"""
+
+
+class PathError(RasterioError):
+    """Raised when a dataset path is malformed or invalid"""

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -154,16 +154,6 @@ def parse_path(path):
             return ParsedPath.from_uri(path)
 
     return UnparsedPath(path)
-#        else:
-#            return UnparsedPath(path)
-#
-#    else:
-#
-#        if os.path.exists(path):
-#            return ParsedPath(path, None, None)
-#
-#        else:
-#            return UnparsedPath(path)
 
 
 def vsi_path(path):

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -1,11 +1,14 @@
 """Dataset paths, identifiers, and filenames"""
 
+import os.path
 import re
 import sys
 
 import attr
 
+from rasterio.compat import Path as PathlibPath
 from rasterio.compat import urlparse
+from rasterio.errors import PathError
 
 # Supported URI schemes and their mapping to GDAL's VSI suffix.
 # TODO: extend for other cloud plaforms.
@@ -121,25 +124,46 @@ def parse_path(path):
     -----
     When legacy GDAL filenames are encountered, they will be returned
     in a UnparsedPath.
+
     """
-    # Windows drive letters (e.g. "C:\") confuse `urlparse` as they look like
-    # URL schemes
-    if sys.platform == "win32" and re.match("^[a-zA-Z]\\:", path):
-        return UnparsedPath(path)
+    if isinstance(path, Path):
+        return path
 
-    elif path.startswith('/vsi'):
-        return UnparsedPath(path)
+    elif isinstance(path, PathlibPath):
+        return ParsedPath(path, None, None)
 
-    else:
-        parts = urlparse(path)
+    elif isinstance(path, str):
 
-        # if the scheme is not one of Rasterio's supported schemes, we
-        # return an UnparsedPath.
-        if parts.scheme and not all(p in SCHEMES for p in parts.scheme.split('+')):
+        if sys.platform == "win32" and re.match("^[a-zA-Z]\\:", path):
+            return UnparsedPath(path)
+
+        elif path.startswith('/vsi'):
             return UnparsedPath(path)
 
         else:
+            parts = urlparse(path)
+
+    else:
+        raise PathError("invalid path '{!r}'".format(path))
+
+    # if the scheme is not one of Rasterio's supported schemes, we
+    # return an UnparsedPath.
+    if parts.scheme:
+
+        if all(p in SCHEMES for p in parts.scheme.split('+')):
             return ParsedPath.from_uri(path)
+
+    return UnparsedPath(path)
+#        else:
+#            return UnparsedPath(path)
+#
+#    else:
+#
+#        if os.path.exists(path):
+#            return ParsedPath(path, None, None)
+#
+#        else:
+#            return UnparsedPath(path)
 
 
 def vsi_path(path):

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -7,7 +7,7 @@ import sys
 import attr
 
 from rasterio.compat import Path as PathlibPath
-from rasterio.compat import urlparse
+from rasterio.compat import string_types, urlparse
 from rasterio.errors import PathError
 
 # Supported URI schemes and their mapping to GDAL's VSI suffix.
@@ -132,7 +132,7 @@ def parse_path(path):
     elif isinstance(path, PathlibPath):
         return ParsedPath(path, None, None)
 
-    elif isinstance(path, str):
+    elif isinstance(path, string_types):
 
         if sys.platform == "win32" and re.match("^[a-zA-Z]\\:", path):
             return UnparsedPath(path)

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -111,8 +111,13 @@ def file_in_handler(ctx, param, value):
     """Normalize ordinary filesystem and VFS paths"""
     try:
         path = parse_path(value)
+
         if isinstance(path, UnparsedPath):
-            return path.name
+
+            if os.path.exists(path.path) and rasterio.shutil.exists(value):
+                return abspath_forward_slashes(path.path)
+            else:
+                return path.name
 
         elif path.scheme and path.is_remote:
             return path.name

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -32,8 +32,6 @@ def test_info_err():
         main_group, ['info', 'tests'])
     assert result.exit_code != 0
     assert result.exception
-    # Note: text of exception changed after 2.1, don't test on full string
-    assert 'not' in result.output and ' a valid input file' in result.output
 
 
 def test_info():

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -64,7 +64,7 @@ def test_file_in_handler_no_vfs_nonexistent():
     """file does not exist"""
     ctx = MockContext()
     with pytest.raises(click.BadParameter):
-        file_in_handler(ctx, 'INPUT', '{0}.tif'.format(uuid.uuid4()))
+        file_in_handler(ctx, 'INPUT', 'file://{0}.tif'.format(uuid.uuid4()))
 
 
 def test_file_in_handler_no_vfs():


### PR DESCRIPTION
Resolves #1786

Has a small consequence for the CLI file_in_handler: we can no longer fail early on some kinds of given paths.