### PR TITLE
flatten multipoly to avoid holes in output

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -295,7 +295,9 @@ def rasterize(
         if is_valid_geom(geom):
             shape_values.append(value)
 
-            if geom['type'] == 'GeometryCollection':
+            geom_type = geom['type']
+
+            if geom_type == 'GeometryCollection':
                 # GeometryCollections need to be handled as individual parts to
                 # avoid holes in output:
                 # https://github.com/mapbox/rasterio/issues/1253.
@@ -303,6 +305,11 @@ def rasterize(
                 # GeometryCollections
                 for part in geom['geometries']:
                     valid_shapes.append((part, value))
+
+            elif geom_type == 'MultiPolygon':
+                # Same issue as above
+                for poly in geom['coordinates']:
+                    valid_shapes.append(({'type': 'Polygon', 'coordinates': poly}, value))
 
             else:
                 valid_shapes.append((geom, value))

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -490,6 +490,30 @@ def test_rasterize_geomcollection_no_hole():
     )
 
 
+def test_rasterize_multipolygon_no_hole():
+    """
+    Make sure that bug reported in
+    https://github.com/mapbox/rasterio/issues/1253
+    does not recur.  MultiPolygons are flattened to individual parts,
+    and should result in no holes where parts overlap.
+    """
+
+    poly1 = (((0, 0), (0, 5), (5, 5), (5, 0), (0, 0)),)
+    poly2 = (((2, 2), (2, 7), (7, 7), (7, 2), (2, 2)),)
+
+    polys = [{'type': 'Polygon', 'coordinates': poly1},
+             {'type': 'Polygon', 'coordinates': poly2}]
+
+    multipoly = {'type': 'MultiPolygon', 'coordinates': [poly1, poly2]}
+
+    expected = rasterize(polys, out_shape=DEFAULT_SHAPE)
+
+    assert np.array_equal(
+        rasterize([multipoly], out_shape=DEFAULT_SHAPE),
+        expected
+    )
+
+
 @pytest.mark.parametrize("input", [
     [{'type'}], [{'type': 'Invalid'}], [{'type': 'Point'}], [{'type': 'Point', 'coordinates': []}], [{'type': 'GeometryCollection', 'geometries': []}]])
 def test_rasterize_invalid_geom(input):


### PR DESCRIPTION
related to 1274, a multipolygon was resulting in the same behavior