### PR TITLE
Add support for bounds of GeometryCollection

### DIFF
--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -425,7 +425,7 @@ def _bounds(geometry, north_up=True, transform=None):
         else:
             return min(xmins), max(ymaxs), max(xmaxs), min(ymins)
 
-    else:
+    elif 'coordinates' in geometry:
         # Input is a singular geometry object
         if transform is not None:
             xyz = list(_explode(geometry['coordinates']))
@@ -439,6 +439,11 @@ def _bounds(geometry, north_up=True, transform=None):
             else:
                 return min(xyz[0]), max(xyz[1]), max(xyz[0]), min(xyz[1])
 
+    # all valid inputs returned above, so whatever falls through is an error
+    raise ValueError(
+            "geometry must be a GeoJSON-like geometry, GeometryCollection, "
+            "or FeatureCollection"
+        )
 
 # Mapping of OGR integer geometry types to GeoJSON type names.
 GEOMETRY_TYPES = {

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -373,6 +373,14 @@ def bounds(geometry, north_up=True, transform=None):
         return tuple(geometry['bbox'])
 
     geom = geometry.get('geometry') or geometry
+
+    # geometry must be a geometry, GeometryCollection, or FeatureCollection
+    if not ('coordinates' in geom or 'geometries' in geom or 'features' in geom):
+        raise ValueError(
+            "geometry must be a GeoJSON-like geometry, GeometryCollection, "
+            "or FeatureCollection"
+        )
+
     return _bounds(geom, north_up=north_up, transform=transform)
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -48,10 +48,21 @@ def test_bounds_z():
     assert bounds(g) == (10, 10, 10, 10)
     assert bounds(MockGeoInterface(g)) == (10, 10, 10, 10)
 
-
-def test_bounds_invalid_obj():
-    with pytest.raises(KeyError):
-        bounds({'type': 'bogus', 'not_coordinates': []})
+@pytest.mark.parametrize('geometry', [
+    {'type': 'Polygon'},
+    {'type': 'Polygon', 'not_coordinates': []},
+    {'type': 'bogus', 'not_coordinates': []},
+    {
+        'type': 'GeometryCollection',
+        'geometries': [
+            {'type': 'Point', 'coordinates': [1, 1]},
+            {'type': 'LineString', 'not_coordinates': [[-10, -20], [10, 20]]},
+        ]
+    }
+])
+def test_bounds_invalid_obj(geometry):
+    with pytest.raises(ValueError, match="geometry must be a GeoJSON-like geometry, GeometryCollection, or FeatureCollection"):
+        bounds(geometry)
 
 
 def test_bounds_feature_collection(basic_featurecollection):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -54,9 +54,23 @@ def test_bounds_invalid_obj():
         bounds({'type': 'bogus', 'not_coordinates': []})
 
 
-def test_feature_collection(basic_featurecollection):
+def test_bounds_feature_collection(basic_featurecollection):
     fc = basic_featurecollection
     assert bounds(fc) == bounds(fc['features'][0]) == (2, 2, 4.25, 4.25)
+
+
+def test_bounds_geometry_collection():
+    gc = {
+        'type': 'GeometryCollection',
+        'geometries': [
+            {'type': 'Point', 'coordinates': [1, 1]},
+            {'type': 'LineString', 'coordinates': [[-10, -20], [10, 20]]},
+            {'type': 'Polygon', 'coordinates': [[[5, 5], [25, 50], [25, 5]]]}
+        ]
+    }
+
+    assert bounds(gc) == (-10, -20, 25, 50)
+    assert bounds(MockGeoInterface(gc)) == (-10, -20, 25, 50)
 
 
 def test_bounds_existing_bbox(basic_featurecollection):


### PR DESCRIPTION
Resolves #1914

`GeometryCollection` geometries were not previously supported due to an oversight.

This adds support for calculating `bounds()` of a `GeometryCollection` and adds additional validation of the geometry type to catch unsupported types sooner.