### PR TITLE
handle md domain prefixed by "xml"

### DIFF
--- a/docs/topics/tags.rst
+++ b/docs/topics/tags.rst
@@ -53,6 +53,11 @@ and 'RPC'. You can get the tags from these namespaces using the `ns` keyword of
     >>> src.tags(ns='RPC')
     {}
 
+.. note::
+
+A special case for GDAL tag namespaces are those prefixed with 'xml' e.g. 'xml:TRE' or 'xml:VRT'. 
+GDAL will treat these namespaces as a single xml string.
+
 Writing tags
 ------------
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -65,3 +65,9 @@ def test_tags_eq(tmpdir):
             'GTiff', 3, 4, 1, dtype=rasterio.ubyte) as dst:
         dst.update_tags(a="foo=bar")
         assert dst.tags() == {'a': "foo=bar"}
+
+def test_tags_xml_prefix():
+    with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src:
+        md = src.tags(ns='xml:VRT')
+        assert 'xml:VRT' in md
+        assert md.get('xml:VRT').startswith('<VRTDataset')


### PR DESCRIPTION
Fixes #2220 

Per https://gdal.org/user/raster_data_model.html#xml-domains, metadata domains prefixed by `xml` should not be treated as typical key:value metadata. 

If we detect a domain/namespace prefixed with `xml` we return a dictionary with the domain as key and xml string as value.