### PR TITLE
Python3 classes does not need to inherit from object

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -223,7 +223,7 @@ cdef GDALDatasetH open_dataset(
             CSLDestroy(options)
 
 
-cdef class DatasetBase(object):
+cdef class DatasetBase:
     """Dataset base class
 
     Attributes

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -69,7 +69,7 @@ def _epsg_treats_as_northingeasting(input_crs):
         raise CRSError("{}".format(exc))
 
 
-cdef class _CRS(object):
+cdef class _CRS:
     """Cython extension class"""
 
     def __cinit__(self):

--- a/rasterio/_env.pxd
+++ b/rasterio/_env.pxd
@@ -1,6 +1,6 @@
 # cython: language_level=3
 
-cdef class ConfigEnv(object):
+cdef class ConfigEnv:
     cdef public object options
 
 

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -176,7 +176,7 @@ cpdef del_gdal_config(key):
         CPLSetThreadLocalConfigOption(<const char *>key, NULL)
 
 
-cdef class ConfigEnv(object):
+cdef class ConfigEnv:
     """Configuration option management"""
 
     def __init__(self, **options):
@@ -199,7 +199,7 @@ cdef class ConfigEnv(object):
         return {k: get_gdal_config(k) for k in self.options}
 
 
-class GDALDataFinder(object):
+class GDALDataFinder:
     """Finds GDAL data files
 
     Note: this is not part of the public API in 1.0.x.
@@ -273,7 +273,7 @@ def catch_errors():
         CPLPopErrorHandler()
 
 
-class PROJDataFinder(object):
+class PROJDataFinder:
     """Finds PROJ data files
 
     Note: this is not part of the public API in 1.0.x.

--- a/rasterio/control.py
+++ b/rasterio/control.py
@@ -3,7 +3,7 @@
 import uuid
 
 
-class GroundControlPoint(object):
+class GroundControlPoint:
     """A mapping of row, col image coordinates to x, y, z."""
 
     def __init__(self, row=None, col=None, x=None, y=None, z=None,

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -54,7 +54,7 @@ local = ThreadEnv()
 log = logging.getLogger(__name__)
 
 
-class Env(object):
+class Env:
     """Abstraction for GDAL and AWS configuration
 
     The GDAL library is stateful: it has a registry of format drivers,
@@ -351,7 +351,7 @@ def delenv():
     local._env = None
 
 
-class NullContextManager(object):
+class NullContextManager:
 
     def __init__(self):
         pass
@@ -441,7 +441,7 @@ def ensure_env_with_credentials(f):
 
 @attr.s(slots=True)
 @total_ordering
-class GDALVersion(object):
+class GDALVersion:
     """Convenience class for obtaining GDAL major and minor version components
     and comparing between versions.  This is highly simplistic and assumes a
     very normal numbering scheme for versions and ignores everything except

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -31,7 +31,7 @@ CURLSCHEMES = set([k for k, v in SCHEMES.items() if v == 'curl'])
 REMOTESCHEMES = set([k for k, v in SCHEMES.items() if v in ('curl', 's3', 'oss', 'gs', 'az',)])
 
 
-class Path(object):
+class Path:
     """Base class for dataset paths"""
 
     def as_vsi(self):

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -17,7 +17,7 @@ from rasterio.warp import transform_bounds
 logger = logging.getLogger(__name__)
 
 
-class _Collection(object):
+class _Collection:
 
     """For use with `rasterio.rio.helpers.write_features()`."""
 

--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -55,7 +55,7 @@ def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
     stdout = click.get_text_stream('stdout')
 
     # This is the generator for (feature, bbox) pairs.
-    class Collection(object):
+    class Collection:
 
         def __init__(self, env):
             self._xs = []

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -57,7 +57,7 @@ from rasterio.path import parse_path, ParsedPath, UnparsedPath
 logger = logging.getLogger(__name__)
 
 
-class IgnoreOptionMarker(object):
+class IgnoreOptionMarker:
     """A marker for an option that is to be ignored.
 
     For use in the case where `None` is a meaningful option value,

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -111,7 +111,7 @@ def shapes(
 
 
 def feature_gen(src, env, *args, **kwargs):
-    class Collection(object):
+    class Collection:
 
         def __init__(self, env):
             self.bboxes = []

--- a/rasterio/rpc.py
+++ b/rasterio/rpc.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 
 @attr.s(slots=True)
-class RPC(object):
+class RPC:
     """Rational Polynomial Coefficients used to map (x, y, z) <-> (row, col) coordinates.
     
     This class contains a mapping between various RPC attributes and values. 

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -17,7 +17,7 @@ except ImportError:
     boto3 = None
 
 
-class Session(object):
+class Session:
     """Base for classes that configure access to secured resources.
 
     Attributes

--- a/rasterio/tools.py
+++ b/rasterio/tools.py
@@ -12,7 +12,7 @@ with rasterio._loading.add_gdal_dll_directories():
     from rasterio.features import dataset_features
 
 
-class JSONSequenceTool(object):
+class JSONSequenceTool:
     """Extracts data from a dataset file and saves a JSON sequence
     """
 

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -14,7 +14,7 @@ IDENTITY = Affine.identity()
 GDAL_IDENTITY = IDENTITY.to_gdal()
 
 
-class TransformMethodsMixin(object):
+class TransformMethodsMixin:
     """Mixin providing methods for calculations related
     to transforming between rows and columns of the raster
     array and the coordinates.

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -32,7 +32,7 @@ with rasterio._loading.add_gdal_dll_directories():
     from rasterio.transform import rowcol, guard_transform
 
 
-class WindowMethodsMixin(object):
+class WindowMethodsMixin:
     """Mixin providing methods for window-related calculations.
     These methods are wrappers for the functionality in
     `rasterio.windows` module.
@@ -504,7 +504,7 @@ def validate_length_value(instance, attribute, value):
 
 @attr.s(slots=True,
         frozen=True)
-class Window(object):
+class Window:
     """Windows are rectangular subsets of rasters.
 
     This class abstracts the 2-tuples mentioned in the module docstring

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -586,7 +586,7 @@ def set_mem_name(request, monkeypatch):
     monkeypatch.setattr(rasterio._io, "uuid4", youyoueyedeefour)
 
 
-class MockGeoInterface(object):
+class MockGeoInterface:
     """Tiny wrapper for GeoJSON to present an object with __geo_interface__ for testing"""
     def __init__(self, geojson):
         self.__geo_interface__ = geojson

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -46,7 +46,7 @@ ESRI_PROJECTION_STRING = (
     'PARAMETER["Direction",1.0],UNIT["Centimeter",0.01]]]')
 
 
-class CustomCRS(object):
+class CustomCRS:
     def to_wkt(self):
         return CRS.from_epsg(4326).to_wkt()
 

--- a/tests/test_io_mixins.py
+++ b/tests/test_io_mixins.py
@@ -16,7 +16,7 @@ def assert_window_almost_equals(a, b, precision=3):
     assert round(a.height, precision) == round(b.height, precision)
 
 
-class MockDatasetBase(object):
+class MockDatasetBase:
     def __init__(self):
         # from tests/data/RGB.byte.tif
         self.affine = Affine(300.0379266750948, 0.0, 101985.0,

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -58,7 +58,7 @@ reproj_expected = (
 )
 
 
-class ReprojectParams(object):
+class ReprojectParams:
     """Class to assist testing reprojection by encapsulating parameters."""
 
     def __init__(self, left, bottom, right, top, width, height, src_crs, dst_crs):


### PR DESCRIPTION
See this [Q/A](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) for a background on `class Foo(object):` vs `class Foo:`.

In summary, only Python 2 required inheriting from `object`, but this is no longer necessary with Python 3 (and the docs don't use that style [here](https://docs.python.org/3/tutorial/classes.html), [here](https://docs.python.org/3/howto/descriptor.html), or [here](https://cython.readthedocs.io/en/latest/src/userguide/extension_types.html)). This PR keeps the base classes a bit tidier and quicker to identify.

Edits were automated using:

    git ls-files -z | xargs -0 sed -i -re 's/class (.*)\(object\):/class \1:/g'