### PR TITLE
Don't use approximate transformer if using rpcs & passing RPC_DEM kwarg

### DIFF
--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1917,7 +1917,9 @@ def test_reproject_rpcs_exact_transformer(caplog):
             
 
 def test_reproject_rpcs_approx_transformer(caplog):
-
+    """Reproject using rational polynomial coefficients without a DEM, for which it's
+       ok to use an approximate transformer.
+    """
     with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src:
         out = np.zeros(
                 (3, src.profile["width"], src.profile["height"]), dtype=np.uint8

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1877,3 +1877,52 @@ def test_warp_gcps_compute_dst_transform_automatically_reader(tmpdir):
     assert not out[:, 0, -1].any()
     assert not out[:, -1, -1].any()
     assert not out[:, -1, 0].any()
+
+def test_reproject_rpcs_transformer_type(caplog):
+    """Reproject using rational polynomial coefficients and additional transformer options"""
+    with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src:
+        with rasterio.MemoryFile(dirname='foo', filename='dem.tif') as mem:
+            crs = 'COMPD_CS["WGS 84 + EGM96 height",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]],VERT_CS["EGM96 height",VERT_DATUM["EGM96 geoid",2005,AUTHORITY["EPSG","5171"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Gravity-related height",UP],AUTHORITY["EPSG","5773"]]]'
+            transform = Affine(0.001953396267361111, 0.0, -124.00013888888888, 0.0, -0.001953396267361111, 50.000138888888884)
+            with mem.open(
+                driver="GTiff",
+                width=1024, 
+                height=1024, 
+                count=1,
+                transform=transform,
+                dtype='int16', 
+                crs=crs
+            ) as dem:
+                # we flush dem dataset before letting GDAL read from vsimem
+                dem.write_band(1, 500 * np.ones((1024, 1024), dtype='int16'))
+            
+            out = np.zeros(
+                (3, src.profile["width"], src.profile["height"]), dtype=np.uint8
+            )
+            out2 = out.copy()
+            src_rpcs = src.rpcs
+            caplog.set_level(logging.DEBUG)
+            reproject(
+                rasterio.band(src, src.indexes),
+                out,
+                src_crs="EPSG:4326",
+                rpcs=src_rpcs,
+                dst_crs="EPSG:3857",
+                resampling=Resampling.nearest,
+                RPC_DEM=dem.name,
+
+            )   
+
+            assert "Created exact transformer" in caplog.text
+            
+            reproject(
+                rasterio.band(src, src.indexes),
+                out2,
+                src_crs="EPSG:4326",
+                rpcs=src_rpcs,
+                dst_crs="EPSG:3857",
+                resampling=Resampling.nearest,
+
+            ) 
+
+            assert "Created approximate transformer" in caplog.text


### PR DESCRIPTION
Related:
- https://github.com/mapbox/rasterio/issues/410#issuecomment-229665628
- https://gdal.org/api/gdal_alg.html?highlight=genimgprojtransformer2#_CPPv432GDALCreateGenImgProjTransformer212GDALDatasetH12GDALDatasetHPPc

In particular:
> The use case for the *_APPROX_ERROR_* options is when defining an approximate transformer on top of the GenImgProjTransformer globally is not practical. Such a use case is when the source dataset has RPC with a RPC DEM. In such case we don’t want to use the approximate transformer on the RPC transformation, as the RPC DEM generally involves non-linearities that the approximate transformer will not detect. In such case, we must a non-approximated GenImgProjTransformer, but it might be worthwile to use approximate sub- transformers, for example on coordinate reprojection. 

This checks if we're passing the RPC_DEM kwarg to `reproject` (along with rpcs). If so, we don't try to create an approximate transformer and use the exact transformer. Also adds a new test to ensure we get the expected debug messages in each case. 