### PR TITLE
Virtual dataset

### DIFF
--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -325,6 +325,7 @@ class VirtualDataset:
         # To avoid a circular import.
         from rasterio.io import MemoryFile
 
+        # TODO: consider implications of calling open a second time.
         self._memfile = MemoryFile(ET.tostring(self._tree))
         return self._memfile.open(driver="VRT", sharing=sharing, **kwargs)
 

--- a/tests/test_vrt.py
+++ b/tests/test_vrt.py
@@ -1,14 +1,12 @@
 """Tests of the rasterio.vrt module"""
 
-from pathlib import Path
-
 import rasterio
-import rasterio.vrt
+from rasterio.vrt import _boundless_vrt_doc, VirtualDataset
 
 
 def test_boundless_vrt(path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as rgb:
-        doc = rasterio.vrt._boundless_vrt_doc(rgb)
+        doc = _boundless_vrt_doc(rgb)
         assert doc.startswith("<VRTDataset")
         with rasterio.open(doc) as vrt:
             assert rgb.count == vrt.count
@@ -18,7 +16,7 @@ def test_boundless_vrt(path_rgb_byte_tif):
 
 def test_boundless_msk_vrt(path_rgb_msk_byte_tif):
     with rasterio.open(path_rgb_msk_byte_tif) as msk:
-        doc = rasterio.vrt._boundless_vrt_doc(msk)
+        doc = _boundless_vrt_doc(msk)
         assert doc.startswith("<VRTDataset")
         with rasterio.open(doc) as vrt:
             assert msk.count == vrt.count
@@ -28,17 +26,15 @@ def test_boundless_msk_vrt(path_rgb_msk_byte_tif):
 
 def test_virtual_dataset_fromstring(path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as rgb:
-        doc = rasterio.vrt._boundless_vrt_doc(rgb)
+        doc = _boundless_vrt_doc(rgb)
 
-        with rasterio.vrt.VirtualDataset.fromstring(
-            doc
-        ) as vrtfile, vrtfile.open() as vrt:
+        with VirtualDataset.fromstring(doc) as vrtfile, vrtfile.open() as vrt:
             assert rgb.count == vrt.count
             assert rgb.dtypes == vrt.dtypes
             assert rgb.mask_flag_enums == vrt.mask_flag_enums
 
 
 def test_virtual_dataset_constructor():
-    vrt = rasterio.vrt.VirtualDataset(height=10, width=11)
+    vrt = VirtualDataset(height=10, width=11)
     assert vrt.height == 10
     assert vrt.width == 11


### PR DESCRIPTION
[Virtual datasets](https://gdal.org/drivers/raster/vrt.html) with deferred computation of data are one of GDAL's killer features. VRTs can represent rasters that are much larger than our computer's memory and can also layer transformations on top of non-virtual datasets (GeoTIFFs, etc).

How can Python developers make a VRT? The two most common options are very different: 1) call a high level GDAL API method like GDALBuildVRT (aka the gdalbuildvrt utility) or GDALCreateCopy (aka the gdal_translate utility), or 2) build up a VRT XML document using an XML library or by interpolating into an XML template. I think something in-between could be very useful. An API that leverages xml.etree (for example) and is easy to extend and modify, feels like existing Rasterio APIs, and glosses over details of the VRT XML schema.

An interesting thing about GDAL's data model is that deferred computation of VRT pixels is only an implementation detail. There are no "immediate" and "lazy" datasets, just datasets, some of which might be lazy. What if you wanted lazily evaluated rasters to be a type in your application? GDAL doesn't provide this. A rasterio virtual dataset class can.

Virtual datasets would support common operations like:

* padding (like rasterio's boundless reads)
* clipping
* merging
* stacking
* layering of metadata and transformations

Virtual datasets would be composable, so that you could virtually stack virtual mosaics.

Ideally, a virtual dataset class would be compatible with Xarray and Dask. As a backend.

This PR contains a sketch of a virtual dataset class.