### PR TITLE
Clean up windows.get_data_window

### DIFF
--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -156,7 +156,11 @@ def get_data_window(arr, nodata=None):
     elif np.ma.is_masked(arr):
         arr_mask = ~np.ma.getmask(arr)
     else:
-        return Window.from_slices((0, arr.shape[-2]), (0, arr.shape[-1]))
+        if arr.ndim == 1:
+            full_window = ((0, arr.size), (0, 0))
+        else:
+            full_window = ((0, arr.shape[-2]), (0, arr.shape[-1]))
+        return Window.from_slices(*full_window)
 
     if arr.ndim == 3:
         arr_mask = np.any(arr_mask, axis=0)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -458,15 +458,25 @@ def test_read_with_window_class(path_rgb_byte_tif):
 
 def test_data_window_invalid_arr_dims():
     """An array of more than 3 dimensions is invalid."""
-    arr = np.ones((3, 3, 3, 3))
+    # Test > 3 dims
     with pytest.raises(WindowError):
-        get_data_window(arr)
+        get_data_window(np.ones((3, 3, 3, 3)))
+    
+    # Test < 1 dim
+    with pytest.raises(WindowError):
+        get_data_window(np.ones(()))
 
 
 def test_data_window_full():
     """Get window of entirely valid data array."""
     arr = np.ones((3, 3))
     window = get_data_window(arr)
+    assert window == Window.from_slices((0, 3), (0, 3))
+
+    window = get_data_window(np.ones(3))
+    assert window == Window.from_slices((0, 3), (0, 0))
+
+    window = get_data_window(np.ones((3, 3, 3)))
     assert window == Window.from_slices((0, 3), (0, 3))
 
 


### PR DESCRIPTION
Cleans up the implementation of `get_data_window` and extends it to properly handle 1D arrays. The documentation implied that 1D arrays are supported, but constructing a full window assumed 2 dimensions.

Primary wins:
* doesn't create a masked array anymore
* nicer handling of masked array (True maps to valid data)
* Avoid some temporary array allocations and removed unnecessary rollaxis usage.
* Small performance improvement.