### PR TITLE
Add docstring to BoundingBox and remove subclass.

### DIFF
--- a/rasterio/coords.py
+++ b/rasterio/coords.py
@@ -2,10 +2,8 @@
 
 from collections import namedtuple, OrderedDict
 
-_BoundingBox = namedtuple('BoundingBox', ('left', 'bottom', 'right', 'top'))
-
-
-class BoundingBox(_BoundingBox):
+BoundingBox = namedtuple('BoundingBox', ('left', 'bottom', 'right', 'top'))
+BoundingBox.__doc__ = \
     """Bounding box named tuple, defining extent in cartesian coordinates.
 
     .. code::
@@ -23,10 +21,6 @@ class BoundingBox(_BoundingBox):
     top :
         Top coordinate
     """
-
-    def _asdict(self):
-        return OrderedDict(zip(self._fields, self))
-
 
 def disjoint_bounds(bounds1, bounds2):
     """Compare two bounds and determine if they are disjoint.

--- a/rasterio/coords.py
+++ b/rasterio/coords.py
@@ -1,6 +1,6 @@
 """Bounding box tuple, and disjoint operator."""
 
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 
 BoundingBox = namedtuple('BoundingBox', ('left', 'bottom', 'right', 'top'))
 BoundingBox.__doc__ = \


### PR DESCRIPTION
In Python 3.5+ the `__doc__` attribute is writable (https://bugs.python.org/issue24064)

This removes the need for a BoundingBox subclass and the subsequent dated workaround in #1488. In recent versions of Python (3.7+), `_asdict` returns a regular dictionary instead of OrderedDict.

An alternative formulation for BoundingBox could be:
```python
from typing import NamedTuple, Union

Number = Union[float, int]
class BoundingBox(NamedTuple):
    """ <Docstring here> """
    left: Number
    bottom: Number
    right: Number
    top: Number
```