### PR TITLE
Don't create AWSSession for presigned URLs

### DIFF
--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -100,7 +100,9 @@ class Session(object):
         if isinstance(path, UnparsedPath) or path.is_local:
             return DummySession
 
-        elif path.scheme == "s3" or "amazonaws.com" in path.path:
+        elif (
+            path.scheme == "s3" or "amazonaws.com" in path.path
+        ) and not "X-Amz-Signature" in path.path:
             if boto3 is not None:
                 return AWSSession
             else:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -116,6 +116,12 @@ def test_session_factory_s3():
     assert isinstance(sesh, AWSSession)
 
 
+def test_session_factory_s3_presigned_url():
+    """Get a DummySession for presigned URLs"""
+    sesh = Session.from_path("https://fancy-cloud.com/lolwut?X-Amz-Signature=foo")
+    assert isinstance(sesh, DummySession)
+
+
 def test_session_factory_s3_no_boto3(monkeypatch):
     """Get an AWSSession for s3:// paths"""
     pytest.importorskip("boto3")


### PR DESCRIPTION
I have an AWS SSO setup on my machine but if I'm not logged in then `rasterio.open` raises an exception while opening presigned URLs.