### PR TITLE
Add LERC_ZSTD & LERC_DEFLATE compression enum values

### DIFF
--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -132,6 +132,8 @@ class Compression(Enum):
     none = 'NONE'
     zstd = 'ZSTD'
     lerc = 'LERC'
+    lerc_deflate = 'LERC_DEFLATE'
+    lerc_zstd = 'LERC_ZSTD'
     webp = 'WEBP'
     jpeg2000 = 'JPEG2000'
 


### PR DESCRIPTION
GDAL [supports](https://gdal.org/drivers/raster/gtiff.html) these compression algorithms now when LERC and ZSTD/DEFLATE are available.

Based on previous PRs adding support for [ZSTD](https://github.com/mapbox/rasterio/commit/ed458b02a55dca6abf28f0844c336005c14a4334) and [LERC](https://github.com/mapbox/rasterio/pull/1412), it's enough to just add the enum values.

Rasterio can already read geotiffs compressed with LERC_ZSTD and LERC_DEFLATE, this PR prevents a value error when accessing `.compression` and lets rasterio write with these algorithms.


```python
>>> with rasterio.open('lerc_zstd.tif') as f:
...     f.read()  # Runs fine
...     f.compression 
ValueError: 'LERC_ZSTD' is not a valid Compression
```
