### PR TITLE
Avoid extra array allocations in copyto functions

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -325,10 +325,9 @@ def merge(
         region = dest[:, roff:roff + trows, coff:coff + tcols]
         if np.isnan(nodataval):
             region_nodata = np.isnan(region)
-            temp_nodata = np.isnan(temp)
         else:
             region_nodata = region == nodataval
-            temp_nodata = temp.mask
+        temp_nodata = np.ma.getmaskarray(temp)
 
         copyto(region, temp, region_nodata, temp_nodata,
                index=idx, roff=roff, coff=coff)

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -273,7 +273,7 @@ def merge(
             inrange = (info.min <= nodataval <= info.max)
         elif np.dtype(dtype).kind == 'f':
             info = np.finfo(dtype)
-            if np.isnan(nodataval):
+            if math.isnan(nodataval):
                 inrange = True
             else:
                 inrange = (info.min <= nodataval <= info.max)
@@ -332,7 +332,8 @@ def merge(
             int(round(dst_window.row_off)), int(round(dst_window.col_off)))
 
         region = dest[:, roff:roff + trows, coff:coff + tcols]
-        if np.isnan(nodataval):
+
+        if math.isnan(nodataval):
             region_nodata = np.isnan(region)
         else:
             region_nodata = region == nodataval

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -142,6 +142,7 @@ def merge(
                 row offset in base array
             coff: int
                 column offset in base array
+
     dst_path : str or Pathlike, optional
         Path of output dataset
     dst_kwds : dict, optional
@@ -168,7 +169,7 @@ def merge(
         copyto = method
     else:
         raise ValueError('Unknown method {0}, must be one of {1} or callable'
-                         .format(method, MERGE_METHODS))
+                         .format(method, list(MERGE_METHODS.keys())))
 
     # Create a dataset_opener object to use in several places in this function.
     if isinstance(datasets[0], str) or isinstance(datasets[0], Path):

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -242,31 +242,39 @@ def merge(
 
     if method == 'first':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.logical_and(old_nodata, ~new_nodata)
-            old_data[mask] = new_data[mask]
+            mask = np.empty_like(new_nodata, dtype='bool')
+            np.logical_not(new_nodata, out=mask)
+            np.logical_and(old_nodata, mask, out=mask)
+            np.copyto(old_data, new_data, where=mask)
 
     elif method == 'last':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
             mask = ~new_nodata
-            old_data[mask] = new_data[mask]
+            np.copyto(old_data, new_data, where=mask)
 
     elif method == 'min':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.logical_and(~old_nodata, ~new_nodata)
-            old_masked = old_data[mask]
-            np.minimum(old_masked, new_data[mask], old_masked)
+            mask = np.empty_like(new_nodata, dtype='bool')
+            np.logical_or(old_nodata, new_nodata, out=mask)
+            np.logical_not(mask, out=mask)
 
-            mask = np.logical_and(old_nodata, ~new_nodata)
-            old_data[mask] = new_data[mask]
+            np.minimum(old_data, new_data, out=old_data, where=mask)
+
+            np.logical_not(new_nodata, out=mask)
+            np.logical_and(old_data, mask, out=mask)
+            np.copyto(old_data, new_data, where=mask)
 
     elif method == 'max':
-        def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.logical_and(~old_nodata, ~new_nodata)
-            old_masked = old_data[mask]
-            np.maximum(old_masked, new_data[mask], old_masked)
+        def copyto1(old_data, new_data, old_nodata, new_nodata, **kwargs):
+            mask = np.empty_like(new_nodata, dtype='bool')
+            np.logical_or(old_nodata, new_nodata, out=mask)
+            np.logical_not(mask, out=mask)
+            
+            np.maximum(old_data, new_data, out=old_data, where=mask)
 
-            mask = np.logical_and(old_nodata, ~new_nodata)
-            old_data[mask] = new_data[mask]
+            np.logical_not(new_nodata, out=mask)
+            np.logical_and(old_data, mask, out=mask)
+            np.copyto(old_data, new_data, where=mask)
 
     elif callable(method):
         copyto = method

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -242,18 +242,21 @@ def merge(
 
     if method == 'first':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.logical_not(new_nodata)
+            mask = np.empty_like(old_data, dtype='bool')
+            np.logical_not(new_nodata, out=mask)
             np.logical_and(old_nodata, mask, out=mask)
             np.copyto(old_data, new_data, where=mask)
 
     elif method == 'last':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.logical_not(new_nodata)
+            mask = np.empty_like(old_data, dtype='bool')
+            np.logical_not(new_nodata, out=mask)
             np.copyto(old_data, new_data, where=mask)
 
     elif method == 'min':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.logical_or(old_nodata, new_nodata)
+            mask = np.empty_like(old_data, dtype='bool')
+            np.logical_or(old_nodata, new_nodata, out=mask)
             np.logical_not(mask, out=mask)
 
             np.minimum(old_data, new_data, out=old_data, where=mask)
@@ -264,7 +267,8 @@ def merge(
 
     elif method == 'max':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.logical_or(old_nodata, new_nodata)
+            mask = np.empty_like(old_data, dtype='bool')
+            np.logical_or(old_nodata, new_nodata, out=mask)
             np.logical_not(mask, out=mask)
             
             np.maximum(old_data, new_data, out=old_data, where=mask)

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -16,7 +16,50 @@ from rasterio.transform import Affine
 
 logger = logging.getLogger(__name__)
 
-MERGE_METHODS = ('first', 'last', 'min', 'max')
+
+def copy_first(old_data, new_data, old_nodata, new_nodata, **kwargs):
+    mask = np.empty_like(old_data, dtype='bool')
+    np.logical_not(new_nodata, out=mask)
+    np.logical_and(old_nodata, mask, out=mask)
+    np.copyto(old_data, new_data, where=mask)
+
+
+def copy_last(old_data, new_data, old_nodata, new_nodata, **kwargs):
+    mask = np.empty_like(old_data, dtype='bool')
+    np.logical_not(new_nodata, out=mask)
+    np.copyto(old_data, new_data, where=mask)
+
+
+def copy_min(old_data, new_data, old_nodata, new_nodata, **kwargs):
+    mask = np.empty_like(old_data, dtype='bool')
+    np.logical_or(old_nodata, new_nodata, out=mask)
+    np.logical_not(mask, out=mask)
+
+    np.minimum(old_data, new_data, out=old_data, where=mask)
+
+    np.logical_not(new_nodata, out=mask)
+    np.logical_and(old_data, mask, out=mask)
+    np.copyto(old_data, new_data, where=mask)
+
+
+def copy_max(old_data, new_data, old_nodata, new_nodata, **kwargs):
+    mask = np.empty_like(old_data, dtype='bool')
+    np.logical_or(old_nodata, new_nodata, out=mask)
+    np.logical_not(mask, out=mask)
+
+    np.maximum(old_data, new_data, out=old_data, where=mask)
+
+    np.logical_not(new_nodata, out=mask)
+    np.logical_and(old_data, mask, out=mask)
+    np.copyto(old_data, new_data, where=mask)
+
+
+MERGE_METHODS = {
+    'first': copy_first,
+    'last': copy_last,
+    'min': copy_min,
+    'max': copy_max
+}
 
 
 def merge(
@@ -119,7 +162,11 @@ def merge(
                 coordinate system
 
     """
-    if method not in MERGE_METHODS and not callable(method):
+    if method in MERGE_METHODS:
+        copyto = MERGE_METHODS[method]
+    elif callable(method):
+        copyto = method
+    else:
         raise ValueError('Unknown method {0}, must be one of {1} or callable'
                          .format(method, MERGE_METHODS))
 
@@ -239,49 +286,6 @@ def merge(
                     nodataval, dtype))
     else:
         nodataval = 0
-
-    if method == 'first':
-        def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.empty_like(old_data, dtype='bool')
-            np.logical_not(new_nodata, out=mask)
-            np.logical_and(old_nodata, mask, out=mask)
-            np.copyto(old_data, new_data, where=mask)
-
-    elif method == 'last':
-        def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.empty_like(old_data, dtype='bool')
-            np.logical_not(new_nodata, out=mask)
-            np.copyto(old_data, new_data, where=mask)
-
-    elif method == 'min':
-        def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.empty_like(old_data, dtype='bool')
-            np.logical_or(old_nodata, new_nodata, out=mask)
-            np.logical_not(mask, out=mask)
-
-            np.minimum(old_data, new_data, out=old_data, where=mask)
-
-            np.logical_not(new_nodata, out=mask)
-            np.logical_and(old_data, mask, out=mask)
-            np.copyto(old_data, new_data, where=mask)
-
-    elif method == 'max':
-        def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.empty_like(old_data, dtype='bool')
-            np.logical_or(old_nodata, new_nodata, out=mask)
-            np.logical_not(mask, out=mask)
-            
-            np.maximum(old_data, new_data, out=old_data, where=mask)
-
-            np.logical_not(new_nodata, out=mask)
-            np.logical_and(old_data, mask, out=mask)
-            np.copyto(old_data, new_data, where=mask)
-
-    elif callable(method):
-        copyto = method
-
-    else:
-        raise ValueError(method)
 
     for idx, dataset in enumerate(datasets):
         with dataset_opener(dataset) as src:

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -265,7 +265,7 @@ def merge(
             np.copyto(old_data, new_data, where=mask)
 
     elif method == 'max':
-        def copyto1(old_data, new_data, old_nodata, new_nodata, **kwargs):
+        def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
             mask = np.empty_like(new_nodata, dtype='bool')
             np.logical_or(old_nodata, new_nodata, out=mask)
             np.logical_not(mask, out=mask)

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -253,7 +253,8 @@ def merge(
     elif method == 'min':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
             mask = np.logical_and(~old_nodata, ~new_nodata)
-            old_data[mask] = np.minimum(old_data[mask], new_data[mask])
+            old_masked = old_data[mask]
+            np.minimum(old_masked, new_data[mask], old_masked)
 
             mask = np.logical_and(old_nodata, ~new_nodata)
             old_data[mask] = new_data[mask]
@@ -261,7 +262,8 @@ def merge(
     elif method == 'max':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
             mask = np.logical_and(~old_nodata, ~new_nodata)
-            old_data[mask] = np.maximum(old_data[mask], new_data[mask])
+            old_masked = old_data[mask]
+            np.maximum(old_masked, new_data[mask], old_masked)
 
             mask = np.logical_and(old_nodata, ~new_nodata)
             old_data[mask] = new_data[mask]

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -242,20 +242,18 @@ def merge(
 
     if method == 'first':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.empty_like(new_nodata, dtype='bool')
-            np.logical_not(new_nodata, out=mask)
+            mask = np.logical_not(new_nodata)
             np.logical_and(old_nodata, mask, out=mask)
             np.copyto(old_data, new_data, where=mask)
 
     elif method == 'last':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = ~new_nodata
+            mask = np.logical_not(new_nodata)
             np.copyto(old_data, new_data, where=mask)
 
     elif method == 'min':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.empty_like(new_nodata, dtype='bool')
-            np.logical_or(old_nodata, new_nodata, out=mask)
+            mask = np.logical_or(old_nodata, new_nodata)
             np.logical_not(mask, out=mask)
 
             np.minimum(old_data, new_data, out=old_data, where=mask)
@@ -266,8 +264,7 @@ def merge(
 
     elif method == 'max':
         def copyto(old_data, new_data, old_nodata, new_nodata, **kwargs):
-            mask = np.empty_like(new_nodata, dtype='bool')
-            np.logical_or(old_nodata, new_nodata, out=mask)
+            mask = np.logical_or(old_nodata, new_nodata)
             np.logical_not(mask, out=mask)
             
             np.maximum(old_data, new_data, out=old_data, where=mask)


### PR DESCRIPTION
In microbenchmark tests, the inplace seems to be slightly faster.

The main win is that we avoid creating allocating a new, potentially large, array every time the function is called