### PR TITLE
Adding clarity for cases where driver is not supported by GDAL

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -40,7 +40,6 @@ import rasterio.coords
 import rasterio.enums
 import rasterio.path
 
-
 __all__ = ['band', 'open', 'pad', 'Env']
 __version__ = "1.2dev"
 __gdal_version__ = gdal_version()
@@ -220,13 +219,17 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
         elif mode == 'r+':
             s = get_writer_for_path(path)(path, mode, driver=driver, sharing=sharing, **kwargs)
         elif mode.startswith("w"):
-            s = get_writer_for_driver(driver)(path, mode, driver=driver,
-                                              width=width, height=height,
-                                              count=count, crs=crs,
-                                              transform=transform,
-                                              dtype=dtype, nodata=nodata,
-                                              sharing=sharing,
-                                              **kwargs)
+            writer = get_writer_for_driver(driver)
+            if writer is not None:
+                s = writer(path, mode, driver=driver,
+                           width=width, height=height,
+                           count=count, crs=crs,
+                           transform=transform,
+                           dtype=dtype, nodata=nodata,
+                           sharing=sharing,
+                           **kwargs)
+            else:
+                raise ValueError("Writer does not exist for driver: %s" % str(driver))
         else:
             raise ValueError(
                 "mode must be one of 'r', 'r+', or 'w', not %s" % mode)


### PR DESCRIPTION
When trying to write a new rasterised image I encountered an error that was really unintuitive. 
Googling ended up making me think I had a bad Conda installation amidst other red herrings.

When picking a driver for writing to a file, if the writer doesn't exist the package reports back this error:
``` python
s = get_writer_for_driver(driver)(path, mode, driver=driver,
TypeError: 'NoneType' object is not callable
```
(This happened for me when trying to re-project a dataset with the AIG driver, didn't realise GDAL didn't have support for writing)

This PR simply adds a None check on the result of get_writer_for_driver(driver) for cases where there isn't a writer for that driver, and throws an error if it doesn't exist.