### PR TITLE
Adds self-contained Dockerfile for compiling rasterio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+WORKDIR /usr/src/app
+
+ENV LANG="C.UTF-8" LC_ALL="C.UTF-8"
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-dev cython3 g++ libgdal-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN python3 -m pip install -r requirements.txt
+
+COPY . .
+RUN python3 setup.py install
+
+ENTRYPOINT ["rio"]
+CMD ["--help"]


### PR DESCRIPTION
Adds a self-contained Dockerfile to compile and install rasterio in a reproducible environment.

    docker build -t danieljh/rasterio .
    docker run danieljh/rasterio --version

For https://github.com/mapbox/rasterio/issues/1907 I had to compile and install an unreleased rasterio version; so I packaged it up in a reproducible and self-contained Dockerfile.

Interested in this? We could eventually
- have environments e.g. for ubuntu 20.04, 18.04, .. to check compilation on Travis
- run tests and compilation in one of these on Travis, so we can build in a reproducible clean environment

Related: I couldn't find where we build and publish wheels; shouldn't this also happen on Travis in an on success hook? If so, this should most likely also happen in a self-contained and reproducible environment.