### PR TITLE
Accept PathLike objects in rasterio.open

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 import logging
 from logging import NullHandler
-from pathlib import Path
+import os
 
 import rasterio._loading
 with rasterio._loading.add_gdal_dll_directories():
@@ -72,7 +72,7 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
 
     Parameters
     ----------
-    fp : str, file object or pathlib.Path object
+    fp : str, file object or PathLike object
         A filename or URL, a file object opened in binary ('rb') mode,
         or a Path object.
     mode : str, optional
@@ -156,7 +156,7 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
     """
 
     if not isinstance(fp, str):
-        if not (hasattr(fp, 'read') or hasattr(fp, 'write') or isinstance(fp, Path)):
+        if not (hasattr(fp, 'read') or hasattr(fp, 'write') or isinstance(fp, os.PathLike)):
             raise TypeError("invalid path or file: {0!r}".format(fp))
     if mode and not isinstance(mode, str):
         raise TypeError("invalid mode: {0!r}".format(mode))
@@ -209,9 +209,8 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
         return fp_writer(fp)
 
     else:
-        # If a pathlib.Path instance is given, convert it to a string path.
-        if isinstance(fp, Path):
-            fp = str(fp)
+        # If a PathLike instance is given, convert it to a string path.
+        fp = os.fspath(fp)
 
         # The 'normal' filename or URL path.
         path = parse_path(fp)

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -2,6 +2,7 @@
 
 from contextlib import contextmanager
 import logging
+import os
 import math
 from pathlib import Path
 import warnings
@@ -92,7 +93,7 @@ def merge(
 
     Parameters
     ----------
-    datasets : list of dataset objects opened in 'r' mode, filenames or pathlib.Path objects
+    datasets : list of dataset objects opened in 'r' mode, filenames or PathLike objects
         source datasets to be merged.
     bounds: tuple, optional
         Bounds of the output image (left, bottom, right, top).
@@ -148,7 +149,7 @@ def merge(
         Whether to adjust output image bounds so that pixel coordinates
         are integer multiples of pixel size, matching the ``-tap``
         options of GDAL utilities.  Default: False.
-    dst_path : str or Pathlike, optional
+    dst_path : str or PathLike, optional
         Path of output dataset
     dst_kwds : dict, optional
         Dictionary of creation options and other paramters that will be
@@ -177,7 +178,7 @@ def merge(
                          .format(method, list(MERGE_METHODS.keys())))
 
     # Create a dataset_opener object to use in several places in this function.
-    if isinstance(datasets[0], str) or isinstance(datasets[0], Path):
+    if isinstance(datasets[0], (str, os.PathLike)):
         dataset_opener = rasterio.open
     else:
 

--- a/rasterio/shutil.pyx
+++ b/rasterio/shutil.pyx
@@ -5,12 +5,7 @@
 include "gdal.pxi"
 
 import logging
-
-try:
-    from pathlib import Path
-except ImportError:  # pragma: no cover
-    class Path:
-        pass
+import os
 
 from rasterio._io cimport DatasetReaderBase
 from rasterio._err cimport exc_wrap_int, exc_wrap_pointer
@@ -63,9 +58,9 @@ def copy(src, dst, driver=None, strict=True, **creation_options):
 
     Parameters
     ----------
-    src : str or pathlib.Path or dataset object opened in 'r' mode
+    src : str or PathLike or dataset object opened in 'r' mode
         Source dataset
-    dst : str or pathlib.Path
+    dst : str or PathLike
         Output dataset path
     driver : str, optional
         Output driver name
@@ -100,10 +95,10 @@ def copy(src, dst, driver=None, strict=True, **creation_options):
     c_strictness = strict
 
     # Convert src and dst Paths to strings.
-    if isinstance(src, Path):
-        src = str(src)
-    if isinstance(dst, Path):
-        dst = str(dst)
+    if isinstance(src, os.PathLike):
+        src = os.fspath(src)
+    if isinstance(dst, os.PathLike):
+        dst = os.fspath(dst)
 
     if driver is None:
         driver = driver_from_extension(dst)
@@ -162,9 +157,9 @@ def copyfiles(src, dst):
 
     Parameters
     ----------
-    src : str or pathlib.Path
+    src : str or PathLike
         Source dataset
-    dst : str or pathlib.Path
+    dst : str or PathLike
         Target dataset
 
     Returns
@@ -177,10 +172,10 @@ def copyfiles(src, dst):
     cdef GDALDriverH h_driver = NULL
 
     # Convert src and dst Paths to strings.
-    if isinstance(src, Path):
-        src = str(src)
-    if isinstance(dst, Path):
-        dst = str(dst)
+    if isinstance(src, os.PathLike):
+        src = os.fspath(src)
+    if isinstance(dst, os.PathLike):
+        dst = os.fspath(dst)
 
     src_path = parse_path(src)
     dst_path = parse_path(dst)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,5 +1,6 @@
 import pytest
 import rasterio
+from pathlib import Path
 
 
 def test_open_bad_path():
@@ -23,10 +24,14 @@ def test_open_bad_driver():
 
 
 def test_open_pathlib_path():
-    try:
-        from pathlib import Path
-    except ImportError:
-        return
     tif = Path.cwd() / 'tests' / 'data' / 'RGB.byte.tif'
     with rasterio.open(tif) as src:
+        assert src.count == 3
+
+
+def test_open_pathlike():
+    class MyPath:
+        def __fspath__(self):
+            return str(Path.cwd() / 'tests' / 'data' / 'RGB.byte.tif')
+    with rasterio.open(MyPath()) as src:
         assert src.count == 3

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import textwrap
+from pathlib import Path
 
 import affine
 from click.testing import CliRunner
@@ -12,7 +13,6 @@ from pytest import fixture
 import pytest
 
 import rasterio
-from rasterio import Path
 from rasterio.enums import Resampling
 from rasterio.merge import merge
 from rasterio.rio.main import main_group


### PR DESCRIPTION
Addresses #2229 

A generalization that allows any PathLike object to be passed to `rasterio.open`. PathLike objects implement a special method, `__fspath__` which can be retrieved by `os.fspath`.

At the moment, I've only updated rasterio.open, but there are several other places where we compare with pathlib.Path when we should compare with os.PathLike or call `os.fspath`.