### PR TITLE
TST: Fix test fixture for test_reproject_error_propagation

### DIFF
--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -2299,7 +2299,6 @@ def test_reproject_rpcs_approx_transformer(caplog):
         assert "Created approximate transformer" in caplog.text
 
 
-@pytest.mark.network
 @pytest.fixture
 def http_error_server(data):
     """Serves files from the test data directory, poorly."""
@@ -2309,9 +2308,10 @@ def http_error_server(data):
 
     Handler = functools.partial(RangeRequestErrorHandler, directory=str(data))
     httpd = http.server.HTTPServer(("", 0), Handler)
-    p = multiprocessing.Process(target=httpd.serve_forever)
+    mp_context = multiprocessing.get_context("fork")
+    p = mp_context.Process(target=httpd.serve_forever)
     p.start()
-    yield f"{httpd.server_name}:{httpd.server_port}"
+    yield f"{httpd.server_address[0]}:{httpd.server_address[1]}"
     p.terminate()
     p.join()
 


### PR DESCRIPTION
Pickling the HTTP server requires the 'fork' multiprocessing context, and in some places, `HTTPServer.server_name` returns something that doesn't work with curl. So force the 'fork' mode, and use `HTTPServer.server_address` instead.

Also, remove the `network` marker, as it does nothing for fixtures and isn't required since that marker signifies _external_ networking.

Fixes #3357
Fixes #3403