### PR TITLE
add CRS.is_northingeasting and CRS.is_latlon to test if EPSG axis is inverted

### DIFF
--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -106,6 +106,34 @@ cdef class _CRS(object):
             units_b = units_c
             return (units_b.decode('utf-8'), to_meters)
 
+    @property
+    def is_latlon(self):
+        """Test if the CRS is in latlon order
+
+        Returns
+        -------
+        bool
+
+        """
+        try:
+            return bool(OSREPSGTreatsAsLatLong(self._osr) == 1)
+        except CPLE_BaseError as exc:
+            raise CRSError("{}".format(exc))
+    
+    @property
+    def is_northingeasting(self):
+        """Test if the CRS should be treated as having northing/easting coordinate ordering
+
+        Returns
+        -------
+        bool
+
+        """
+        try:
+            return bool(OSREPSGTreatsAsNorthingEasting(self._osr) == 1)
+        except CPLE_BaseError as exc:
+            raise CRSError("{}".format(exc))
+
     def __eq__(self, other):
         cdef OGRSpatialReferenceH osr_s = NULL
         cdef OGRSpatialReferenceH osr_o = NULL

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -210,6 +210,66 @@ class CRS(Mapping):
         return self._crs.is_projected
 
     @property
+    def is_latlon(self):
+        """Test if the CRS is in latlon order
+
+        From GDAL docs:
+
+        > This method returns TRUE if EPSG feels this geographic coordinate
+        system should be treated as having lat/long coordinate ordering.
+
+        > Currently this returns TRUE for all geographic coordinate systems with
+        an EPSG code set, and axes set defining it as lat, long.
+
+        > FALSE will be returned for all coordinate systems that are not
+        geographic, or that do not have an EPSG code set.
+
+        > **Note**
+
+        > Important change of behavior since GDAL 3.0.
+        In previous versions, geographic CRS imported with importFromEPSG()
+        would cause this method to return FALSE on them, whereas now it returns
+        TRUE, since importFromEPSG() is now equivalent to importFromEPSGA().
+
+
+        Returns
+        -------
+        bool
+
+        """
+        return self._crs.is_latlon
+
+    @property
+    def is_northingeasting(self):
+        """Test if the CRS should be treated as having northing/easting coordinate ordering
+
+        From GDAL docs:
+
+        > This method returns TRUE if EPSG feels this projected coordinate
+        system should be treated as having northing/easting coordinate ordering.
+
+        > Currently this returns TRUE for all projected coordinate systems with
+        an EPSG code set, and axes set defining it as northing, easting.
+
+        > FALSE will be returned for all coordinate systems that are not
+        projected, or that do not have an EPSG code set.
+
+        > **Note**
+
+        > Important change of behavior since GDAL 3.0.
+        In previous versions, projected CRS with northing, easting axis order
+        imported with importFromEPSG() would cause this method to return FALSE
+        on them, whereas now it returns TRUE, since importFromEPSG() is now 
+        equivalent to importFromEPSGA().
+
+        Returns
+        -------
+        bool
+
+        """
+        return self._crs.is_northingeasting
+
+    @property
     def is_valid(self):
         """Test that the CRS is a geographic or projected CRS
 

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -115,6 +115,8 @@ cdef extern from "ogr_srs_api.h" nogil:
     int OSRSetFromUserInput(OGRSpatialReferenceH srs, const char *input)
     OGRErr OSRValidate(OGRSpatialReferenceH srs)
     double OSRGetLinearUnits(OGRSpatialReferenceH srs, char **ppszName)
+    int OSREPSGTreatsAsLatLong(OGRSpatialReferenceH srs)
+    int OSREPSGTreatsAsNorthingEasting(OGRSpatialReferenceH srs)
 
 cdef extern from "gdal.h" nogil:
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -511,3 +511,17 @@ def test_equals_different_type(other):
 def test_from_user_input_custom_crs_class():
     """Support comparison to foreign objects that provide to_wkt()"""
     assert CRS.from_user_input(CustomCRS()) == CRS.from_epsg(4326)
+
+
+def test_is_latlong():
+    """Test if CRS should be treated as latlon."""
+    assert not CRS.from_user_input("http://www.opengis.net/def/crs/OGC/1.3/CRS84").is_latlon
+    assert not CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/2193").is_latlon
+    assert CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/4326").is_latlon
+
+
+def test_is_northingeasting():
+    """Test if CRS should be treated as having northing/easting coordinate ordering."""
+    assert not CRS.from_user_input("http://www.opengis.net/def/crs/OGC/1.3/CRS84").is_northingeasting
+    assert CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/2193").is_northingeasting
+    assert not CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/4326").is_northingeasting


### PR DESCRIPTION
Hi @sgillies and contributors,
Sorry for the impromptu PR. 

This PR adds 2 new properties to the CRS object:
- `is_latlon`
- `is_northingeasting`

We need this in https://github.com/developmentseed/morecantile to check if a CRS has inverted (latlon) axis as in https://github.com/OSGeo/gdal/blob/137640fc6f78a2fd91cff0d71163ad0b305c5104/gdal/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp#L173-L183

ref https://github.com/developmentseed/morecantile/issues/26