### PR TITLE
make sure the WarpedVRT dataset is marked as closed on ctx exit

### DIFF
--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -122,10 +122,6 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
     def __del__(self):
         self.close()
 
-    def close(self):
-        self.stop()
-        self._closed = True
-
 
 def _boundless_vrt_doc(
         src_dataset, nodata=None, background=None, hidenodata=False,

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -124,6 +124,7 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
 
     def close(self):
         self.stop()
+        self._closed = True
 
 
 def _boundless_vrt_doc(

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -608,3 +608,11 @@ def test_vrt_mem_src_kept_alive(path_rgb_byte_tif):
 
     assert (vrt.read() != 0).any()
     vrt.close()
+
+
+def test_warped_vrt_is_closed(path_rgb_byte_tif):
+    """A VirtualVRT should be set as closed on exit."""
+    with rasterio.open(path_rgb_byte_tif) as src:
+        with WarpedVRT(src, crs=DST_CRS) as vrt:
+            assert not vrt.closed
+        assert vrt.closed


### PR DESCRIPTION
closes #2092 

The `WarpedVRT` class implement its own `close` method but was missing the `self._closed = True` as we can find in https://github.com/mapbox/rasterio/blob/17efe94c530b22b6d93fc617117080ad37f897bc/rasterio/_base.pyx#L383-L386

That is said, maybe a better fix will be to get rid of the `close` method definition in `WarpedVRT` and rely on the parent classe (`DatasetBase`) `close` method?

cc @sgillies 