### PR TITLE
Small georeferencing and reproject doc fix

### DIFF
--- a/docs/topics/georeferencing.rst
+++ b/docs/topics/georeferencing.rst
@@ -69,7 +69,7 @@ described at https://github.com/sgillies/affine.
 Some datasets may not have an affine transformation matrix, but are still georeferenced.
 
 Ground Control Points
-=====================
+----------------------
 
 A ground control point (GCP) is the mapping of a dataset's row and pixel coordinate to a
 single world x, y, and optionally z coordinate. Typically a dataset will have multiple
@@ -77,7 +77,7 @@ GCPs distributed across the image. Rasterio can calculate an affine transformati
 from a collection of GCPs using the ``rasterio.transform.from_gcps`` method.
 
 Rational Polynomial Coefficients
-================================
+---------------------------------
 
 A dataset may also be georeferenced with a set of rational polynomial coefficients (RPCs)
 which can be used to compute pixel coordinates from x, y, and z coordinates. The RPCs are

--- a/docs/topics/reproject.rst
+++ b/docs/topics/reproject.rst
@@ -201,7 +201,8 @@ reference system with a newly computed geotransform.
             rpcs=source.rpcs,
             src_crs=src_crs,
             dst_crs=dst_crs,
-            resampling=Resampling.nearest
+            resampling=Resampling.nearest,
+            **kwargs
         )
 
         assert destination.any()


### PR DESCRIPTION
- Fixes subheadings being rendered as separate pages on sidebar
- Fixes reproject example using rpcs to properly use kwargs to pass options to `GDALCreateGenImgProjTransformer2`