### PR TITLE
Add link to raserio.groups.io for questions when raising issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,8 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
 <!--
 
 WELCOME ABOARD!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Ask questions
+    url: https://rasterio.groups.io/g/main/topics
+    about: Please ask and answer questions here.


### PR DESCRIPTION
I figured this would be helpful to redirect traffic.

You can see an example of how it might look here: https://github.com/pyproj4/pyproj/issues/new/choose