### PR TITLE
Fix tests win

### DIFF
--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -71,7 +71,7 @@ class ParsedPath(Path):
         parts = path.split('!')
         path = parts.pop() if parts else None
         archive = parts.pop() if parts else None
-        return ParsedPath(path, archive, scheme)
+        return ParsedPath(pathlib.Path(path).as_posix(), archive, scheme)
 
     @property
     def name(self):

--- a/tests/test_boundless_read.py
+++ b/tests/test_boundless_read.py
@@ -1,5 +1,6 @@
 """Test of boundless reads"""
 
+import shutil
 from hypothesis import given
 import hypothesis.strategies as st
 import numpy
@@ -47,7 +48,7 @@ def test_hit_ovr(red_green):
     # overviews of green.tif over the red overviews and expect to find
     # green pixels below.
     green_ovr = red_green.join("green.tif.ovr")
-    green_ovr.rename(red_green.join("red.tif.ovr"))
+    shutil.move(green_ovr, red_green.join("red.tif.ovr"))
     assert not green_ovr.exists()
     with rasterio.open(str(red_green.join("red.tif.ovr"))) as ovr:
         data = ovr.read()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,7 +1,7 @@
 """High level tests for Rasterio's ``GDALDataset`` abstractions."""
 
 
-import os
+from pathlib import Path
 try:
     from unittest.mock import MagicMock
 except ImportError:
@@ -16,12 +16,12 @@ from rasterio.transform import Affine
 
 
 def test_files(data):
-    tif = str(data.join('RGB.byte.tif'))
-    aux = tif + '.aux.xml'
+    tif = Path(data).joinpath('RGB.byte.tif')
+    aux = tif.parent.joinpath(tif.name + '.aux.xml')
     with open(aux, 'w'):
         pass
     with rasterio.open(tif) as src:
-        assert src.files == [tif, aux]
+        assert src.files == [tif.as_posix(), aux.as_posix()]
 
 
 def test_handle_closed(path_rgb_byte_tif):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -96,11 +96,11 @@ def test_parse_gdal():
     assert parse_path('GDAL:filepath:varname').path == 'GDAL:filepath:varname'
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason="Checking behavior on posix, not win32")
 def test_parse_windows_path(monkeypatch):
     """Return Windows paths unparsed"""
     monkeypatch.setattr(sys, 'platform', 'win32')
-    monkeypatch.setattr(os, 'name', 'nt')
-    assert parse_path(r'C:\\foo.tif').path == r'C:/foo.tif'
+    assert parse_path(r'C:\\foo.tif').path == r'C:\\foo.tif'
 
 
 def test_vsi_path_scheme():

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,6 @@
 """Tests of rasterio.path"""
 
+import os
 import sys
 
 import pytest
@@ -98,6 +99,7 @@ def test_parse_gdal():
 def test_parse_windows_path(monkeypatch):
     """Return Windows paths unparsed"""
     monkeypatch.setattr(sys, 'platform', 'win32')
+    monkeypatch.setattr(os, 'name', 'nt')
     assert parse_path(r'C:\\foo.tif').path == r'C:/foo.tif'
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -98,7 +98,7 @@ def test_parse_gdal():
 def test_parse_windows_path(monkeypatch):
     """Return Windows paths unparsed"""
     monkeypatch.setattr(sys, 'platform', 'win32')
-    assert parse_path(r'C:\\foo.tif').path == r'C:\\foo.tif'
+    assert parse_path(r'C:\\foo.tif').path == r'C:/foo.tif'
 
 
 def test_vsi_path_scheme():

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -103,7 +103,7 @@ def test_file_in_handler_with_vfs():
     uri = 'zip://tests/data/files.zip!/RGB.byte.tif'
     ctx = MockContext()
     retval = file_in_handler(ctx, 'INPUT', uri)
-    assert retval.startswith('zip:///')
+    assert retval.startswith('zip://')
     assert 'tests/data/files.zip!/RGB.byte.tif' in retval
 
 

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -2,6 +2,7 @@
 
 from __future__ import division
 import logging
+import shutil
 
 import affine
 import boto3
@@ -355,7 +356,7 @@ def test_hit_ovr(red_green):
     # overviews of green.tif over the red overviews and expect to find
     # green pixels below.
     green_ovr = red_green.join("green.tif.ovr")
-    green_ovr.rename(red_green.join("red.tif.ovr"))
+    shutil.move(green_ovr, red_green.join("red.tif.ovr"))
     assert not green_ovr.exists()
     with rasterio.open(str(red_green.join("red.tif.ovr"))) as ovr:
         data = ovr.read()

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 import subprocess
 import sys
 
@@ -61,7 +62,7 @@ def test_no_crs(tmpdir):
 
 @pytest.mark.gdalbin
 def test_context(tmpdir):
-    name = str(tmpdir.join("test_context.tif"))
+    name = Path(str(tmpdir.join("test_context.tif"))).as_posix()
     with rasterio.open(
             name, 'w',
             driver='GTiff', width=100, height=100, count=1,


### PR DESCRIPTION
Fix some tests that had been failing on windows, mostly related to forward/backwards slashes.

Notably:
 
- `rename` method of `red_green` pytest fixture results in a `FILEEXSISTSERROR` on win32, replaced with `shutil.move`
- updated `ParsedPath.from_uri` to pass a `.as_posix()` path to class __init__ method, to be consistent with other usages (fixes test_shutil.py:test_copyfiles_same_dataset_another_name)

Not particularly important since there's currently no windows CI builds running tests, but nice to have