### PR TITLE
Resolve numpy deprecation warnings in tests

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1573,7 +1573,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 GDALFillRaster(mask, 255, 0)
             elif mask_array is False:
                 GDALFillRaster(mask, 0, 0)
-            elif mask_array.dtype == bool :
+            elif mask_array.dtype == bool:
                 array = 255 * mask_array.astype(np.uint8)
                 io_band(mask, 1, xoff, yoff, width, height, array)
             else:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1573,7 +1573,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 GDALFillRaster(mask, 255, 0)
             elif mask_array is False:
                 GDALFillRaster(mask, 0, 0)
-            elif mask_array.dtype == np.bool:
+            elif mask_array.dtype == bool :
                 array = 255 * mask_array.astype(np.uint8)
                 io_band(mask, 1, xoff, yoff, width, height, array)
             else:

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -46,8 +46,8 @@ def test_get_minimum_dtype():
     assert get_minimum_dtype(np.array([0, 1], dtype=np.uint)) == uint8
     assert get_minimum_dtype(np.array([0, 1000], dtype=np.uint)) == uint16
     assert get_minimum_dtype(np.array([0, 100000], dtype=np.uint)) == uint32
-    assert get_minimum_dtype(np.array([-1, 0, 1], dtype=np.int)) == int16
-    assert get_minimum_dtype(np.array([-1, 0, 100000], dtype=np.int)) == int32
+    assert get_minimum_dtype(np.array([-1, 0, 1], dtype=int)) == int16
+    assert get_minimum_dtype(np.array([-1, 0, 100000], dtype=int)) == int32
     assert get_minimum_dtype(np.array([-1.5, 0, 1.5], dtype=np.float64)) == float32
 
 


### PR DESCRIPTION
Resolves the deprecation warnings about `np.bool` and `np.int` that are emitted with Numpy 1.20+.
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations