### PR TITLE
Exclude c files from the distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CHANGES.txt AUTHORS.txt LICENSE.txt VERSION.txt README.rst setup.py pypr
 include rasterio/*.pyx
 include rasterio/*.pxd
 include rasterio/*.pxi
+exclude rasterio/*.c
 recursive-include examples *.py
 recursive-include tests *.py *.rst
 recursive-exclude tests/data *.tif


### PR DESCRIPTION
Apparently this causes issues when using compile time environment variables: https://github.com/pyproj4/pyproj/issues/791