### PR TITLE
Properly declare int8 pixel types to GDAL

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1746,6 +1746,7 @@ cdef class InMemoryRaster:
         cdef OGRSpatialReferenceH osr = NULL
         cdef GDALDriverH mdriver = NULL
         cdef GDAL_GCP *gcplist = NULL
+        cdef char **options = NULL
 
         if image is not None:
             if image.ndim == 3:
@@ -1773,10 +1774,13 @@ cdef class InMemoryRaster:
                 "in a `with rasterio.Env()` or `with rasterio.open()` "
                 "block.")
 
+        if dtype == 'int8':
+            options = CSLSetNameValue(options, 'PIXELTYPE', 'SIGNEDBYTE')
+
         datasetname = str(uuid4()).encode('utf-8')
         self._hds = exc_wrap_pointer(
             GDALCreate(memdriver, <const char *>datasetname, width, height,
-                       count, <GDALDataType>dtypes.dtype_rev[dtype], NULL))
+                       count, <GDALDataType>dtypes.dtype_rev[dtype], options))
 
         if transform is not None:
             self.transform = transform
@@ -1815,6 +1819,9 @@ cdef class InMemoryRaster:
                 CPLFree(gcplist)
                 CPLFree(srcwkt)
                 _safe_osr_release(osr)
+
+        if options != NULL:
+            CSLDestroy(options)
 
         self._image = None
         if image is not None:
@@ -2015,6 +2022,9 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
             # We've mapped numpy scalar types to GDAL types so see
             # if we can crosswalk those.
             if hasattr(self._init_dtype, 'type'):
+                if self._init_dtype == 'int8':
+                    options = CSLSetNameValue(options, 'PIXELTYPE', 'SIGNEDBYTE')
+
                 tp = self._init_dtype.type
                 if tp not in dtypes.dtype_rev:
                     raise ValueError(
@@ -2026,7 +2036,7 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
 
             self._hds = exc_wrap_pointer(
                 GDALCreate(memdrv, "temp", self.width, self.height,
-                           self._count, gdal_dtype, NULL))
+                           self._count, gdal_dtype, options))
 
             if self._init_nodata is not None:
                 for i in range(self._count):

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -443,7 +443,7 @@ def _reproject(
 
     # Set up GDALCreateGenImgProjTransformer2 keyword arguments.
     cdef char **imgProjOptions = NULL
-    CSLSetNameValue(imgProjOptions, "GCPS_OK", "TRUE")
+    imgProjOptions = CSLSetNameValue(imgProjOptions, "GCPS_OK", "TRUE")
 
     # See http://www.gdal.org/gdal__alg_8h.html#a94cd172f78dbc41d6f407d662914f2e3
     # for a list of supported options. I (Sean) don't see harm in


### PR DESCRIPTION
GDAL treats signed byte data in a special way, there is only one 8-bit data type GDT_Byte, unsigned by default. To represent signed version one needs to set PIXELTYPE='SIGNEDBYTE'. When int8 support was added in #1595 InMemoryRaster class was not adjusted to support int8 inputs. Calls to GDALCreate need to include options dictionary.

Closes #1878.

There was also missing assignment in `_warp.pyx`, which I think is an omission.