### PR TITLE
Feature show hist labels

### DIFF
--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -240,6 +240,9 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=No
         Title for the figure.
     ax : matplotlib axes (opt)
         The raster will be added to this axes if passed.
+    label : matplotlib labels (opt)
+        If passed, matplotlib will use this label list.
+        Otherwise, a default label list will be automatically created
     **kwargs : optional keyword arguments
         These will be passed to the matplotlib hist method. See full list at:
         http://matplotlib.org/api/axes_api.html?highlight=imshow#matplotlib.axes.Axes.hist

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -222,7 +222,7 @@ def reshape_as_raster(arr):
     return im
 
 
-def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs):
+def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=None, **kwargs):
     """Easily display a histogram with matplotlib.
 
     Parameters
@@ -273,12 +273,17 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, **kwargs
     else:
         colors = colors[:arr.shape[-1]]
 
-    # If a rasterio.Band() is given make sure the proper index is displayed
-    # in the legend.
-    if isinstance(source, (tuple, rasterio.Band)):
-        labels = [str(source[1])]
+    # if the user used the label argument, pass them drectly to matplotlib
+    if label:
+        labels = label
+    # else, create default labels
     else:
-        labels = (str(i + 1) for i in range(len(arr)))
+        # If a rasterio.Band() is given make sure the proper index is displayed
+        # in the legend.
+        if isinstance(source, (tuple, rasterio.Band)):
+            labels = [str(source[1])]
+        else:
+            labels = (str(i + 1) for i in range(len(arr)))
 
     if ax:
         show = False


### PR DESCRIPTION
This PR allows the user to pass a custom labels list as an argument to rasterio's show_hist() function.

### Previous behavior:
- hidden inside show_hist(), a default label list is created and passed to the underlying matplotlib's hist() function.
- if a user tries to pass their own label list `show_hist( ... , label=['some', 'labels'] )` then matplotlib complains that `hist() got multiple values for keyword argument "label"`. (see screenshot)

![image](https://user-images.githubusercontent.com/26211495/84350292-04419c00-abf4-11ea-8724-2dc06509c3d8.png)




### New behavior: 
- If no argument is passed to show_hist(): same behavior as previously, a default label list is created by show_hist().
- If show_hist( ... , label=['some', 'labels'] ) is used, then this label list is passed instead to matplotlib's hist() function. (see screenshot: legend on upper right hand corner has custom test1/../test7 labels)

![image](https://user-images.githubusercontent.com/26211495/84350587-934eb400-abf4-11ea-9bd2-d5b0c4ef47a0.png)



### Notes:
- There does not seem to be any previously opened/closed issue relevant to this feature
- PR that first implemented show_hist() is #457
- For the show_hist() keyword argument, I chose `label=` and not `labels=`, to follow the matplotlib convention
- Disclaimer: this is my first pull request for this project. I'm happy to receive feedback and run further tests. And pointers to update the documentation 