### PR TITLE
REF: set language level in cythonize options in setup.py

### DIFF
--- a/rasterio/_base.pxd
+++ b/rasterio/_base.pxd
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 include "gdal.pxi"
 
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3, boundscheck=False, c_string_type=unicode, c_string_encoding=utf8"""
+# cython: boundscheck=False, c_string_type=unicode, c_string_encoding=utf8"""
 
 """Numpy-free base classes."""
 

--- a/rasterio/_crs.pxd
+++ b/rasterio/_crs.pxd
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 include "gdal.pxi"
 
 

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3, boundscheck=False
+# cython: boundscheck=False
 
 """Coordinate reference systems, class and functions.
 """

--- a/rasterio/_env.pxd
+++ b/rasterio/_env.pxd
@@ -1,5 +1,5 @@
-# cython: language_level=3
 include "gdal.pxi"
+
 
 cdef class ConfigEnv:
     cdef public object options

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3, c_string_type=unicode, c_string_encoding=utf8
+# cython: c_string_type=unicode, c_string_encoding=utf8
 
 """GDAL and OGR driver and configuration management
 

--- a/rasterio/_err.pxd
+++ b/rasterio/_err.pxd
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 include "gdal.pxi"
 
 from libc.stdio cimport *

--- a/rasterio/_err.pyx
+++ b/rasterio/_err.pyx
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 """rasterio._err
 
 Exception-raising wrappers for GDAL API functions.

--- a/rasterio/_features.pxd
+++ b/rasterio/_features.pxd
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 include "gdal.pxi"
 
 

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 """Feature extraction"""
 
 import logging

--- a/rasterio/_fill.pyx
+++ b/rasterio/_fill.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # distutils: language = c++
 
 """Raster fill."""

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 include "gdal.pxi"
 
 cimport numpy as np

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3, boundscheck=False
+# cython: boundscheck=False
 
 """Rasterio input/output."""
 

--- a/rasterio/_transform.pyx
+++ b/rasterio/_transform.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3, boundscheck=False, c_string_type=unicode, c_string_encoding=utf8
+# cython: boundscheck=False, c_string_type=unicode, c_string_encoding=utf8
 
 """Transforms."""
 

--- a/rasterio/_warp.pxd
+++ b/rasterio/_warp.pxd
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 from rasterio._io cimport DatasetReaderBase
 
 include "gdal.pxi"

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -1,4 +1,3 @@
-# cython: language_level=3
 # distutils: language = c++
 
 """Raster and vector warping and reprojection."""

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 # GDAL API definitions.
 
 from libc.stdio cimport FILE

--- a/rasterio/shutil.pyx
+++ b/rasterio/shutil.pyx
@@ -1,5 +1,3 @@
-# cython: language_level=3
-
 """Raster file management."""
 
 include "gdal.pxi"

--- a/setup.py
+++ b/setup.py
@@ -210,7 +210,7 @@ if (gdal_major_version, gdal_minor_version) >= (2, 3):
     cpp_ext_options['extra_compile_args'] = eca
 
 # Configure optional Cython coverage.
-cythonize_options = {}
+cythonize_options = {"language_level": sys.version_info[0]}
 if os.environ.get('CYTHON_COVERAGE'):
     cythonize_options['compiler_directives'] = {'linetrace': True}
     cythonize_options['annotate'] = True


### PR DESCRIPTION
Saw this:
```
FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: rasterio/rasterio/_example.pyx
```
