### PR TITLE
Improve warp.reproject and enums.Resampling docs

### DIFF
--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -26,38 +26,41 @@ class ColorInterp(IntEnum):
 
 
 class Resampling(IntEnum):
-    """Available warp resampling algorithms are:
+    """Available warp resampling algorithms.
     
-    nearest = 0 : Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
-    
-    bilinear = 1 : Bilinear resampling.
-    
-    cubic = 2 : Cubic resampling.
-    
-    cubic_sp = 3 : Cubic spline resampling.
-    
-    lanczos = 4 : Lanczos windowed sinc resampling.
-    
-    average = 5 : Average resampling, computes the weighted average of all non-NODATA contributing pixels.
-    
-    mode = 6 : Mode resampling, selects the value which appears most often of all the sampled points.
-    
-    gauss = 7 : Gaussian resampling, Note: not available to the functions in rio.warp.
-    
-    max = 8 : Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
-    
-    min = 9 : Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
-    
-    med = 10 : Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
-    
-    q1 = 11 : Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
-    
-    q3 = 12 : Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
-    
-    sum = 13 : Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)
-    
-    rms = 14 : RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
-    
+    Attributes
+    ----------
+    nearest
+        Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
+    bilinear
+        Bilinear resampling.
+    cubic
+        Cubic resampling.
+    cubic_sp
+        Cubic spline resampling.
+    lanczos
+        Lanczos windowed sinc resampling.
+    average
+        Average resampling, computes the weighted average of all non-NODATA contributing pixels.
+    mode
+        Mode resampling, selects the value which appears most often of all the sampled points.
+    gauss
+        Gaussian resampling, Note: not available to the functions in rio.warp.
+    max
+        Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.0)
+    min
+        Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.0)
+    med
+        Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.0)
+    q1
+        Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)
+    q3
+        Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)
+    sum
+        Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)
+    rms
+        RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
+   
     The first 8, 'nearest', 'bilinear', 'cubic', 'cubic_spline',
     'lanczos', 'average', 'mode', and 'gauss', are available for making
     dataset overviews.

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -36,7 +36,7 @@ class Resampling(IntEnum):
         Bilinear resampling.
     cubic
         Cubic resampling.
-    cubic_sp
+    cubic_spline
         Cubic spline resampling.
     lanczos
         Lanczos windowed sinc resampling.

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -26,8 +26,38 @@ class ColorInterp(IntEnum):
 
 
 class Resampling(IntEnum):
-    """Available warp resampling algorithms.
-
+    """Available warp resampling algorithms are:
+    
+    nearest = 0 : Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
+    
+    bilinear = 1 : Bilinear resampling.
+    
+    cubic = 2 : Cubic resampling.
+    
+    cubic_sp = 3 : Cubic spline resampling.
+    
+    lanczos = 4 : Lanczos windowed sinc resampling.
+    
+    average = 5 : Average resampling, computes the weighted average of all non-NODATA contributing pixels.
+    
+    mode = 6 : Mode resampling, selects the value which appears most often of all the sampled points.
+    
+    gauss = 7 : Gaussian resampling, Note: not available to the functions in rio.warp.
+    
+    max = 8 : Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+    
+    min = 9 : Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
+    
+    med = 10 : Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+    
+    q1 = 11 : Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+    
+    q3 = 12 : Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
+    
+    sum = 13 : Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)
+    
+    rms = 14 : RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
+    
     The first 8, 'nearest', 'bilinear', 'cubic', 'cubic_spline',
     'lanczos', 'average', 'mode', and 'gauss', are available for making
     dataset overviews.
