### PR TITLE
Raise WarpOperationError (new) if ChunkAndWarpMulti/Image fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ install:
 
 script:
   - python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
+  - CPL_DEBUG=YES GDAL_HTTP_MAX_RETRY=2 GDAL_HTTP_RETRY_DELAY=1 GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR python -m pytest tests/test_warp.py -k error_prop --log-level DEBUG -rP
 
 after_success:
   - coveralls || echo "!! intermittent coveralls failure"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+1.2.10 (TBD)
+------------
+
+- Raise WarpOperationError if ChunkAndWarp* do not succeed.
+
 1.2.9 (2021-10-01)
 ------------------
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -40,7 +40,7 @@ import rasterio.enums
 import rasterio.path
 
 __all__ = ['band', 'open', 'pad', 'Env']
-__version__ = "1.2.9"
+__version__ = "1.2.10dev"
 __gdal_version__ = gdal_version()
 
 # Rasterio attaches NullHandler to the 'rasterio' logger and its

--- a/rasterio/_err.pyx
+++ b/rasterio/_err.pyx
@@ -11,6 +11,7 @@ from enum import IntEnum
 import logging
 import sys
 
+log = logging.getLogger(__name__)
 
 # Python exceptions expressing the CPL error numbers.
 

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -146,3 +146,7 @@ class WarpedVRTError(RasterioError):
 
 class DatasetIOShapeError(RasterioError):
     """Raised when data buffer shape is a mismatch when reading and writing"""
+
+
+class WarpOperationError(RasterioError):
+    """Raised when a warp operation fails."""

--- a/tests/rangehttpserver.py
+++ b/tests/rangehttpserver.py
@@ -1,0 +1,114 @@
+#!/usr/bin/python
+'''
+Use this in the same way as Python's SimpleHTTPServer:
+
+  python -m RangeHTTPServer [port]
+
+The only difference from SimpleHTTPServer is that RangeHTTPServer supports
+'Range:' headers to load portions of files. This is helpful for doing local web
+development with genomic data files, which tend to be to large to load into the
+browser all at once.
+'''
+
+import os
+import re
+
+try:
+    # Python3
+    from http.server import SimpleHTTPRequestHandler
+
+except ImportError:
+    # Python 2
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+
+
+def copy_byte_range(infile, outfile, start=None, stop=None, bufsize=16*1024):
+    '''Like shutil.copyfileobj, but only copy a range of the streams.
+
+    Both start and stop are inclusive.
+    '''
+    if start is not None: infile.seek(start)
+    while 1:
+        to_read = min(bufsize, stop + 1 - infile.tell() if stop else bufsize)
+        buf = infile.read(to_read)
+        if not buf:
+            break
+        outfile.write(buf)
+
+
+BYTE_RANGE_RE = re.compile(r'bytes=(\d+)-(\d+)?$')
+def parse_byte_range(byte_range):
+    '''Returns the two numbers in 'bytes=123-456' or throws ValueError.
+
+    The last number or both numbers may be None.
+    '''
+    if byte_range.strip() == '':
+        return None, None
+
+    m = BYTE_RANGE_RE.match(byte_range)
+    if not m:
+        raise ValueError('Invalid byte range %s' % byte_range)
+
+    first, last = [x and int(x) for x in m.groups()]
+    if last and last < first:
+        raise ValueError('Invalid byte range %s' % byte_range)
+    return first, last
+
+
+class RangeRequestHandler(SimpleHTTPRequestHandler):
+    """Adds support for HTTP 'Range' requests to SimpleHTTPRequestHandler
+
+    The approach is to:
+    - Override send_head to look for 'Range' and respond appropriately.
+    - Override copyfile to only transmit a range when requested.
+    """
+    def send_head(self):
+        if 'Range' not in self.headers:
+            self.range = None
+            return SimpleHTTPRequestHandler.send_head(self)
+        try:
+            self.range = parse_byte_range(self.headers['Range'])
+        except ValueError as e:
+            self.send_error(400, 'Invalid byte range')
+            return None
+        first, last = self.range
+
+        # Mirroring SimpleHTTPServer.py here
+        path = self.translate_path(self.path)
+        f = None
+        ctype = self.guess_type(path)
+        try:
+            f = open(path, 'rb')
+        except IOError:
+            self.send_error(404, 'File not found')
+            return None
+
+        fs = os.fstat(f.fileno())
+        file_len = fs[6]
+        if first >= file_len:
+            self.send_error(416, 'Requested Range Not Satisfiable')
+            return None
+
+        self.send_response(206)
+        self.send_header('Content-type', ctype)
+        self.send_header('Accept-Ranges', 'bytes')
+
+        if last is None or last >= file_len:
+            last = file_len - 1
+        response_length = last - first + 1
+
+        self.send_header('Content-Range',
+                         'bytes %s-%s/%s' % (first, last, file_len))
+        self.send_header('Content-Length', str(response_length))
+        self.send_header('Last-Modified', self.date_time_string(fs.st_mtime))
+        self.end_headers()
+        return f
+
+    def copyfile(self, source, outputfile):
+        if not self.range:
+            return SimpleHTTPRequestHandler.copyfile(self, source, outputfile)
+
+        # SimpleHTTPRequestHandler uses shutil.copyfileobj, which doesn't let
+        # you stop the copying before the end of the file.
+        start, stop = self.range  # set in send_head()
+        copy_byte_range(source, outputfile, start, stop)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1943,6 +1943,7 @@ def http_error_server(data):
                 return super().copyfile(source, outputfile)
 
             start, stop = self.range
+            print(start, stop)
 
             if start >= 16384 and stop < 1720320:
                 self.send_error(503, "Boom!")

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import sys
 
 from affine import Affine
 import numpy as np
@@ -1961,6 +1962,10 @@ def http_error_server(data):
     p.join()
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="Python 3.7 required to serve the data fixture directory",
+)
 def test_reproject_error_propagation(http_error_server):
     """Propagate errors up from ChunkAndWarpMulti."""
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1945,7 +1945,7 @@ def http_error_server(data):
             start, stop = self.range
             print(start, stop)
 
-            if start >= 16384 and stop < 1720320:
+            if start < 1609000 < stop:
                 self.send_error(503, "Boom!")
                 return None
             else:


### PR DESCRIPTION
We've been hiding these errors and allowing chunks of a warp operation to pass with no data copied to the output.

Note that the error message isn't very detailed. In a lot of cases it's a generic "TIFF read block error" and doesn't surface root causes like server errors.

Without the changes to _warp.pyx, reproject passes with no output copied (out will be all zeros). With the changes, an exception is raised.