### PR TITLE
Update vrt.py (dead links)

### DIFF
--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -70,7 +70,7 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
         The working data type for warp operation and output.
     warp_extras : dict
         GDAL extra warp options. See
-        http://www.gdal.org/structGDALWarpOptions.html.
+        https://gdal.org/doxygen/structGDALWarpOptions.html.
 
     Attributes
     ----------
@@ -94,7 +94,7 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
         The working data type for warp operation and output.
     warp_extras : dict
         GDAL extra warp options. See
-        http://www.gdal.org/structGDALWarpOptions.html.
+        https://gdal.org/doxygen/structGDALWarpOptions.html.
 
     Examples
     --------


### PR DESCRIPTION
fixed dead url in docs, optionally could switch to the non doxygen docs at https://gdal.org/api/gdalwarp_cpp.html#_CPPv415GDALWarpOptions