### PR TITLE
Resampling docs typo

### DIFF
--- a/docs/topics/resampling.rst
+++ b/docs/topics/resampling.rst
@@ -1,7 +1,8 @@
 Resampling
 ==========
 
-For details on changing coordinate reference systems, see `Reprojection`.
+For details on changing coordinate reference systems, see
+:doc:`Reprojection <reproject>`.
 
 Up and downsampling
 -------------------
@@ -55,13 +56,13 @@ Resampling Methods
 When you change the raster cell grid, you must recalculate the pixel values.
 There is no "correct" way to do this as all methods involve some interpolation.
 
-The current resampling methods can be found in the `rasterio.enums`_ source.
+The current resampling methods can be found in the
+:class:`rasterio.enums.Resampling()` class.
 
-Of note, the default ``Resampling.nearest`` method may not be suitable for
-continuous data. In those cases, ``Resampling.bilinear`` and
-``Resampling.cubic`` are better suited.  Some specialized statistical
-resampling method exist, e.g. ``Resampling.average``, which may be useful when
+Of note, the default :attr:`~rasterio.enums.Resampling.nearest` method may not
+be suitable for continuous data. In those cases,
+:attr:`~rasterio.enums.Resampling.bilinear` and
+:attr:`~rasterio.enums.Resampling.cubic` are better suited.
+Some specialized statistical resampling method exist, e.g.
+:attr:`~rasterio.enums.Resampling.average`, which may be useful when
 certain numerical properties of the data are to be retained.
-
-
-.. _rasterio.enums: https://github.com/mapbox/rasterio/blob/master/rasterio/enums.py#L28

--- a/docs/topics/resampling.rst
+++ b/docs/topics/resampling.rst
@@ -42,8 +42,8 @@ method.
 
         # scale image transform
         transform = dataset.transform * dataset.transform.scale(
-            (dataset.width / data.shape[-2]),
-            (dataset.height / data.shape[-1])
+            (dataset.width / data.shape[-1]),
+            (dataset.height / data.shape[-2])
         )
 
 Downsampling to 1/2 of the resolution can be done with ``upscale_factor = 1/2``.

--- a/docs/topics/resampling.rst
+++ b/docs/topics/resampling.rst
@@ -52,7 +52,7 @@ Downsampling to 1/2 of the resolution can be done with ``upscale_factor = 1/2``.
 Resampling Methods
 ------------------
 
-When you change the raster cell grid, you must recalulate the pixel values.
+When you change the raster cell grid, you must recalculate the pixel values.
 There is no "correct" way to do this as all methods involve some interpolation.
 
 The current resampling methods can be found in the `rasterio.enums`_ source.


### PR DESCRIPTION
This PR fixes what I think is a mistake in the example given in the resampling documentation: `data.shape` contains `(count, height, width)`, hence my fix.

I also took the opportunity to add sphinx autodoc links to this documentation page to make the navigation easier.