### PR TITLE
Eliminate unneeded IgnoreOption

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,11 @@
 Changes
 =======
 
-1.2.4 (TBD)
------------
+1.2.4 (2021-05-31)
+------------------
 
+- Eliminate unneeded marker for CLI nodata options to be ignored. We will stick
+  with None (#2191).
 - Guard against use of gauss resampling when creating a WarpedVRT (#2190).
 - Prevent segfaults when buffer and band indexes are mismatched in
   io_multi_band and io_multi_mask (#2189).

--- a/rasterio/rio/edit_info.py
+++ b/rasterio/rio/edit_info.py
@@ -190,13 +190,13 @@ def edit(ctx, input, bidx, nodata, unset_nodata, crs, unset_crs, transform,
             tags = allmd['tags']
             colorinterp = allmd['colorinterp']
 
-        if unset_nodata and str(nodata) != str(options.IgnoreOption):
+        if unset_nodata and nodata is not None:
             raise click.BadParameter(
-                "--unset-nodata and --nodata cannot be used together.")
+                "--unset-nodata and --nodata cannot be used together."
+            )
 
         if unset_crs and crs:
-            raise click.BadParameter(
-                "--unset-crs and --crs cannot be used together.")
+            raise click.BadParameter("--unset-crs and --crs cannot be used together.")
 
         if unset_nodata:
             # Setting nodata to None will raise NotImplementedError
@@ -207,17 +207,18 @@ def edit(ctx, input, bidx, nodata, unset_nodata, crs, unset_crs, transform,
             except NotImplementedError as exc:  # pragma: no cover
                 raise click.ClickException(str(exc))
 
-        elif str(nodata) != str(options.IgnoreOption):
+        elif nodata is not None:
             dtype = dst.dtypes[0]
             if nodata is not None and not in_dtype_range(nodata, dtype):
                 raise click.BadParameter(
-                    "outside the range of the file's "
-                    "data type (%s)." % dtype,
-                    param=nodata, param_hint='nodata')
+                    "outside the range of the file's data type (%s)." % dtype,
+                    param=nodata,
+                    param_hint="nodata",
+                )
             dst.nodata = nodata
 
         if unset_crs:
-            dst.crs = None  # CRS()
+            dst.crs = None
         elif crs:
             dst.crs = crs
 

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -9,8 +9,13 @@ import pytest
 
 from rasterio.enums import ColorInterp
 from rasterio.rio.options import (
-    IgnoreOption, bounds_handler, file_in_handler, like_handler,
-    edit_nodata_handler, nodata_handler, _cb_key_val)
+    bounds_handler,
+    file_in_handler,
+    like_handler,
+    edit_nodata_handler,
+    nodata_handler,
+    _cb_key_val,
+)
 
 
 class MockContext:
@@ -186,14 +191,14 @@ def test_edit_nodata_callback_like(data):
 
 def test_edit_nodata_callback_all_like(data):
     ctx = MockContext()
-    ctx.obj['like'] = {'nodata': 0.0}
-    ctx.obj['all_like'] = True
-    assert edit_nodata_handler(ctx, MockOption('nodata'), IgnoreOption) == 0.0
+    ctx.obj["like"] = {"nodata": 0.0}
+    ctx.obj["all_like"] = True
+    assert edit_nodata_handler(ctx, MockOption("nodata"), None) == 0.0
 
 
 def test_edit_nodata_callback_ignore(data):
     ctx = MockContext()
-    assert edit_nodata_handler(ctx, MockOption('nodata'), IgnoreOption) is IgnoreOption
+    assert edit_nodata_handler(ctx, MockOption("nodata"), None) is None
 
 
 def test_edit_nodata_callback_none(data):


### PR DESCRIPTION
Click 8.0 made it clear that `None` is really the only marker for options to be ignored that works from version to version.