### PR TITLE
Fix types

### DIFF
--- a/rasterio/_shim.pxd
+++ b/rasterio/_shim.pxd
@@ -3,8 +3,8 @@ include "gdal.pxi"
 cdef GDALDatasetH open_dataset(object filename, int mode, object allowed_drivers, object open_options, object siblings) except NULL
 cdef int delete_nodata_value(GDALRasterBandH hBand) except 3
 cdef int io_band(GDALRasterBandH band, int mode, float xoff, float yoff, float width, float height, object data, int resampling=*) except -1
-cdef int io_multi_band(GDALDatasetH hds, int mode, float xoff, float yoff, float width, float height, object data, Py_ssize_t[:] indexes, int resampling=*) except -1
-cdef int io_multi_mask(GDALDatasetH hds, int mode, float xoff, float yoff, float width, float height, object data, Py_ssize_t[:] indexes, int resampling=*) except -1
+cdef int io_multi_band(GDALDatasetH hds, int mode, double xoff, double yoff, double width, double height, object data, Py_ssize_t[:] indexes, int resampling=*) except -1
+cdef int io_multi_mask(GDALDatasetH hds, int mode, double xoff, double yoff, double width, double height, object data, Py_ssize_t[:] indexes, int resampling=*) except -1
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs)
 cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs)
 cdef void set_proj_search_path(object path)

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -83,8 +83,8 @@ cdef int io_band(
 
 
 cdef int io_multi_band(
-        GDALDatasetH hds, int mode, float x0, float y0, float width,
-        float height, object data, Py_ssize_t[:] indexes, int resampling=0) except -1:
+        GDALDatasetH hds, int mode, double x0, double y0, double width,
+        double height, object data, Py_ssize_t[:] indexes, int resampling=0) except -1:
     """Read or write a region of data for multiple bands.
 
     Implicit are
@@ -130,8 +130,8 @@ cdef int io_multi_band(
 
 
 cdef int io_multi_mask(
-        GDALDatasetH hds, int mode, float x0, float y0, float width,
-        float height, object data, Py_ssize_t[:] indexes, int resampling=0) except -1:
+        GDALDatasetH hds, int mode, double x0, double y0, double width,
+        double height, object data, Py_ssize_t[:] indexes, int resampling=0) except -1:
     """Read or write a region of data for multiple band masks.
 
     Implicit are

--- a/rasterio/shim_rasterioex.pxi
+++ b/rasterio/shim_rasterioex.pxi
@@ -83,8 +83,8 @@ cdef int io_band(GDALRasterBandH band, int mode, float x0, float y0,
     return exc_wrap_int(retval)
 
 
-cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
-                       float width, float height, object data,
+cdef int io_multi_band(GDALDatasetH hds, int mode, double x0, double y0,
+                       double width, double height, object data,
                        Py_ssize_t[:] indexes, int resampling=0) except -1:
     """Read or write a region of data for multiple bands.
 
@@ -145,8 +145,8 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, float x0, float y0,
         CPLFree(bandmap)
 
 
-cdef int io_multi_mask(GDALDatasetH hds, int mode, float x0, float y0,
-                       float width, float height, object data,
+cdef int io_multi_mask(GDALDatasetH hds, int mode, double x0, double y0,
+                       double width, double height, object data,
                        Py_ssize_t[:] indexes, int resampling=0) except -1:
     """Read or write a region of data for multiple band masks.
 


### PR DESCRIPTION
Resolves #1932. Using the same type as in [_read](https://github.com/mapbox/rasterio/blob/5af075c1c0f260100e831b281909e8e5dee7f571/rasterio/_io.pyx#L626) helps to overcome shift issue.

Before:
![image](https://user-images.githubusercontent.com/866124/83323217-88dc0400-a25d-11ea-864e-1da5af828431.png)

After:
![image](https://user-images.githubusercontent.com/866124/83313705-a7b7a780-a217-11ea-8f33-2d04a42eb0e3.png)
