### PR TITLE
rasterio.windows.Window: fix docstring

### DIFF
--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -527,6 +527,8 @@ class Window:
     width, height: float
         Lengths of the window.
 
+    Notes
+    -----
     Previously the lengths were called 'num_cols' and 'num_rows' but
     this is a bit confusing in the new float precision world and the
     attributes have been changed. The originals are deprecated.


### PR DESCRIPTION
The docstring for https://rasterio.readthedocs.io/en/latest/api/rasterio.windows.html#rasterio.windows.Window is broken, and the note at the bottom is being interpreted as a list of attributes. Using the [notes](https://numpydoc.readthedocs.io/en/latest/format.html#notes) section should hopefully solve this issue.

@calebrob6 