### PR TITLE
add CRS.is_northingeasting and CRS.is_latlon to test if EPSG axis is …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes
 1.1.7 (TBD)
 -----------
 
+- Add missing methods needed to determine whether GDAL treats a CRS as lat/long
+  or northing/easting (#1943).
 - Raise RasterioDeprecationWarning when a dataset opened in modes other than
   'r' is given to the WarpedVRT constructor.
 - Base RasterioDeprecationWarning on FutureWarning, following the

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -28,6 +28,48 @@ def gdal_version():
     return info_b.decode("utf-8")
 
 
+def _epsg_treats_as_latlong(input_crs):
+    """Test if the CRS is in latlon order
+
+    Parameters
+    ----------
+    input_crs : _CRS
+        rasterio _CRS object
+
+    Returns
+    -------
+    bool
+
+    """
+    cdef _CRS crs = input_crs
+
+    try:
+        return bool(OSREPSGTreatsAsLatLong(crs._osr) == 1)
+    except CPLE_BaseError as exc:
+        raise CRSError("{}".format(exc))
+
+
+def _epsg_treats_as_northingeasting(input_crs):
+    """Test if the CRS should be treated as having northing/easting coordinate ordering
+
+    Parameters
+    ----------
+    input_crs : _CRS
+        rasterio _CRS object
+
+    Returns
+    -------
+    bool
+
+    """
+    cdef _CRS crs = input_crs
+
+    try:
+        return bool(OSREPSGTreatsAsNorthingEasting(crs._osr) == 1)
+    except CPLE_BaseError as exc:
+        raise CRSError("{}".format(exc))
+
+
 cdef class _CRS(object):
     """Cython extension class"""
 

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -13,7 +13,7 @@ used.
 import json
 import pickle
 
-from rasterio._crs import _CRS, all_proj_keys
+from rasterio._crs import _CRS, all_proj_keys, _epsg_treats_as_latlong, _epsg_treats_as_northingeasting
 from rasterio.compat import Mapping, string_types
 from rasterio.errors import CRSError
 
@@ -496,3 +496,80 @@ class CRS(Mapping):
             return cls.from_string(value, morph_from_esri_dialect=morph_from_esri_dialect)
         else:
             raise CRSError("CRS is invalid: {!r}".format(value))
+
+
+def epsg_treats_as_latlong(input):
+    """Test if the CRS is in latlon order
+
+    From GDAL docs:
+
+    > This method returns TRUE if EPSG feels this geographic coordinate
+    system should be treated as having lat/long coordinate ordering.
+
+    > Currently this returns TRUE for all geographic coordinate systems with
+    an EPSG code set, and axes set defining it as lat, long.
+
+    > FALSE will be returned for all coordinate systems that are not
+    geographic, or that do not have an EPSG code set.
+
+    > **Note**
+
+    > Important change of behavior since GDAL 3.0.
+    In previous versions, geographic CRS imported with importFromEPSG()
+    would cause this method to return FALSE on them, whereas now it returns
+    TRUE, since importFromEPSG() is now equivalent to importFromEPSGA().
+
+    Parameters
+    ----------
+    input : CRS
+        Coordinate reference system, as a rasterio CRS object
+        Example: CRS({'init': 'EPSG:4326'})
+
+    Returns
+    -------
+    bool
+
+    """
+    if not isinstance(input, CRS):
+        input = CRS.from_user_input(input)
+
+    return _epsg_treats_as_latlong(input._crs)
+
+
+def epsg_treats_as_northingeasting(input):
+    """Test if the CRS should be treated as having northing/easting coordinate ordering
+
+    From GDAL docs:
+
+    > This method returns TRUE if EPSG feels this projected coordinate
+    system should be treated as having northing/easting coordinate ordering.
+
+    > Currently this returns TRUE for all projected coordinate systems with
+    an EPSG code set, and axes set defining it as northing, easting.
+
+    > FALSE will be returned for all coordinate systems that are not
+    projected, or that do not have an EPSG code set.
+
+    > **Note**
+
+    > Important change of behavior since GDAL 3.0.
+    In previous versions, projected CRS with northing, easting axis order
+    imported with importFromEPSG() would cause this method to return FALSE
+    on them, whereas now it returns TRUE, since importFromEPSG() is now 
+    equivalent to importFromEPSGA().
+
+    Parameters
+    ----------
+    input : CRS
+        Coordinate reference system, as a rasterio CRS object
+        Example: CRS({'init': 'EPSG:4326'})
+
+    Returns
+    -------
+    bool
+
+    """
+    if not isinstance(input, CRS):
+        input = CRS.from_user_input(input)
+
+    return _epsg_treats_as_northingeasting(input._crs)

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -115,6 +115,8 @@ cdef extern from "ogr_srs_api.h" nogil:
     int OSRSetFromUserInput(OGRSpatialReferenceH srs, const char *input)
     OGRErr OSRValidate(OGRSpatialReferenceH srs)
     double OSRGetLinearUnits(OGRSpatialReferenceH srs, char **ppszName)
+    int OSREPSGTreatsAsLatLong(OGRSpatialReferenceH srs)
+    int OSREPSGTreatsAsNorthingEasting(OGRSpatialReferenceH srs)
 
 cdef extern from "gdal.h" nogil:
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -11,7 +11,7 @@ import pytest
 
 import rasterio
 from rasterio._base import _can_create_osr
-from rasterio.crs import CRS
+from rasterio.crs import CRS, epsg_treats_as_latlong, epsg_treats_as_northingeasting
 from rasterio.env import env_ctx_if_needed, Env
 from rasterio.errors import CRSError
 
@@ -565,3 +565,44 @@ def test_to_authority__no_code_available():
     lcc_crs = CRS.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc '
                               '+x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     assert lcc_crs.to_authority() is None
+
+
+@pytest.mark.parametrize(
+    'crs_obj,result',
+    [
+        (CRS.from_user_input("http://www.opengis.net/def/crs/OGC/1.3/CRS84"), False),
+        (CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/2193"), False),
+        (CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/4326"), True),
+    ]
+)
+def test_is_latlong(crs_obj, result):
+    """Test if CRS should be treated as latlon."""
+    assert epsg_treats_as_latlong(crs_obj) == result
+
+
+@pytest.mark.parametrize(
+    'crs_obj,result',
+    [
+        (CRS.from_user_input("http://www.opengis.net/def/crs/OGC/1.3/CRS84"), False),
+        (CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/2193"), True),
+        (CRS.from_user_input("http://www.opengis.net/def/crs/EPSG/0/4326"), False),
+    ]
+)
+def test_is_northingeasting(crs_obj, result):
+    """Test if CRS should be treated as having northing/easting coordinate ordering."""
+    assert epsg_treats_as_northingeasting(crs_obj) == result
+
+
+@requires_gdal_lt_3
+@pytest.mark.parametrize('crs_obj', [CRS.from_epsg(4326), CRS.from_epsg(2193)])
+def test_latlong_northingeasting_gdal2(crs_obj):
+    """Check CRS created from epsg with GDAL 2 always return False."""
+    assert not epsg_treats_as_latlong(crs_obj)
+    assert not epsg_treats_as_northingeasting(crs_obj)
+
+
+@requires_gdal3
+def test_latlong_northingeasting_gdal3():
+    """Check CRS created from epsg with GDAL 3."""
+    assert epsg_treats_as_latlong(CRS.from_epsg(4326))
+    assert epsg_treats_as_northingeasting(CRS.from_epsg(2193))


### PR DESCRIPTION
…inverted (#1943)

* add CRS.is_northingeasting and CRS.is_latlon to test if EPSG axis is inverted

* make separate functions

* pass _crs object to _CRS functions

* update test and confirm GDAL2/3 difference

* fix tests

* more pytest.mark.parametrize

* rename test functions