### PR TITLE
Register custom pytest markings.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = ["setuptools", "wheel", "cython==0.29.21", "oldest-supported-numpy"]
 markers = [
     "slow: marks tests as slow",
     "gdalbin: marks test requiring GDAL binaries",
-    "wheel: ",
+    "wheel: marks test specific to wheel-building infra",
     "network: marks tests that require network access"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,10 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython==0.29.21", "oldest-supported-numpy"]
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+    "gdalbin: marks test requiring GDAL binaries",
+    "wheel: ",
+    "network: marks tests that require network access"
+]


### PR DESCRIPTION
Pytest seems to prefer that custom markings be defined in either a pytest.ini or pyproject.toml.
https://docs.pytest.org/en/stable/mark.html