### PR TITLE
#2097 fixed error string spacing

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -475,10 +475,10 @@ def calculate_default_transform(
     """
     if any(x is not None for x in (left, bottom, right, top)) and gcps:
         raise ValueError("Bounding values and ground control points may not"
-                         "be used together.")
+                         " be used together.")
     if any(x is not None for x in (left, bottom, right, top)) and rpcs:
         raise ValueError("Bounding values and rational polynomial coefficients may not"
-                         "be used together.")
+                         " be used together.")
 
     if any(x is None for x in (left, bottom, right, top)) and not (gcps or rpcs):
         raise ValueError("Either four bounding values, ground control points,"


### PR DESCRIPTION
Fixed error string spacing in rasterio/warp.py:calculate_default_transform for gcps and rpcs