### PR TITLE
DEP: use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,2 @@
 [build-system]
-requires = [
-    "setuptools",
-    "wheel",
-    "cython==0.29.21",
-    "numpy==1.13.3; python_version=='3.6'",
-    "numpy==1.14.5; python_version=='3.7'",
-    "numpy==1.17.3; python_version=='3.8'",
-    "numpy==1.19.3; python_version=='3.9'",
-    "numpy; python_version>='3.10'",
-]
+requires = ["setuptools", "wheel", "cython==0.29.21", "oldest-supported-numpy"]


### PR DESCRIPTION
Forward from #2142
- Closes #1608
- Also related to #1741
