### PR TITLE
ENH: WarpedVRT - pass warp_extras into _calculate_default_transform

### DIFF
--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -1023,9 +1023,17 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
                 left, bottom, right, top = self.src_dataset.bounds
                 self.dst_transform, width, height = _calculate_default_transform(
-                    self.src_crs, self.dst_crs, self.src_dataset.width, self.src_dataset.height,
-                    left=left, bottom=bottom, right=right, top=top,
-                    gcps=self.src_gcps, rpcs=self.src_dataset.rpcs,
+                    self.src_crs,
+                    self.dst_crs,
+                    self.src_dataset.width,
+                    self.src_dataset.height,
+                    left=left,
+                    bottom=bottom,
+                    right=right,
+                    top=top,
+                    gcps=self.src_gcps,
+                    rpcs=self.src_dataset.rpcs,
+                    **self.warp_extras,
                 )
                 self.dst_transform = Affine.scale(width / self.dst_width, height / self.dst_height ) * self.dst_transform
 

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -227,6 +227,24 @@ def test_transformer_options(path_rgb_byte_tif):
             assert not vrt.transform.almost_equals(transform)
 
 
+def test_transformer_options__width_height(path_rgb_byte_tif):
+    transform = affine.Affine(79.1, 0.0, 0.0, 0.0, -71.8, 51552.4)
+    transformer_options = {
+        "SRC_METHOD": "NO_GEOTRANSFORM",
+        "DST_METHOD": "NO_GEOTRANSFORM",
+    }
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(
+        src,
+        crs=DST_CRS,
+        width=10,
+        height=10,
+        **transformer_options,
+    ) as vrt:
+        for key, value in transformer_options.items():
+            assert vrt.warp_extras[key] == value
+        assert vrt.transform.almost_equals(transform)
+
+
 @requires_gdal21(reason="S3 raster access requires GDAL 2.1+")
 @credentials
 @pytest.mark.network


### PR DESCRIPTION
Noticed this would be good to add as well.

Ideally it should be added to #2195, but it needs #2193 merged in to work properly. This is a temporary PR with all of them together so you can see it. 

The commit of interest says "Pass warp_extras into _calculate_default_transform" and the commit hash is `bae8224`