### PR TITLE
fix the Alibaba Cloud OSS public access session

### DIFF
--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -343,16 +343,16 @@ class AWSSession(Session):
 class OSSSession(Session):
     """Configures access to secured resources stored in Alibaba Cloud OSS.
     """
-    def __init__(self, oss_access_key_id, oss_secret_access_key, oss_endpoint='oss-us-east-1.aliyuncs.com'):
+    def __init__(self, oss_access_key_id=None, oss_secret_access_key=None, oss_endpoint=None):
         """Create new Alibaba Cloud OSS session
 
         Parameters
         ----------
-        oss_access_key_id: string
+        oss_access_key_id: string, optional (default: None)
             An access key id
-        oss_secret_access_key: string
+        oss_secret_access_key: string, optional (default: None)
             An secret access key
-        oss_endpoint: string, default 'oss-us-east-1.aliyuncs.com'
+        oss_endpoint: string, optional (default: None)
             the region attached to the bucket
         """
 


### PR DESCRIPTION
The previous version read the Alibaba OSS (VSI file) file should with `OSS_ACCESS_KEY_ID` and `OSS_SECRET_ACCESS_KEY` parameters. This is not convenient for public data access.

This PR can read the public access data on Alibaba OSS directly without supply `OSS_ACCESS_KEY_ID` and `OSS_SECRET_ACCESS_KEY`.

```python
In [1]: import rasterio

In [2]: from rasterio.windows import Window

In [3]: window = Window(0, 0, 256, 256)
   ...: fp1 = 'https://sshuair.oss-cn-beijing.aliyuncs.com/test-oss-public.tif'
   ...: with rasterio.open(fp1) as src:
   ...:     print(src.profile)
   ...:     data = src.read(window=window)
   ...:

{'driver': 'GTiff', 'dtype': 'uint8', 'nodata': None, 'width': 1215, 'height': 994, 'count': 4, 'crs': CRS.from_epsg(4326), 'transform': Affine(5.363604115221975e-06, 0.0, 113.326558602,
       0.0, -5.362646881288344e-06, 40.066535177), 'tiled': False, 'interleave': 'pixel'}
In [4]:
```

For private file on alibaba oss, same as before.
```python
In [2]: import rasterio
   ...: from rasterio.windows import Window
   ...: from rasterio.session import OSSSession
   ...:
   ...: oss_access_key_id = '***************' # your key is
   ...: oss_secret_access_key = '***************' # your access key
   ...: oss_endpoint = "oss-cn-beijing.aliyuncs.com"
   ...:
   ...: fp2 = '/vsioss/sshuair/test-oss-private.tif'
   ...: session = OSSSession(oss_access_key_id=oss_access_key_id, oss_secret_access_key=oss_secret_access_key,os
   ...: s_endpoint=oss_endpoint)
   ...: window = Window(0, 0, 256, 256)
   ...: with rasterio.Env(session):
   ...:     with rasterio.open(fp2) as src:
   ...:         print(src.profile)
   ...:         data = src.read(window=window)
   ...:
{'driver': 'GTiff', 'dtype': 'uint8', 'nodata': None, 'width': 1215, 'height': 994, 'count': 4, 'crs': CRS.from_epsg(4326), 'transform': Affine(5.363604115221975e-06, 0.0, 113.326558602,
       0.0, -5.362646881288344e-06, 40.066535177), 'tiled': False, 'interleave': 'pixel'}
```
