### PR TITLE
_transform(): correctly check error code of OCTTransform()) (fixes #2282)

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -1490,7 +1490,8 @@ def _transform(src_crs, dst_crs, xs, ys, zs):
     try:
         transform = OCTNewCoordinateTransformation(src, dst)
         transform = exc_wrap_pointer(transform)
-        exc_wrap_int(OCTTransform(transform, n, x, y, z))
+        # OCTTransform() returns TRUE/FALSE contrary to most GDAL API functions
+        exc_wrap_int(OCTTransform(transform, n, x, y, z) == 0)
 
         res_xs = [0]*n
         res_ys = [0]*n

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -6,6 +6,7 @@ import pytest
 from numpy.testing import assert_almost_equal
 
 import rasterio
+from rasterio._err import CPLE_BaseError
 from rasterio._warp import _calculate_default_transform
 from rasterio.control import GroundControlPoint
 from rasterio.crs import CRS
@@ -242,12 +243,15 @@ def test_transform_bounds__beyond_global_bounds():
 
 @requires_gdal3
 def test_transform_bounds__ignore_inf():
-    assert not numpy.isinf(
-        transform_bounds(
-            "EPSG:4326", "ESRI:102036", -180.0, -90.0, 180.0, 0.0,
-        )
-    ).any()
-
+    # Depending on the GDAL version we might get an exception or inf values
+    try:
+        assert not numpy.isinf(
+            transform_bounds(
+                "EPSG:4326", "ESRI:102036", -180.0, -90.0, 180.0, 0.0,
+            )
+        ).any()
+    except CPLE_BaseError:
+        pass
 
 def test_transform_bounds__noop_geographic():
     bounds = (19.57, 35.14, -168.97, 81.91)


### PR DESCRIPTION
Another fix I tried which didn't affect the test suite was to call CPLErrorReset() before OCTTransform(), but that fix is more appropriate. I'm not sure if the intent was for a single failed coordinate to transform to cause the whole call to error out (which is now the case, provided that a CPLError() is emitted, which isn't necessary the case if the same cached OGRCoordinateTransformation object is reused, and in a previous invokation saturated the 20 max error messages), or not