### PR TITLE
Support for pathlib.Path in merge

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -1,17 +1,12 @@
 """Copy valid pixels from input files to an output file."""
 
 from contextlib import contextmanager
+from pathlib import Path
 import logging
 import math
 import warnings
 
 import numpy as np
-
-try:
-    from pathlib import Path
-except ImportError:  # pragma: no cover
-    class Path:
-        pass
 
 import rasterio
 from rasterio import windows

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -7,6 +7,12 @@ import warnings
 
 import numpy as np
 
+try:
+    from pathlib import Path
+except ImportError:  # pragma: no cover
+    class Path:
+        pass
+
 import rasterio
 from rasterio import windows
 from rasterio.enums import Resampling
@@ -38,7 +44,7 @@ def merge(datasets, bounds=None, res=None, nodata=None, dtype=None, precision=10
 
     Parameters
     ----------
-    datasets : list of dataset objects opened in 'r' mode or filenames
+    datasets : list of dataset objects opened in 'r' mode, filenames or pathlib.Path objects
         source datasets to be merged.
     bounds: tuple, optional
         Bounds of the output image (left, bottom, right, top).
@@ -109,7 +115,7 @@ def merge(datasets, bounds=None, res=None, nodata=None, dtype=None, precision=10
                          .format(method, MERGE_METHODS))
 
     # Create a dataset_opener object to use in several places in this function.
-    if isinstance(datasets[0], string_types):
+    if isinstance(datasets[0], string_types) or isinstance(datasets[0], Path):
         dataset_opener = rasterio.open
     else:
 

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -599,6 +599,8 @@ def test_merge_filenames(tiffs):
     inputs.sort()
     merge(inputs, res=2)
 
+
+def test_merge_pathlib_path(tiffs):
     inputs = [Path(x) for x in tiffs.listdir()]
     inputs.sort()
     merge(inputs, res=2)

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -12,6 +12,7 @@ from pytest import fixture
 import pytest
 
 import rasterio
+from rasterio import Path
 from rasterio.enums import Resampling
 from rasterio.merge import merge
 from rasterio.rio.main import main_group
@@ -595,6 +596,10 @@ def test_merge_resampling(test_data_dir_resampling, resampling, runner):
 
 def test_merge_filenames(tiffs):
     inputs = [str(x) for x in tiffs.listdir()]
+    inputs.sort()
+    merge(inputs, res=2)
+
+    inputs = [Path(x) for x in tiffs.listdir()]
     inputs.sort()
     merge(inputs, res=2)
 


### PR DESCRIPTION
Pathlib is supported in other parts of rasterio ( #1296), but not in merge so I suggest to add it there as well.