### PR TITLE
Test option to ignore overviews (OVERVIEW_LEVEL=-1)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -622,3 +622,7 @@ requires_gdal_lt_3 = pytest.mark.skipif(
 requires_gdal3 = pytest.mark.skipif(
     not gdal_version.at_least('3.0'),
     reason="Requires GDAL 3.0.x")
+
+requires_gdal33 = pytest.mark.skipif(
+    not gdal_version.at_least('3.3'),
+    reason="Requires GDAL 3.3.x")


### PR DESCRIPTION
Test for upcoming GDAL feature (from 3.3) allowing existing overviews to not be exposed
- see https://github.com/OSGeo/gdal/pull/3181
- see https://rasterio.groups.io/g/main/message/649

The test:
- requires gdal 3.3
- tests whether a dataset can be opened with OVERVIEW_LEVEL=-1
- ensures that opening a dataset with OVERVIEW_LEVEL=-1 ignores the file
overview
- ensures that a decimated read on a dataset opened with
OVERVIEW_LEVEL=1 does not read the file overview