### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,47 @@ jobs:
       env:
         GDALVERSION="master"
         PROJVERSION="6.2.1"
+    #powerjobs
+    - python: "3.6"
+      arch: ppc64le
+      env:
+        GDALVERSION="2.3.3"
+        PROJVERSION="4.9.3"
+    - python: "3.6"
+      arch: ppc64le
+      env:
+        GDALVERSION="2.4.4"
+        PROJVERSION="4.9.3"
+    - python: "3.7"
+      arch: ppc64le
+      env:
+        GDALVERSION="2.4.4"
+        PROJVERSION="4.9.3"
+    - python: "3.8"
+      arch: ppc64le
+      env:
+        GDALVERSION="2.4.4"
+        PROJVERSION="4.9.3"
+    - python: "3.6"
+      arch: ppc64le
+      env:
+        GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+    - python: "3.7"
+      arch: ppc64le
+      env:
+        GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+    - python: "3.8"
+      arch: ppc64le
+      env:
+        GDALVERSION="3.0.4"
+        PROJVERSION="6.2.1"
+    - python: "3.8"
+      arch: ppc64le
+      env:
+        GDALVERSION="master"
+        PROJVERSION="6.2.1"    
   allow_failures:
     - env:
         GDALVERSION="master"


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
