### PR TITLE
Use the right dtype when checking nodataval

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -220,11 +220,11 @@ def merge(
     if nodataval is not None:
         # Only fill if the nodataval is within dtype's range
         inrange = False
-        if np.dtype(dtype).kind in ('i', 'u'):
-            info = np.iinfo(dtype)
+        if np.dtype(dt).kind in ('i', 'u'):
+            info = np.iinfo(dt)
             inrange = (info.min <= nodataval <= info.max)
-        elif np.dtype(dtype).kind == 'f':
-            info = np.finfo(dtype)
+        elif np.dtype(dt).kind == 'f':
+            info = np.finfo(dt)
             if np.isnan(nodataval):
                 inrange = True
             else:
@@ -236,7 +236,7 @@ def merge(
                 "Input file's nodata value, %s, is beyond the valid "
                 "range of its data type, %s. Consider overriding it "
                 "using the --nodata option for better results." % (
-                    nodataval, dtype))
+                    nodataval, dt))
     else:
         nodataval = 0
 

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -281,8 +281,8 @@ def merge(
             dest.fill(nodataval)
         else:
             warnings.warn(
-                "Input file's nodata value, %s, is beyond the valid "
-                "range of its data type, %s. Consider overriding it "
+                "The nodata value, %s, is beyond the valid "
+                "range of the chosen data type, %s. Consider overriding it "
                 "using the --nodata option for better results." % (
                     nodataval, dt))
     else:

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -220,10 +220,10 @@ def merge(
     if nodataval is not None:
         # Only fill if the nodataval is within dtype's range
         inrange = False
-        if np.dtype(dt).kind in ('i', 'u'):
+        if np.issubdtype(dt, np.integer):
             info = np.iinfo(dt)
             inrange = (info.min <= nodataval <= info.max)
-        elif np.dtype(dt).kind == 'f':
+        elif np.issubdtype(dt, np.floating):
             info = np.finfo(dt)
             if np.isnan(nodataval):
                 inrange = True

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -272,10 +272,10 @@ def merge(
             info = np.iinfo(dt)
             inrange = (info.min <= nodataval <= info.max)
         elif np.issubdtype(dt, np.floating):
-            info = np.finfo(dt)
             if math.isnan(nodataval):
                 inrange = True
             else:
+                info = np.finfo(dt)
                 inrange = (info.min <= nodataval <= info.max)
         if inrange:
             dest.fill(nodataval)

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -465,6 +465,19 @@ def test_merge_tiny_res_bounds(tiffs, runner):
         assert data[0, 1, 1] == 0
 
 
+def test_merge_out_of_range_nodata(tiffs):
+    inputs = [
+        'tests/data/rgb1.tif',
+        'tests/data/rgb2.tif',
+        'tests/data/rgb3.tif',
+        'tests/data/rgb4.tif']
+    datasets = [rasterio.open(x) for x in inputs]
+    assert datasets[1].dtypes[0] == 'uint8'
+
+    with pytest.warns(UserWarning):
+        rv, transform = merge(datasets, nodata=9999)
+    assert not (rv == np.uint8(9999)).any()
+
 @pytest.mark.xfail(
     gdal_version.major == 1,
     reason="GDAL versions < 2 do not support data read/write with float sizes and offsets",


### PR DESCRIPTION
According the documentation of this function, if `dtype` is None, then the dtype of the first dataset is used. This is stored in `dt`. However, if `dtype` is not None, then `dt = dtype`. Therefore, when checking if `nodataval` is in range, `dt` should be used instead of `dtype`.

If the first dataset has a dtype of `int8` and the `merge(datasets, nodata=9999)` is called, the checks for `nodataval` being in range will use float64, since `np.dtype(None) == np.float64`. But, according to the documentation, `merge` should be default to `int8` as the dtype. In this scenario, `dest` will get filled with a `nodataval` that would be out of range of the dtype.

EDIT: This is a more serious problem than I thought. It could explain some strange values I've seen in past merges. In the scenario above the 9999 nodata value becomes 15 in the merged result because of the wraparound of the datatype.
To avoid this problem, when you define `nodata`, you _must_ define `dtype` as well.