### PR TITLE
Wrap calls to GDALChecksumImage so that we can catch GDAL errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes
 1.1.7 (TBD)
 -----------
 
+- Wrap calls to GDALChecksumImage so that errors set by GDAL are propagated to
+  Python as a RasterioIOError.
 - Raise RasterioDeprecationWarning when a dataset opened in modes other than
   'r' is given to the WarpedVRT constructor.
 - Base RasterioDeprecationWarning on FutureWarning, following the

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -14,7 +14,7 @@ from libc.string cimport strncmp
 from rasterio._err import (
     GDALError, CPLE_BaseError, CPLE_IllegalArgError, CPLE_OpenFailedError,
     CPLE_NotSupportedError)
-from rasterio._err cimport exc_wrap_pointer, exc_wrap_int
+from rasterio._err cimport exc_wrap_pointer, exc_wrap_int, exc_wrap
 from rasterio._shim cimport open_dataset, osr_get_name, osr_set_traditional_axis_mapping_strategy
 
 from rasterio.compat import string_types
@@ -1216,7 +1216,11 @@ cdef class DatasetBase(object):
             yoff = window.row_off
             height = window.height
 
-        return GDALChecksumImage(band, xoff, yoff, width, height)
+        try:
+            return exc_wrap(GDALChecksumImage(band, xoff, yoff, width, height))
+        except CPLE_BaseError as err:
+            raise RasterioIOError(str(err))
+
 
     def get_gcps(self):
         """Get GCPs and their associated CRS."""

--- a/rasterio/_err.pxd
+++ b/rasterio/_err.pxd
@@ -9,6 +9,7 @@ cdef extern from "ogr_core.h":
     ctypedef int OGRErr
 
 
+cdef int exc_wrap(int retval) except -1
 cdef int exc_wrap_int(int retval) except -1
 cdef OGRErr exc_wrap_ogrerr(OGRErr retval) except -1
 cdef void *exc_wrap_pointer(void *ptr) except NULL

--- a/rasterio/_err.pyx
+++ b/rasterio/_err.pyx
@@ -139,7 +139,7 @@ class GDALError(IntEnum):
 
 cdef inline object exc_check():
     """Checks GDAL error stack for fatal or non-fatal errors
-    
+
     Returns
     -------
     An Exception, SystemExit, or None
@@ -169,6 +169,14 @@ cdef inline object exc_check():
 
     else:
         return
+
+
+cdef int exc_wrap(int retval) except -1:
+    """Wrap a GDAL function that returns int without checking the retval"""
+    exc = exc_check()
+    if exc:
+        raise exc
+    return retval
 
 
 cdef int exc_wrap_int(int err) except -1:


### PR DESCRIPTION
Lets us catch RasterioIOError for a quick integrity check.