### PR TITLE
Plum the new rowcol precision default all the way up thru rio-merge

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 1.2.1 (TBD)
 -----------
 
-- Fix an off-by-one error in the merge tool (#2106, #).
+- Fix an off-by-one error in the merge tool (#2106, #2109).
 
 1.2.0 (2021-01-25)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+1.2.1 (TBD)
+-----------
+
+- Fix an off-by-one error in the merge tool (#2106, #).
+
 1.2.0 (2021-01-25)
 ------------------
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -27,7 +27,7 @@ import rasterio.enums
 import rasterio.path
 
 __all__ = ['band', 'open', 'pad', 'Env']
-__version__ = "1.2.0"
+__version__ = "1.2.1dev"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -68,7 +68,7 @@ def merge(
     res=None,
     nodata=None,
     dtype=None,
-    precision=10,
+    precision=None,
     indexes=None,
     output_count=None,
     resampling=Resampling.nearest,

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -21,9 +21,12 @@ from rasterio.rio.helpers import resolve_inout
 @options.nodata_opt
 @options.bidx_mult_opt
 @options.overwrite_opt
-@click.option('--precision', type=int, default=10,
-              help="Number of decimal places of precision in alignment of "
-                   "pixels")
+@click.option(
+    "--precision",
+    type=int,
+    default=None,
+    help="Number of decimal places of precision in alignment of pixels",
+)
 @options.creation_options
 @click.pass_context
 def merge(ctx, files, output, driver, bounds, res, resampling,

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -226,11 +226,14 @@ def rowcol(transform, xs, ys, op=math.floor, precision=None):
         ys = [ys]
 
     if precision is None:
-        eps = sys.float_info.epsilon * (1.0 - 2.0 * op(0.1))
+        eps = sys.float_info.epsilon
     elif isinstance(precision, int):
-        eps = 10.0 ** -precision * (1.0 - 2.0 * op(0.1))
+        eps = 10.0 ** -precision
     else:
         eps = precision
+
+    if op(0.1) > 0.1:
+        eps = -eps
 
     invtransform = ~transform
 

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -208,8 +208,9 @@ def rowcol(transform, xs, ys, op=math.floor, precision=None):
     op : function
         Function to convert fractional pixels to whole numbers (floor, ceiling,
         round)
-    precision : int, optional
-        Decimal places of precision in indexing, as in `round()`.
+    precision : int or float, optional
+        An integer number of decimal points of precision when computing
+        inverse transform, or an absolute float precision.
 
     Returns
     -------
@@ -224,8 +225,13 @@ def rowcol(transform, xs, ys, op=math.floor, precision=None):
     if not isinstance(ys, Iterable):
         ys = [ys]
 
-    eps = sys.float_info.epsilon
-    
+    if precision is None:
+        eps = sys.float_info.epsilon * (1.0 - 2.0 * op(0.1))
+    elif isinstance(precision, int):
+        eps = 10.0 ** -precision * (1.0 - 2.0 * op(0.1))
+    else:
+        eps = precision
+
     invtransform = ~transform
 
     rows = []

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -232,7 +232,8 @@ def rowcol(transform, xs, ys, op=math.floor, precision=None):
     else:
         eps = precision
 
-    if op(0.1) > 0.1:
+    # If op rounds up, switch the sign of eps.
+    if op(0.1) >= 1:
         eps = -eps
 
     invtransform = ~transform

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -271,9 +271,9 @@ def from_bounds(left, bottom, right, top, transform=None,
         Number of rows of the window.
     width: int, required
         Number of columns of the window.
-    precision: int, optional
-        Number of decimal points of precision when computing inverse
-        transform.
+    precision: int or float, optional
+        An integer number of decimal points of precision when computing
+        inverse transform, or an absolute float precision.
 
     Returns
     -------
@@ -680,6 +680,7 @@ class Window(object):
                 operator(round(self.height, pixel_precision) if
                          pixel_precision is not None else self.height))
 
+    # TODO: deprecate round_shape at 1.3.0, with a warning.
     round_shape = round_lengths
 
     def round_offsets(self, op='floor', pixel_precision=None):


### PR DESCRIPTION
Follow up to #2106. Restores the previous behavior for the benefit of users who depend on it, but also makes the new better eps default in `rowcol` available in the merge tool and CLI.