### PR TITLE
Make NotGeoreferencedWarning rarer

### DIFF
--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,4 +1,16 @@
-from rasterio.errors import NodataShadowWarning
+import logging
+
+import rasterio
+from rasterio.errors import NodataShadowWarning, NotGeoreferencedWarning
+from affine import Affine
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+def gen_rpcs():
+    with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src:
+        return src.rpcs
 
 
 def test_nodata_shadow():
@@ -6,3 +18,30 @@ def test_nodata_shadow():
         "The dataset's nodata attribute is shadowing "
         "the alpha band. All masks will be determined "
         "by the nodata attribute")
+
+
+def test_notgeoref_warning():
+    with rasterio.MemoryFile() as mem:
+        with mem.open(driver='GTiff', width=10, height=10, dtype='uint8', count=1) as src:
+            pass
+        with pytest.warns(NotGeoreferencedWarning):
+            with mem.open() as dst:
+                pass
+
+
+@pytest.mark.parametrize('transform, gcps, rpcs', [(Affine.identity() * Affine.scale(2.0), None, None),
+                                                   (None, [rasterio.control.GroundControlPoint(0, 0, 0, 0, 0)], None),
+                                                   (None, None, gen_rpcs())])
+def test_no_notgeoref_warning(transform, gcps, rpcs):
+    with rasterio.MemoryFile() as mem:
+        with mem.open(driver='GTiff', width=10, height=10, dtype='uint8', count=1, transform=transform) as src:
+            if gcps:
+                src.gcps = (gcps, rasterio.crs.CRS.from_epsg(4326))
+            if rpcs:
+                src.rpcs = rpcs
+
+        with pytest.warns(None) as record:
+            with mem.open() as dst:
+                pass
+        
+        assert len(record) == 0

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,11 +1,7 @@
-import logging
-
 import rasterio
 from rasterio.errors import NodataShadowWarning, NotGeoreferencedWarning
 from affine import Affine
 import pytest
-
-log = logging.getLogger(__name__)
 
 
 def gen_rpcs():


### PR DESCRIPTION
Related:
- https://github.com/mapbox/rasterio/pull/1922#issuecomment-720004720
- https://rasterio.groups.io/g/main/topic/70046907#411

This adds a new private method `DatasetBase._has_gcps_or_rpcs` which does a simple check for gcps or rpcs. This is used in `DatasetBase.read_transform` to decide whether to raise a `NotGeoreferencedWarning`, which now is only raised if a dataset has none of geotransform, gcps, or rpcs.

As mentioned in the first related link, I think the existing warning is a bit misleading. But I could see there being some new confusion if someone is opening up a dataset with only gcps/rpcs and none of the transform related methods seemingly do what they expect. Perhaps, if this is a real issue and not just in my head, it could minimized with more documentation.

Also in the first related link, I mentioned that maybe we could cleverly warn once if a dataset has gcps or rpcs, but no geotransform in an effort to pull user attention to the fact that special care might need to be taken. I couldn't actually think of a good way to do that. Happy to discuss more.