### PR TITLE
Enable reproject to better handle computation of dst_transform when reprojecting from gcps

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -13,7 +13,7 @@ from rasterio._warp import _calculate_default_transform, _reproject, _transform_
 from rasterio.enums import Resampling
 from rasterio.env import GDALVersion, ensure_env, require_gdal_version
 from rasterio.errors import GDALBehaviorChangeException, TransformError
-from rasterio.transform import array_bounds
+from rasterio.transform import array_bounds, from_gcps
 
 # Gauss (7) is not supported for warp
 SUPPORTED_RESAMPLING = [r for r in Resampling if r.value < 7]
@@ -307,21 +307,31 @@ def reproject(source, destination=None, src_transform=None, gcps=None,
 
     # calculate the destination transform if not provided
     if dst_transform is None and (destination is None or isinstance(destination, np.ndarray)):
+        src_bounds = tuple([None] * 4)
         if isinstance(source, np.ndarray):
             if source.ndim == 3:
                 src_count, src_height, src_width = source.shape
             else:
                 src_count = 1
                 src_height, src_width = source.shape
-            src_bounds = array_bounds(src_height, src_width, src_transform)
+            
+            # try to compute src_bounds if we don't have gcps
+            if not gcps:
+                src_bounds = array_bounds(src_height, src_width, src_transform)
         else:
             src_rdr, src_bidx, _, src_shape = source
-            src_bounds = src_rdr.bounds
+
+            # dataset.bounds will return raster extents in pixel coordinates
+            # if dataset does not have geotransform, which is not useful here.
+            if not (src_rdr.transform.is_identity and src_rdr.crs is None):
+                src_bounds = src_rdr.bounds
+
             src_crs = src_rdr.crs
             if isinstance(src_bidx, int):
                 src_bidx = [src_bidx]
             src_count = len(src_bidx)
             src_height, src_width = src_shape
+            gcps = src_rdr.gcps[0] if src_rdr.gcps[0] else None
 
         dst_height = None
         dst_width = None

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -13,7 +13,7 @@ from rasterio._warp import _calculate_default_transform, _reproject, _transform_
 from rasterio.enums import Resampling
 from rasterio.env import GDALVersion, ensure_env, require_gdal_version
 from rasterio.errors import GDALBehaviorChangeException, TransformError
-from rasterio.transform import array_bounds, from_gcps
+from rasterio.transform import array_bounds
 
 # Gauss (7) is not supported for warp
 SUPPORTED_RESAMPLING = [r for r in Resampling if r.value < 7]

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -6,7 +6,6 @@ import sys
 from affine import Affine
 import numpy as np
 from numpy.testing import assert_almost_equal
-from numpy.testing._private.utils import tempdir
 import pytest
 
 import rasterio


### PR DESCRIPTION
In exploring adding rpcs to warping functionality, I noticed some pains with reprojecting from gcps. 

In the case `dst_transform=None` and `gcps` are supplied, we should expect `dst_transform` to be calculated from `calculate_default_transform`. There are two distinct cases:

- When reprojecting from a `ndarray`
An `AttributeError` will be raised due to https://github.com/mapbox/rasterio/blob/0e2d9e275ef9a51f962e98884d7eacd0121b2774/rasterio/warp.py#L316 due to passing `src_transform=None` to `array_bounds`

- When reprojecting from a `rasterion.Band`
A `ValueError` will be raised due to guard check in `calculate_default_transform` https://github.com/mapbox/rasterio/blob/0e2d9e275ef9a51f962e98884d7eacd0121b2774/rasterio/warp.py#L456. This occurs because `src_bounds` is populated from `dataset.bounds`, conflicting with the `gcps` already provided.

This PR attempts improves the situation by checking for these conditions, and adds some test to guard against regression to this behavior. Also reads `gcps` from dataset if `source` is a dataset object, mimicking behavior of reading `dataset.crs`. 