### PR TITLE
Add new merge tool arguments

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,11 @@
 Changes
 =======
 
-1.2dev
-------
+1.2a1
+-----
+
+- Add dst_path and dst_kwds parameters to rasterio's merge tool to allow
+  results to be written directly to a dataset (#1867).
 
 1.1.8 (2020-10-20)
 ------------------

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -41,7 +41,7 @@ import rasterio.enums
 import rasterio.path
 
 __all__ = ['band', 'open', 'pad', 'Env']
-__version__ = "1.2dev"
+__version__ = "1.2a1"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -606,6 +606,19 @@ def test_merge_pathlib_path(tiffs):
     merge(inputs, res=2)
 
 
+def test_merge_output_dataset(tiffs, tmpdir):
+    """Write to an open dataset"""
+    inputs = [str(x) for x in tiffs.listdir()]
+    inputs.sort()
+    output_file = tmpdir.join("output.tif")
+    merge(inputs, res=2, dst_path=str(output_file), dst_kwds=dict(driver="PNG"))
+
+    with rasterio.open(str(output_file)) as result:
+        assert result.count == 1
+        assert result.driver == "PNG"
+        assert result.height == result.width == 2
+
+
 @fixture(scope='function')
 def test_data_dir_resampling(tmpdir):
     kwargs = {


### PR DESCRIPTION
To support resolution of #1867. Note that block-wise merge result writing is not implemented yet, that will be another piece of work. For now, results are still accumulated in one big array.

The new args come from the "tool" interface: https://github.com/mapbox/rasterio/blob/master/rasterio/tools.py#L36-L43.