### PR TITLE
Transform.xy performance improvement

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -27,7 +27,7 @@ import rasterio.enums
 import rasterio.path
 
 __all__ = ['band', 'open', 'pad', 'Env']
-__version__ = "1.2.1dev"
+__version__ = "1.3dev"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -27,7 +27,7 @@ import rasterio.enums
 import rasterio.path
 
 __all__ = ['band', 'open', 'pad', 'Env']
-__version__ = "1.3dev"
+__version__ = "1.2.1dev"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -154,7 +154,7 @@ def xy(transform, rows, cols, offset='center'):
         cols = [cols]
     if not isinstance(rows, Iterable):
         rows = [rows]
-        
+
     if offset == 'center':
         coff, roff = (0.5, 0.5)
     elif offset == 'ul':
@@ -239,11 +239,9 @@ def rowcol(transform, xs, ys, op=math.floor, precision=None):
         cols.append(op(fcol))
         rows.append(op(frow))
 
-    if len(xs) == 1:
-        cols = cols[0]
-    if len(ys) == 1:
-        rows = rows[0]
-
+    if len(cols) == 1:
+        # rows and cols will always have the same length
+        return rows[0], cols[0]
     return rows, cols
 
 

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -150,16 +150,11 @@ def xy(transform, rows, cols, offset='center'):
     ys : list
         y coordinates in coordinate reference system
     """
-
-    single_col = False
-    single_row = False
     if not isinstance(cols, Iterable):
         cols = [cols]
-        single_col = True
     if not isinstance(rows, Iterable):
         rows = [rows]
-        single_row = True
-
+        
     if offset == 'center':
         coff, roff = (0.5, 0.5)
     elif offset == 'ul':
@@ -175,16 +170,15 @@ def xy(transform, rows, cols, offset='center'):
 
     xs = []
     ys = []
-    for col, row in zip(cols, rows):
-        x, y = transform * transform.translation(coff, roff) * (col, row)
+    T = transform * transform.translation(coff, roff)
+    for pt in zip(cols, rows):
+        x, y = T * pt
         xs.append(x)
         ys.append(y)
 
-    if single_row:
-        ys = ys[0]
-    if single_col:
-        xs = xs[0]
-
+    if len(xs) == 1:
+        # xs and ys will always have the same length
+        return xs[0], ys[0]
     return xs, ys
 
 


### PR DESCRIPTION
In transform.xy, lifted the static part of computation outside of the loop.

Also take advantage of the fact that lists we build up will always be exactly the same length, so only check one list to see if we need to unpack the first element or not.