### PR TITLE
Add mixin methods to MemoryDataset

### DIFF
--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -11,6 +11,7 @@ from rasterio._io import (
     DatasetWriterBase,
     BufferedDatasetWriterBase,
     MemoryFileBase,
+    MemoryDataset as _MemoryDataset
 )
 from rasterio.windows import WindowMethodsMixin
 from rasterio.env import ensure_env
@@ -158,6 +159,11 @@ class MemoryFile(MemoryFileBase):
 
     def __exit__(self, *args):
         self.close()
+
+
+class MemoryDataset(_MemoryDataset, TransformMethodsMixin, WindowMethodsMixin):
+    """An in-memory Dataset object that uses an array for its storage"""
+    pass
 
 
 class _FilePath(FilePathBase):


### PR DESCRIPTION
The base implementation of MemoryDataset lacks transform and window methods. There are some places in rasterio where Datasets are assumed to have these kinds of methods. This PR adds those mixin methods and exposes MemoryDataset via rasterio.io.

@sgillies Is exposing MemoryDataset like this something we want to do?