### PR TITLE
Add resampling method option to merge

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 from rasterio import windows
+from rasterio.enums import Resampling
 from rasterio.transform import Affine
 
 
@@ -17,7 +18,8 @@ MERGE_METHODS = ('first', 'last', 'min', 'max')
 
 
 def merge(datasets, bounds=None, res=None, nodata=None, dtype=None, precision=10,
-          indexes=None, output_count=None, method='first'):
+          indexes=None, output_count=None, resampling=Resampling.nearest,
+          method='first'):
     """Copy valid pixels from input files to an output file.
 
     All files must have the same number of bands, data type, and
@@ -55,6 +57,9 @@ def merge(datasets, bounds=None, res=None, nodata=None, dtype=None, precision=10
     output_count: int, optional
         If using callable it may be useful to have additional bands in the output
         in addition to the indexes specified for read
+    resampling : Resampling, optional
+        Resampling algorithm used when reading input files.
+        Default: `Resampling.nearest`.
     method : str or callable
         pre-defined method:
             first: reverse painting
@@ -247,7 +252,8 @@ def merge(datasets, bounds=None, res=None, nodata=None, dtype=None, precision=10
             int(round(dst_window.height)), int(round(dst_window.width)))
         temp_shape = (src_count, trows, tcols)
         temp = src.read(out_shape=temp_shape, window=src_window,
-                        boundless=False, masked=True, indexes=indexes)
+                        boundless=False, masked=True, indexes=indexes,
+                        resampling=resampling)
 
         # 5. Copy elements of temp into dest
         roff, coff = (

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -566,7 +566,11 @@ def test_data_dir_resampling(tmpdir):
     return tmpdir
 
 
-@pytest.mark.parametrize("resampling", [resamp for resamp in Resampling if resamp < 7])
+@pytest.mark.parametrize(
+    "resampling",
+    [resamp for resamp in Resampling if resamp < 7] +
+    [pytest.param(Resampling.gauss, marks=pytest.mark.xfail)]
+)
 def test_merge_resampling(test_data_dir_resampling, resampling, runner):
     outputname = str(test_data_dir_resampling.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_resampling.listdir()]

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -12,6 +12,7 @@ from pytest import fixture
 import pytest
 
 import rasterio
+from rasterio.enums import Resampling
 from rasterio.merge import merge
 from rasterio.rio.main import main_group
 from rasterio.transform import Affine
@@ -540,3 +541,49 @@ def test_merge_precision(tmpdir, precision):
     result = runner.invoke(main_group, ["merge", "-f", "AAIGrid"] + precision + inputs + [outputname])
     assert result.exit_code == 0
     assert open(outputname).read() == textwrap.dedent(expected)
+
+
+@fixture(scope='function')
+def test_data_dir_resampling(tmpdir):
+    kwargs = {
+        "crs": {'init': 'epsg:4326'},
+        "transform": affine.Affine(0.2, 0, 0,
+                                   0, -0.2, 0),
+        "count": 1,
+        "dtype": rasterio.uint8,
+        "driver": "GTiff",
+        "width": 9,
+        "height": 1,
+        "nodata": 1
+    }
+
+    with rasterio.open(str(tmpdir.join('a.tif')), 'w', **kwargs) as dst:
+        data = np.ones((1, 9), dtype=rasterio.uint8)
+        data[:, :3] = 100
+        data[:, 3:6] = 255
+        dst.write(data, indexes=1)
+
+    return tmpdir
+
+
+@pytest.mark.parametrize("resampling", [resamp for resamp in Resampling if resamp < 7])
+def test_merge_resampling(test_data_dir_resampling, resampling, runner):
+    outputname = str(test_data_dir_resampling.join('merged.tif'))
+    inputs = [str(x) for x in test_data_dir_resampling.listdir()]
+    with rasterio.open(inputs[0]) as src:
+        bounds = src.bounds
+        res = src.res[0]
+        expected_raster = src.read(
+            out_shape=tuple(dim * 2 for dim in src.shape),
+            resampling=resampling
+        )
+    result = runner.invoke(
+        main_group, ['merge'] + inputs + [outputname] +
+        ['--res', res / 2, '--resampling', resampling.name] +
+        ['--bounds', ' '.join(map(str, bounds))])
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+    with rasterio.open(outputname) as dst:
+        output_raster = dst.read()
+
+    np.testing.assert_array_equal(output_raster, expected_raster)


### PR DESCRIPTION
Hi!

As discussed in the [mailing list](https://rasterio.groups.io/g/dev/topic/73014342#131), this PR adds the ability to override the resampling method used when reading the input files in `rasterio.merge.merge()`.

This is useful for example when giving to the `merge` function a resolution that is different from the input files' resolution.