### PR TITLE
Load Windows DLL directories for Python >= 3.8

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes
 -----------
 
 - Building from source now requires Cython (#2016).
+- add GDAL DLL directory to DLL search path on Windows and Python >= 3.8. 
+  DLLs will be loaded from .libs (for wheels) or from directories in PATH 
+  environment variable.
 
 1.2.1 (2021-03-03)
 ------------------

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -6,25 +6,27 @@ import logging
 from logging import NullHandler
 from pathlib import Path
 
-from rasterio._base import gdal_version
-from rasterio.drivers import driver_from_extension, is_blacklisted
-from rasterio.dtypes import (
-    bool_, ubyte, sbyte, uint8, int8, uint16, int16, uint32, int32, float32, float64,
-    complex_, check_dtype)
-from rasterio.env import ensure_env_with_credentials, Env
-from rasterio.errors import RasterioIOError, DriverCapabilityError
-from rasterio.io import (
-    DatasetReader, get_writer_for_path, get_writer_for_driver, MemoryFile)
-from rasterio.profiles import default_gtiff_profile
-from rasterio.transform import Affine, guard_transform
-from rasterio.path import parse_path
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio._base import gdal_version
+    from rasterio.drivers import driver_from_extension, is_blacklisted
+    from rasterio.dtypes import (
+        bool_, ubyte, sbyte, uint8, int8, uint16, int16, uint32, int32, float32, float64,
+        complex_, check_dtype)
+    from rasterio.env import ensure_env_with_credentials, Env
+    from rasterio.errors import RasterioIOError, DriverCapabilityError
+    from rasterio.io import (
+        DatasetReader, get_writer_for_path, get_writer_for_driver, MemoryFile)
+    from rasterio.profiles import default_gtiff_profile
+    from rasterio.transform import Affine, guard_transform
+    from rasterio.path import parse_path
 
-# These modules are imported from the Cython extensions, but are also import
-# here to help tools like cx_Freeze find them automatically
-import rasterio._err
-import rasterio.coords
-import rasterio.enums
-import rasterio.path
+    # These modules are imported from the Cython extensions, but are also import
+    # here to help tools like cx_Freeze find them automatically
+    import rasterio._err
+    import rasterio.coords
+    import rasterio.enums
+    import rasterio.path
 
 __all__ = ['band', 'open', 'pad', 'Env']
 __version__ = "1.3dev"

--- a/rasterio/_loading.py
+++ b/rasterio/_loading.py
@@ -1,0 +1,32 @@
+import glob
+import os
+import logging
+import contextlib
+import platform
+import sys
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+# With Python >= 3.8 on Windows directories in PATH are not automatically
+# searched for DLL dependencies and must be added manually with
+# os.add_dll_directory.
+# see https://github.com/Toblerity/Fiona/issues/851
+
+@contextlib.contextmanager
+def add_gdal_dll_directories():
+    dll_dirs = []
+    if platform.system() == 'Windows' and sys.version_info >= (3, 8):
+        dll_directory = os.path.join(os.path.dirname(__file__), '.libs')
+        if os.path.exists(dll_directory):
+            dll_dirs.append(os.add_dll_directory(dll_directory))
+        else:
+            if 'PATH' in os.environ:
+                for p in os.environ['PATH'].split(os.pathsep):
+                    if glob.glob(os.path.join(p, 'gdal*.dll')):
+                        os.add_dll_directory(p)
+    try:
+        yield None
+    finally:
+        for dll_dir in dll_dirs:
+            dll_dir.close()

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -14,8 +14,10 @@ from collections.abc import Mapping
 import json
 import pickle
 
-from rasterio._crs import _CRS, all_proj_keys, _epsg_treats_as_latlong, _epsg_treats_as_northingeasting
-from rasterio.errors import CRSError
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio._crs import _CRS, all_proj_keys, _epsg_treats_as_latlong, _epsg_treats_as_northingeasting
+    from rasterio.errors import CRSError
 
 
 class CRS(Mapping):

--- a/rasterio/drivers.py
+++ b/rasterio/drivers.py
@@ -11,8 +11,10 @@ http://unidata.github.io/netcdf4-python/.
 """
 import os
 
-from rasterio._base import _raster_driver_extensions
-from rasterio.env import GDALVersion, ensure_env, require_gdal_version
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio._base import _raster_driver_extensions
+    from rasterio.env import GDALVersion, ensure_env, require_gdal_version
 
 # Methods like `rasterio.open()` may use this blacklist to preempt
 # combinations of drivers and file modes.

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -9,12 +9,14 @@ import re
 import threading
 import warnings
 
-from rasterio._env import (
-        GDALEnv, get_gdal_config, set_gdal_config,
-        GDALDataFinder, PROJDataFinder, set_proj_data_search_path)
-from rasterio.errors import (
-    EnvError, GDALVersionError, RasterioDeprecationWarning)
-from rasterio.session import Session, DummySession
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio._env import (
+            GDALEnv, get_gdal_config, set_gdal_config,
+            GDALDataFinder, PROJDataFinder, set_proj_data_search_path)
+    from rasterio.errors import (
+        EnvError, GDALVersionError, RasterioDeprecationWarning)
+    from rasterio.session import Session, DummySession
 
 
 class ThreadEnv(threading.local):

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -8,17 +8,20 @@ import warnings
 
 import numpy as np
 
-import rasterio
-from rasterio.dtypes import validate_dtype, can_cast_dtype, get_minimum_dtype
-from rasterio.enums import MergeAlg
-from rasterio.env import ensure_env
-from rasterio.errors import ShapeSkipWarning
-from rasterio._features import _shapes, _sieve, _rasterize, _bounds
-from rasterio import warp
-from rasterio.rio.helpers import coords
-from rasterio.transform import Affine
-from rasterio.transform import IDENTITY, guard_transform, rowcol
-from rasterio.windows import Window
+
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    import rasterio
+    from rasterio.dtypes import validate_dtype, can_cast_dtype, get_minimum_dtype
+    from rasterio.enums import MergeAlg
+    from rasterio.env import ensure_env
+    from rasterio.errors import ShapeSkipWarning
+    from rasterio._features import _shapes, _sieve, _rasterize, _bounds
+    from rasterio import warp
+    from rasterio.rio.helpers import coords
+    from rasterio.transform import Affine
+    from rasterio.transform import IDENTITY, guard_transform, rowcol
+    from rasterio.windows import Window
 
 log = logging.getLogger(__name__)
 

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -1,9 +1,12 @@
 """Fill holes in raster dataset by interpolation from the edges."""
 
-import rasterio
-from rasterio._fill import _fillnodata
-from rasterio.env import ensure_env
-from rasterio import dtypes
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+
+    import rasterio
+    from rasterio._fill import _fillnodata
+    from rasterio.env import ensure_env
+    from rasterio import dtypes
 
 from numpy.ma import MaskedArray
 

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -5,15 +5,17 @@ Instances of these classes are called dataset objects.
 
 import logging
 
-from rasterio._base import (
-    get_dataset_driver, driver_can_create, driver_can_create_copy)
-from rasterio._io import (
-    DatasetReaderBase, DatasetWriterBase, BufferedDatasetWriterBase,
-    MemoryFileBase)
-from rasterio.windows import WindowMethodsMixin
-from rasterio.env import ensure_env, env_ctx_if_needed
-from rasterio.transform import TransformMethodsMixin
-from rasterio.path import UnparsedPath
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio._base import (
+        get_dataset_driver, driver_can_create, driver_can_create_copy)
+    from rasterio._io import (
+        DatasetReaderBase, DatasetWriterBase, BufferedDatasetWriterBase,
+        MemoryFileBase)
+    from rasterio.windows import WindowMethodsMixin
+    from rasterio.env import ensure_env, env_ctx_if_needed
+    from rasterio.transform import TransformMethodsMixin
+    from rasterio.path import UnparsedPath
 
 
 log = logging.getLogger(__name__)

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -5,8 +5,10 @@ import warnings
 
 import numpy
 
-from rasterio.errors import WindowError
-from rasterio.features import geometry_mask, geometry_window
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio.errors import WindowError
+    from rasterio.features import geometry_mask, geometry_window
 
 
 logger = logging.getLogger(__name__)

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -8,10 +8,12 @@ import warnings
 
 import numpy as np
 
-import rasterio
-from rasterio.enums import Resampling
-from rasterio import windows
-from rasterio.transform import Affine
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    import rasterio
+    from rasterio.enums import Resampling
+    from rasterio import windows
+    from rasterio.transform import Affine
 
 
 logger = logging.getLogger(__name__)

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -12,9 +12,11 @@ import warnings
 
 import numpy as np
 
-import rasterio
-from rasterio.io import DatasetReader
-from rasterio.transform import guard_transform
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    import rasterio
+    from rasterio.io import DatasetReader
+    from rasterio.transform import guard_transform
 
 logger = logging.getLogger(__name__)
 

--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -2,8 +2,10 @@
 
 import numpy
 
-from rasterio.enums import MaskFlags
-from rasterio.windows import Window
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio.enums import MaskFlags
+    from rasterio.windows import Window
 
 
 def sample_gen(dataset, xy, indexes=None, masked=False):

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -3,7 +3,9 @@
 import logging
 import os
 
-from rasterio.path import parse_path, UnparsedPath
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio.path import parse_path, UnparsedPath
 
 
 log = logging.getLogger(__name__)

--- a/rasterio/tools.py
+++ b/rasterio/tools.py
@@ -6,8 +6,10 @@ https://github.com/mapbox/rasterio/issues/1300.
 
 import json
 
-import rasterio
-from rasterio.features import dataset_features
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    import rasterio
+    from rasterio.features import dataset_features
 
 
 class JSONSequenceTool(object):

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -6,7 +6,9 @@ import sys
 
 from affine import Affine
 
-from rasterio._transform import _transform_from_gcps
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio._transform import _transform_from_gcps
 
 IDENTITY = Affine.identity()
 GDAL_IDENTITY = IDENTITY.to_gdal()

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -2,14 +2,16 @@
 
 import xml.etree.ElementTree as ET
 
-import rasterio
-from rasterio._warp import WarpedVRTReaderBase
-from rasterio.dtypes import _gdal_typename
-from rasterio.enums import MaskFlags
-from rasterio.env import env_ctx_if_needed
-from rasterio.path import parse_path
-from rasterio.transform import TransformMethodsMixin
-from rasterio.windows import WindowMethodsMixin
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    import rasterio
+    from rasterio._warp import WarpedVRTReaderBase
+    from rasterio.dtypes import _gdal_typename
+    from rasterio.enums import MaskFlags
+    from rasterio.env import env_ctx_if_needed
+    from rasterio.path import parse_path
+    from rasterio.transform import TransformMethodsMixin
+    from rasterio.windows import WindowMethodsMixin
 
 
 class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -4,14 +4,17 @@ from math import ceil, floor
 
 from affine import Affine
 import numpy as np
-import rasterio
 
-from rasterio._base import _transform
-from rasterio.enums import Resampling
-from rasterio.env import GDALVersion, ensure_env, require_gdal_version
-from rasterio.errors import GDALBehaviorChangeException, TransformError
-from rasterio.transform import array_bounds
-from rasterio._warp import _calculate_default_transform, _reproject, _transform_geom
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    import rasterio
+
+    from rasterio._base import _transform
+    from rasterio.enums import Resampling
+    from rasterio.env import GDALVersion, ensure_env, require_gdal_version
+    from rasterio.errors import GDALBehaviorChangeException, TransformError
+    from rasterio.transform import array_bounds
+    from rasterio._warp import _calculate_default_transform, _reproject, _transform_geom
 
 # Gauss (7) is not supported for warp
 SUPPORTED_RESAMPLING = [r for r in Resampling if r.value < 7]

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -26,8 +26,10 @@ from affine import Affine
 import attr
 import numpy as np
 
-from rasterio.errors import WindowError
-from rasterio.transform import rowcol, guard_transform
+import rasterio._loading
+with rasterio._loading.add_gdal_dll_directories():
+    from rasterio.errors import WindowError
+    from rasterio.transform import rowcol, guard_transform
 
 
 class WindowMethodsMixin(object):


### PR DESCRIPTION
This aims to replicate steps that have been taken in https://github.com/Toblerity/Fiona/pull/875 for Fiona regarding Python >= 3.8 and Windows.

Largely direct adaption of the aforementioned PR, with additional steps taken to add directories to `os.add_dll_directory` from PATH environment variable if they are found to contain a gdal DLL. Although rasterio doesn't currently publish Windows wheels, this would still help users who:

- build their own wheels (and include dlls in `.libs` directory)
- build from source

From https://github.com/mapbox/rasterio/issues/2064 

> Travis CI isn't supporting Python 3.9 for macos yet, I see other projects switching to AppVeyor or GitHub Actions. I think we will eventually have to do so too, and pick up Windows along the way.

so in the future, if Windows wheels are provided this should make things a tiny bit easier.
