### PR TITLE
Raise an exception while clipping rotated raster with rio clip

### DIFF
--- a/rasterio/rio/clip.py
+++ b/rasterio/rio/clip.py
@@ -95,6 +95,10 @@ def clip(
         input = files[0]
 
         with rasterio.open(input) as src:
+            rotated = src.transform.b != 0 or src.transform.d != 0
+            if rotated:
+                raise click.BadParameter('rotated raster cannot be clipped')
+
             if bounds:
                 if projection == 'geographic':
                     bounds = transform_bounds(CRS.from_epsg(4326), src.crs, *bounds)


### PR DESCRIPTION
Fixes https://github.com/mapbox/rasterio/issues/2112