### PR TITLE
Mark test_rio_env_no_credentials as needing network.

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -781,6 +781,7 @@ def test_require_gdal_version_chaining():
     assert message in exc_info.value.args[0]
 
 
+@pytest.mark.network
 def test_rio_env_no_credentials(tmpdir, monkeypatch, runner):
     """Confirm that we can get drivers without any credentials"""
     credentials_file = tmpdir.join('credentials')


### PR DESCRIPTION
Or else it's not excluded and fails to run when there's no network.