### PR TITLE
DEP: use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "cython==0.29.21", "numpy==1.19.5"]
+requires = ["setuptools", "wheel", "cython==0.29.21", "oldest-supported-numpy"]


### PR DESCRIPTION
- Closes #1608 
- Also related to #1741