### PR TITLE
Update windows install instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -217,6 +217,8 @@ package layout.
 
 To run the entire suite and the code coverage report:
 
+Note: rasterio must be installed in editable mode in order to run tests.
+
 .. code-block:: console
 
     $ py.test --cov rasterio --cov-report term-missing

--- a/README.rst
+++ b/README.rst
@@ -313,8 +313,8 @@ With pip
     $ pip install --no-use-pep517 --global-option -I<path to gdal include files> -lgdal_i -L<path to gdal library> .
 
 Note: :code:`--no-use-pep517` is required as pip currently hasn't implemented a
-way for optional arguments to be passed to the build backend. See  `here <https://github.com/pypa/pip/issues/5771>`__. 
-for more details.
+way for optional arguments to be passed to the build backend when using PEP 517. 
+See  `here <https://github.com/pypa/pip/issues/5771>`__. for more details.
 
 Alternatively environment variables (e.g. INCLUDE and LINK) used by MSVC compiler can be used to point 
 to include directories and library files.

--- a/README.rst
+++ b/README.rst
@@ -299,12 +299,25 @@ cannot rely on gdal-config, which is only present on UNIX systems, to discover
 the locations of header files and libraries that rasterio needs to compile its
 C extensions. On Windows, these paths need to be provided by the user. You
 will need to find the include files and the library files for gdal and use
-setup.py as follows.
+setup.py as follows. You will also need to specify the installed gdal version
+through the GDAL_VERSION environment variable.
 
 .. code-block:: console
 
-    $ python setup.py build_ext -I<path to gdal include files> -lgdal_i -L<path to gdal library>
-    $ python setup.py install
+    $ python setup.py build_ext -I<path to gdal include files> -lgdal_i -L<path to gdal library> install
+
+With pip
+
+.. code-block:: console
+
+    $ pip install --no-use-pep517 --global-option -I<path to gdal include files> -lgdal_i -L<path to gdal library> .
+
+Note: :code:`--no-use-pep517` is required as pip currently hasn't implemented a
+way for optional arguments to be passed to the build backend. See  `here <https://github.com/pypa/pip/issues/5771>`__. 
+for more details.
+
+Alternatively environment variables (e.g. INCLUDE and LINK) used by MSVC compiler can be used to point 
+to include directories and library files.
 
 We have had success compiling code using the same version of Microsoft's
 Visual Studio used to compile the targeted version of Python (more info on

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -109,8 +109,20 @@ setup.py as follows.
 
 .. code-block:: console
 
-    $ python setup.py build_ext -I<path to gdal include files> -lgdal_i -L<path to gdal library>
-    $ python setup.py install
+    $ python setup.py build_ext -I<path to gdal include files> -lgdal_i -L<path to gdal library> install
+
+With pip
+
+.. code-block:: console
+
+    $ pip install --no-use-pep517 --global-option -I<path to gdal include files> -lgdal_i -L<path to gdal library> .
+
+Note: :code:`--no-use-pep517` is required as pip currently hasn't implemented a
+way for optional arguments to be passed to the build backend. See  `here <https://github.com/pypa/pip/issues/5771>`__. 
+for more details.
+
+Alternatively environment variables (e.g. INCLUDE and LINK) used by MSVC compiler can be used to point 
+to include directories and library files.
 
 We have had success compiling code using the same version of Microsoft's
 Visual Studio used to compile the targeted version of Python (more info on

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -118,8 +118,8 @@ With pip
     $ pip install --no-use-pep517 --global-option -I<path to gdal include files> -lgdal_i -L<path to gdal library> .
 
 Note: :code:`--no-use-pep517` is required as pip currently hasn't implemented a
-way for optional arguments to be passed to the build backend. See  `here <https://github.com/pypa/pip/issues/5771>`__. 
-for more details.
+way for optional arguments to be passed to the build backend when using PEP 517. 
+See  `here <https://github.com/pypa/pip/issues/5771>`__. for more details.
 
 Alternatively environment variables (e.g. INCLUDE and LINK) used by MSVC compiler can be used to point 
 to include directories and library files.


### PR DESCRIPTION
From #2037 I felt @awa5114 highlighted some deficiencies in how to install rasterio on windows. I realized that my understanding of setup.py and pip were a bit lacking and after some trial and error I think I have a better picture that I can describe here:

The current windows install from source instructions have two steps:

```
python setup.py build_ext <options>
python setup.py install
```

however this will fail as the install command will run build_ext internally again, knowing nothing about the previously built pyd files under build/ and not having the proper include and library files to compile again. However if install is passed as a second command to setup.py, the optional arguments will be used when install calls build_ext internally. e.g.

```
python setup.py build_ext <options> install
```

Another way is for a developer to locally modify setup.cfg and have the build_ext optional arguments there

```
[build_ext]
include-dirs=<path to gdal include>
library-dirs=<path to gdal lib>
libraries=gdal_i
```
and then call
```
python setup.py install
```

An additional twist, is that somewhat recently pip has implemented PEP 517 and will install packages using PEP 517 machinery when it detects a pyproject.toml file. However, according to https://github.com/pypa/pip/issues/5771 this does not support the `--global-option` that setuptools does, and silently ignores it. This isn't a concern on linux since we can set the include and library directories from gdal-config. Passing `--no-use-pep517` will force legacy behavior, and accept `--global-option`.

Anyway this PR updates installation notes to reflect what's outlined here. Also adds a note about in order to run tests locally rasterio needs to be installed in editable mode.