### PR TITLE
Docs: Change `rasterio.insp` to `rio insp`

### DIFF
--- a/docs/topics/tags.rst
+++ b/docs/topics/tags.rst
@@ -14,7 +14,7 @@ I'm going to use the rasterio interactive inspector in these examples below.
 .. code-block:: console
 
     $ rio insp tests/data/RGB.byte.tif
-    Rasterio 1.1.7 Interactive Inspector (Python 3.7.7)
+    Rasterio 1.2.0 Interactive Inspector (Python 3.7.8)
     Type "src.name", "src.read(1)", or "help(src)" for more information.
     >>> 
 
@@ -89,4 +89,3 @@ files.
 
 As with image data, tags aren't written to the file on disk until the dataset
 is closed.
-

--- a/docs/topics/tags.rst
+++ b/docs/topics/tags.rst
@@ -13,8 +13,8 @@ I'm going to use the rasterio interactive inspector in these examples below.
 
 .. code-block:: console
 
-    $ rasterio.insp tests/data/RGB.byte.tif
-    Rasterio 0.6 Interactive Inspector (Python 2.7.5)
+    $ rio insp tests/data/RGB.byte.tif
+    Rasterio 1.1.7 Interactive Inspector (Python 3.7.7)
     Type "src.name", "src.read(1)", or "help(src)" for more information.
     >>> 
 


### PR DESCRIPTION
`rasterio.insp` didn't work for me; `rio insp` did.