### PR TITLE
Update attrs>=19.2.0 (hypothesis 5.12.0 requires attrs >= 19.2.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 affine~=2.3.0
-attrs>=17.4.0
+attrs>=19.2.0
 boto3>=1.2.4
 click~=7.1.0
 click-plugins


### PR DESCRIPTION
This resolves recent travis builds failling due to hypothesis requiring a more recent version of `attrs`.