### PR TITLE
Retry with certifi cert if curl fails to find any

### DIFF
--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -20,7 +20,7 @@ import threading
 from rasterio._base cimport _safe_osr_release
 from rasterio._err import CPLE_BaseError
 from rasterio._err cimport exc_wrap_ogrerr, exc_wrap_int
-from rasterio._shim cimport set_proj_search_path
+from rasterio._shim cimport set_proj_search_path, vsi_curl_clear_cache
 
 from libc.stdio cimport stderr
 
@@ -412,3 +412,7 @@ cdef class GDALEnv(ConfigEnv):
 def set_proj_data_search_path(path):
     """Set PROJ data search path"""
     set_proj_search_path(path)
+
+
+def clear_vsi_curl_cache():
+    vsi_curl_clear_cache()

--- a/rasterio/_shim.pxd
+++ b/rasterio/_shim.pxd
@@ -8,3 +8,4 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, double xoff, double yoff, dou
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs)
 cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs)
 cdef void set_proj_search_path(object path)
+cdef void vsi_curl_clear_cache()

--- a/rasterio/_shim1.pyx
+++ b/rasterio/_shim1.pyx
@@ -191,3 +191,7 @@ cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
 
 cdef void set_proj_search_path(object path):
     os.environ["PROJ_LIB"] = path
+
+
+cdef void vsi_curl_clear_cache():
+    pass

--- a/rasterio/_shim20.pyx
+++ b/rasterio/_shim20.pyx
@@ -82,3 +82,7 @@ cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
 
 cdef void set_proj_search_path(object path):
     os.environ["PROJ_LIB"] = path
+
+
+cdef void vsi_curl_clear_cache():
+    pass

--- a/rasterio/_shim21.pyx
+++ b/rasterio/_shim21.pyx
@@ -18,6 +18,7 @@ cdef extern from "gdal.h" nogil:
     cdef CPLErr GDALDeleteRasterNoDataValue(GDALRasterBandH hBand)
     GDALDatasetH GDALOpenEx(const char *filename, int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
 
+
 from rasterio._err cimport exc_wrap_pointer
 
 
@@ -83,3 +84,7 @@ cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
 
 cdef void set_proj_search_path(object path):
     os.environ["PROJ_LIB"] = path
+
+
+cdef void vsi_curl_clear_cache():
+    pass

--- a/rasterio/_shim24.pyx
+++ b/rasterio/_shim24.pyx
@@ -1,4 +1,4 @@
-"""Rasterio shims for GDAL 3.x"""
+"""Rasterio shims for GDAL 2.1"""
 
 # cython: boundscheck=False
 
@@ -7,25 +7,16 @@ include "directives.pxi"
 # The baseline GDAL API.
 include "gdal.pxi"
 
-# Shim API for GDAL >= 3.0
+# Shim API for GDAL >= 2.0
 include "shim_rasterioex.pxi"
 
+import os
 
-# Declarations and implementations specific for GDAL >= 3.x
+# Declarations and implementations specific for GDAL >= 2.1
 cdef extern from "gdal.h" nogil:
 
     cdef CPLErr GDALDeleteRasterNoDataValue(GDALRasterBandH hBand)
     GDALDatasetH GDALOpenEx(const char *filename, int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
-
-
-cdef extern from "ogr_srs_api.h" nogil:
-
-    ctypedef enum OSRAxisMappingStrategy:
-        OAMS_TRADITIONAL_GIS_ORDER
-
-    const char* OSRGetName(OGRSpatialReferenceH hSRS)
-    void OSRSetAxisMappingStrategy(OGRSpatialReferenceH hSRS, OSRAxisMappingStrategy)
-    void OSRSetPROJSearchPaths(const char *const *papszPaths)
 
 
 cdef extern from "cpl_vsi.h" nogil:
@@ -39,7 +30,6 @@ cdef GDALDatasetH open_dataset(
         object filename, int flags, object allowed_drivers,
         object open_options, object siblings) except NULL:
     """Open a dataset and return a handle"""
-
 
     cdef char **drivers = NULL
     cdef char **options = NULL
@@ -90,20 +80,14 @@ cdef int delete_nodata_value(GDALRasterBandH hBand) except 3:
 
 
 cdef const char* osr_get_name(OGRSpatialReferenceH hSrs):
-    return OSRGetName(hSrs)
-
+    return ''
 
 cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs):
-    OSRSetAxisMappingStrategy(hSrs, OAMS_TRADITIONAL_GIS_ORDER)
+    pass
 
 
 cdef void set_proj_search_path(object path):
-    cdef char **paths = NULL
-    cdef const char *path_c = NULL
-    path_b = path.encode("utf-8")
-    path_c = path_b
-    paths = CSLAddString(paths, path_c)
-    OSRSetPROJSearchPaths(paths)
+    os.environ["PROJ_LIB"] = path
 
 
 cdef void vsi_curl_clear_cache():

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -134,3 +134,7 @@ class TransformError(RasterioError):
 
 class WarpedVRTError(RasterioError):
     """Raised when WarpedVRT can't be initialized"""
+
+
+class CertificateError(RasterioError):
+    """Raised when certificates aren't found"""


### PR DESCRIPTION
Towards resolving #2009

This requires being able to clear the VSI cache, which will have been contaminated by previous failure. And thus requires GDAL 2.2.1, but I'm going to require 2.4 because we might want to scope the cache clear to a single file.