@@ -43,36 +73,20 @@ class Resampling(IntEnum):
 
     Note: 'gauss' is not available to the functions in rio.warp.
     """
-    
-    #: Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
     nearest = 0
-    #: Bilinear resampling.
     bilinear = 1
-    #: Cubic resampling.
     cubic = 2
-    #: Cubic spline resampling.
     cubic_spline = 3
-    #: Lanczos windowed sinc resampling.
     lanczos = 4
-    #: Average resampling, computes the weighted average of all non-NODATA contributing pixels.
     average = 5
-    #: Mode resampling, selects the value which appears most often of all the sampled points.
     mode = 6
-    #: Gaussian resampling, not available to the functions in rio.warp.
     gauss = 7
-    #: Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
     max = 8
-    #: Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
     min = 9
-    #: Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
     med = 10
-    #: Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
     q1 = 11
-    #: Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
     q3 = 12
-    #: Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.3)
     sum = 13
-    #: RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
     rms = 14
 
 

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -43,20 +43,36 @@ class Resampling(IntEnum):
 
     Note: 'gauss' is not available to the functions in rio.warp.
     """
+    
+    #: Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
     nearest = 0
+    #: Bilinear resampling.
     bilinear = 1
+    #: Cubic resampling.
     cubic = 2
+    #: Cubic spline resampling.
     cubic_spline = 3
+    #: Lanczos windowed sinc resampling.
     lanczos = 4
+    #: Average resampling, computes the weighted average of all non-NODATA contributing pixels.
     average = 5
+    #: Mode resampling, selects the value which appears most often of all the sampled points.
     mode = 6
+    #: Gaussian resampling, not available to the functions in rio.warp.
     gauss = 7
+    #: Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
     max = 8
+    #: Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.2)
     min = 9
+    #: Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.2)
     med = 10
+    #: Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
     q1 = 11
+    #: Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.2)
     q3 = 12
+    #: Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.3)
     sum = 13
+    #: RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
     rms = 14
 
 

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -60,7 +60,9 @@ class Resampling(IntEnum):
         Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)
     rms
         RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
-   
+    
+    Notes
+    ----------
     The first 8, 'nearest', 'bilinear', 'cubic', 'cubic_spline',
     'lanczos', 'average', 'mode', and 'gauss', are available for making
     dataset overviews.

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -257,22 +257,9 @@ def reproject(source, destination=None, src_transform=None, gcps=None, rpcs=None
         Index of a band to use as the alpha band when warping.
     dst_alpha : int, optional
         Index of a band to use as the alpha band when warping.
-    resampling: rasterio.enums.Resampling
+    resampling: int, rasterio.enums.Resampling
         Resampling method to use.  
         Default is :attr:`rasterio.enums.Resampling.nearest`.
-        One of the following:
-            Resampling.nearest,
-            Resampling.bilinear,
-            Resampling.cubic,
-            Resampling.cubic_spline,
-            Resampling.lanczos,
-            Resampling.average,
-            Resampling.mode,
-            Resampling.max (GDAL >= 2.2),
-            Resampling.min (GDAL >= 2.2),
-            Resampling.med (GDAL >= 2.2),
-            Resampling.q1 (GDAL >= 2.2),
-            Resampling.q3 (GDAL >= 2.2)
         An exception will be raised for a method not supported by the running
         version of GDAL.
     num_threads : int, optional

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -257,8 +257,10 @@ def reproject(source, destination=None, src_transform=None, gcps=None, rpcs=None
         Index of a band to use as the alpha band when warping.
     dst_alpha : int, optional
         Index of a band to use as the alpha band when warping.
-    resampling: int
-        Resampling method to use.  One of the following:
+    resampling: rasterio.enums.Resampling
+        Resampling method to use.  
+        Default is :attr:`rasterio.enums.Resampling.nearest`.
+        One of the following:
             Resampling.nearest,
             Resampling.bilinear,
             Resampling.cubic,


### PR DESCRIPTION
I had a hard time finding the resampling options for warp.reproject in the docs. 

I've tried to make it a bit easier by adding a link from warp.reproject to enums.Resampling, and then adding short descriptions in enums.Resampling from gdalwarp's resampling docs.

I hope this will clarify the warp.reproject resampling parameter options for others too.