### PR TITLE
add some type hinting

### DIFF
--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -13,6 +13,7 @@ used.
 from collections.abc import Mapping
 import json
 import pickle
+from typing import Union
 
 import rasterio._loading
 with rasterio._loading.add_gdal_dll_directories():
@@ -504,6 +505,9 @@ class CRS(Mapping):
             return cls.from_string(value, morph_from_esri_dialect=morph_from_esri_dialect)
         else:
             raise CRSError("CRS is invalid: {!r}".format(value))
+
+
+CRSLike = Union[CRS, str, dict]
 
 
 def epsg_treats_as_latlong(input):

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -4,8 +4,11 @@ Instances of these classes are called dataset objects.
 """
 
 import logging
+from typing import Optional, Union
 
 import rasterio._loading
+from rasterio.types import PathLikeOrStr
+
 with rasterio._loading.add_gdal_dll_directories():
     from rasterio._base import (
         get_dataset_driver, driver_can_create, driver_can_create_copy)
@@ -39,6 +42,9 @@ class DatasetWriter(DatasetWriterBase, WindowMethodsMixin,
     def __repr__(self):
         return "<{} DatasetWriter name='{}' mode='{}'>".format(
             self.closed and 'closed' or 'open', self.name, self.mode)
+
+
+Dataset = Union[DatasetReader, DatasetWriter]
 
 
 class BufferedDatasetWriter(BufferedDatasetWriterBase, WindowMethodsMixin,
@@ -182,7 +188,7 @@ class ZipMemoryFile(MemoryFile):
         return DatasetReader(zippath, driver=driver, sharing=sharing, **kwargs)
 
 
-def get_writer_for_driver(driver):
+def get_writer_for_driver(driver: str) -> Optional[DatasetWriterBase]:
     """Return the writer class appropriate for the specified driver."""
     if not driver:
         raise ValueError("'driver' is required to write dataset.")
@@ -194,7 +200,7 @@ def get_writer_for_driver(driver):
     return cls
 
 
-def get_writer_for_path(path, driver=None):
+def get_writer_for_path(path: PathLikeOrStr, driver: Optional[str] = None) -> Optional[DatasetWriterBase]:
     """Return the writer class appropriate for the existing dataset."""
     if not driver:
         driver = get_dataset_driver(path)

--- a/rasterio/types.py
+++ b/rasterio/types.py
@@ -1,0 +1,9 @@
+""" some basic types """
+import os
+from typing import TypeVar, Union, Sequence, Any
+
+T = TypeVar("T")
+MaybeSequence = Union[T, Sequence[T]]
+PathLikeOrStr = Union[str, os.PathLike]
+FileType = Any
+

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -1,6 +1,7 @@
 """Raster warping and reprojection."""
 
 from math import ceil, floor
+from typing import Union, Optional
 
 from affine import Affine
 import numpy as np
@@ -15,6 +16,7 @@ with rasterio._loading.add_gdal_dll_directories():
     from rasterio.errors import GDALBehaviorChangeException, TransformError
     from rasterio.transform import array_bounds
     from rasterio._warp import _calculate_default_transform, _reproject, _transform_geom
+    from rasterio import Band
 
 # Gauss (7) is not supported for warp
 SUPPORTED_RESAMPLING = [r for r in Resampling if r.value < 7]
@@ -186,7 +188,8 @@ def transform_bounds(
 
 @ensure_env
 @require_gdal_version('2.0', param='resampling', values=GDAL2_RESAMPLING)
-def reproject(source, destination=None, src_transform=None, gcps=None, rpcs=None,
+def reproject(source: Union[np.ndarray, Band], destination: Optional[Union[np.ndarray, Band]]=None, 
+              src_transform=None, gcps=None, rpcs=None,
               src_crs=None, src_nodata=None, dst_transform=None, dst_crs=None,
               dst_nodata=None, dst_resolution=None, src_alpha=0, dst_alpha=0,
               resampling=Resampling.nearest, num_threads=1,


### PR DESCRIPTION
Now that Python < 3.6 was dropped, I think it's a great time to add some type hinting as they really help humans and machines (IDEs, mypy) to understand the expected IOs. 