### PR TITLE
Make rio-clip's intersection-only results optional

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Changes
 
 Bug fixes:
 
+- Make the strict intersection in rio-clip optional with a --with-complement
+  option (#1907).
 - Add a new as_vsi() method to the Path class for internal use and improve
   Windows path handling and tests thereof (#1895).
 

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -1,14 +1,12 @@
-import sys
 import os
-import logging
-import numpy as np
+
 from click.testing import CliRunner
+import numpy as np
+import pytest
 
 import rasterio
 from rasterio.rio.main import main_group
 
-
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 TEST_BBOX = [-11850000, 4804000, -11840000, 4808000]
 
@@ -17,16 +15,40 @@ def bbox(*args):
     return ' '.join([str(x) for x in args])
 
 
-def test_clip_bounds(runner, tmpdir):
+@pytest.mark.parametrize("bounds", [bbox(*TEST_BBOX)])
+def test_clip_bounds(runner, tmpdir, bounds):
     output = str(tmpdir.join('test.tif'))
     result = runner.invoke(
-        main_group,
-        ['clip', 'tests/data/shade.tif', output, '--bounds', bbox(*TEST_BBOX)])
+        main_group, ["clip", "tests/data/shade.tif", output, "--bounds", bounds]
+    )
     assert result.exit_code == 0
     assert os.path.exists(output)
 
     with rasterio.open(output) as out:
         assert out.shape == (419, 173)
+
+
+@pytest.mark.parametrize("bounds", [bbox(*TEST_BBOX)])
+def test_clip_bounds_with_complement(runner, tmpdir, bounds):
+    output = str(tmpdir.join("test.tif"))
+    result = runner.invoke(
+        main_group,
+        [
+            "clip",
+            "tests/data/shade.tif",
+            output,
+            "--bounds",
+            bounds,
+            "--with-complement",
+        ],
+    )
+    assert result.exit_code == 0
+    assert os.path.exists(output)
+
+    with rasterio.open(output) as out:
+        assert out.shape == (419, 1047)
+        data = out.read()
+        assert (data[420:, :] == 255).all()
 
 
 def test_clip_bounds_geographic(runner, tmpdir):
@@ -106,9 +128,16 @@ def test_clip_overwrite_with_option(runner, tmpdir):
     assert result.exit_code == 0
 
     result = runner.invoke(
-        main_group, [
-        'clip', 'tests/data/shade.tif', output, '--bounds', bbox(*TEST_BBOX),
-        '--overwrite'])
+        main_group,
+        [
+            "clip",
+            "tests/data/shade.tif",
+            output,
+            "--bounds",
+            bbox(*TEST_BBOX),
+            "--overwrite",
+        ],
+    )
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
But still the default.

Resolves #1907

I used https://pypi.org/project/darker/ to reformat only the section of rio/clip.py and its tests that I touched in this PR. Pretty slick tool, that.

I considered the following alternatives for the option name:

* --fill
* --pad
* --generous
* --with-extra

But in the end I decided --with-complement is 1) uncommon, and 2) a pretty good technical description of what's going on. I'm open to other suggestions.