### PR TITLE
DatasetReader and Writer now accept string filenames and URLs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Changes
 1.3.0 (TBD)
 -----------
 
+Bug fixes:
+
+- Allow DatasetReader and DatasetWriter to take string filenames and URLs
+  (#2426).
+
 1.3a3 (2022-02-04)
 ------------------
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -296,7 +296,8 @@ cdef class DatasetBase:
         self._hds = NULL
 
         if path is not None:
-            filename = parse_path(path).as_vsi()
+            path = parse_path(path)
+            filename = path.as_vsi()
 
             # driver may be a string or list of strings. If the
             # former, we put it into a list.
@@ -310,8 +311,11 @@ cdef class DatasetBase:
                 self._hds = open_dataset(filename, flags, driver, kwargs, None)
             except CPLE_BaseError as err:
                 raise RasterioIOError(str(err))
+        
+            self.name = path.name
+        else:
+            self.name = None
 
-        self.name = path.name
         self.mode = 'r'
         self.options = kwargs.copy()
         self._dtypes = []

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1321,10 +1321,12 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 except Exception:
                     raise TypeError("A valid dtype is required.")
 
+        internal_path = parse_path(path)
+
         # Make and store a GDAL dataset handle.
-        filename = path.name
-        path = path.as_vsi()
-        name_b = path.encode('utf-8')
+        filename = internal_path.name
+        vsi_path = internal_path.as_vsi()
+        name_b = vsi_path.encode('utf-8')
         fname = name_b
 
         # Process dataset opening options.
@@ -1348,7 +1350,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             if bool(CSLFetchBoolean(options, "APPEND_SUBDATASET", 0)):
                 log.debug("No deletion, subdataset will be added: path=%r", path)
             else:
-                _delete_dataset_if_exists(path)
+                _delete_dataset_if_exists(vsi_path)
 
             driver_b = driver.encode('utf-8')
             drv_name = driver_b
@@ -1413,7 +1415,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             flags = 0x01 | sharing_flag | 0x40
 
             try:
-                self._hds = open_dataset(path, flags, driver, kwargs, None)
+                self._hds = open_dataset(vsi_path, flags, driver, kwargs, None)
             except CPLE_OpenFailedError as err:
                 raise RasterioIOError(str(err))
 
@@ -2103,8 +2105,8 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
 
         # Parse the path to determine if there is scheme-specific
         # configuration to be done.
-        path = path.as_vsi()
-        name_b = path.encode('utf-8')
+        vsi_filename = path.as_vsi()
+        name_b = vsi_filename.encode('utf-8')
 
         memdrv = GDALGetDriverByName("MEM")
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,37 @@
+"""Tests of the rasterio.io module."""
+
+import pytest
+
+from rasterio.io import DatasetReader, DatasetWriter
+
+
+httpstif = (
+    "https://github.com/rasterio/rasterio/blob/master/tests/data/float32.tif?raw=true"
+)
+
+
+def test_datasetreader_ctor_filename(path_rgb_byte_tif):
+    """DatasetReader constructor accepts string filenames."""
+    assert DatasetReader(path_rgb_byte_tif).name.endswith("RGB.byte.tif")
+
+
+@pytest.mark.network
+def test_datasetreader_ctor_url(gdalenv):
+    """DatasetReader constructor accepts URLs."""
+    dataset = DatasetReader(httpstif)
+    assert dataset.name.startswith("https")
+    assert dataset.name.endswith("float32.tif?raw=true")
+
+
+def test_datasetwriter_no_crs(tmp_path):
+    """DatasetWriter constructor accepts string filenames."""
+    filename = str(tmp_path.joinpath("lol.tif"))
+    assert DatasetWriter(
+        filename,
+        "w",
+        driver="GTiff",
+        width=100,
+        height=100,
+        count=1,
+        dtype="uint8",
+    ).name.endswith("lol.tif")


### PR DESCRIPTION
This was the intent for some time, but there were a few bugs and no tests that called the constructors directly. Now there are.

Resolves #2426