### PR TITLE
Remove older GDAL versions, add newer GDAL versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: trusty
+dist: xenial
 
 env:
   global:
@@ -37,11 +37,6 @@ addons:
     - libatlas-dev
     - libatlas-base-dev
     - gfortran
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - "sleep 3"
 
 before_install:
   - python -m pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ jobs:
     - python: "3.8"
       env: GDALVERSION="3.1.2" PROJVERSION="6.2.1"
   allow_failures:
-    - python "3.8"
+    - python: "3.8"
       env: GDALVERSION="release/3.1" PROJVERSION="7.1.1"
-    - python "3.8"
+    - python: "3.8"
       env: GDALVERSION="master" PROJVERSION="7.1.1"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ jobs:
       env: GDALVERSION="3.1.2" PROJVERSION="6.2.1"
     - python: "3.8"
       env: GDALVERSION="3.1.2" PROJVERSION="6.2.1"
+    - python: "3.8"
+      env: GDALVERSION="release/3.1" PROJVERSION="7.1.1"
+    - python: "3.8"
+      env: GDALVERSION="master" PROJVERSION="7.1.1"
   allow_failures:
     - python: "3.8"
       env: GDALVERSION="release/3.1" PROJVERSION="7.1.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,20 @@ env:
 jobs:
   include:
     - python: "2.7"
-      env: GDALVERSION="1.11.5" PROJVERSION="4.8.0"
-    - python: "2.7"
-      env: GDALVERSION="2.2.4" PROJVERSION="4.9.3"
-    - python: "3.6"
-      env: GDALVERSION="2.2.4" PROJVERSION="4.9.3"
-    - python: "3.6"
-      env: GDALVERSION="2.3.3" PROJVERSION="4.9.3"
+      env: GDALVERSION="2.4.4" PROJVERSION="4.9.3"
     - python: "3.6"
       env: GDALVERSION="2.4.4" PROJVERSION="4.9.3"
     - python: "3.6"
       env: GDALVERSION="3.0.4" PROJVERSION="6.2.1"
+    - python: "3.7"
+      env: GDALVERSION="3.1.2" PROJVERSION="6.2.1"
+    - python: "3.8"
+      env: GDALVERSION="3.1.2" PROJVERSION="6.2.1"
+  allow_failures:
+    - python "3.8"
+      env: GDALVERSION="release/3.1" PROJVERSION="7.1.1"
+    - python "3.8"
+      env: GDALVERSION="master" PROJVERSION="7.1.1"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
     - python: "3.8"
       env: GDALVERSION="master" PROJVERSION="7.1.1"
   allow_failures:
+    - python: "2.7"
+      env: GDALVERSION="2.4.4" PROJVERSION="4.9.3"
     - python: "3.8"
       env: GDALVERSION="release/3.1" PROJVERSION="7.1.1"
     - python: "3.8"


### PR DESCRIPTION
The older versions might be returned, but the GDAL project doesn't
support these old versions anymore.