### PR TITLE
ENH:merge: Open files at most twice | open_kwargs | always chunk

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -499,7 +499,6 @@ def merge(
                         src_bounds, chunk_bound, chunk_transform
                     )
                     src_win= windows.from_bounds(*ibounds, src_transform)
-                    chunk_win = _align_window(windows.from_bounds(*ibounds, chunk_transform))
                     dst_win = _align_window(windows.from_bounds(*ibounds, output_transform))
                 except (ValueError, WindowError):
                     logger.info(
@@ -508,7 +507,7 @@ def merge(
                     continue
 
                 data = src.read(
-                    out_shape=(src_count, chunk_win.height, chunk_win.width),
+                    out_shape=(src_count, dst_win.height, dst_win.width),
                     indexes=indexes,
                     masked=True,
                     window=src_win,


### PR DESCRIPTION
Consequential changes:
1. When paths to datasets are provided, open the datasets once and reuse the dataset objects. This results in a substantial performance boost when there are many chunks.
2. Properly handle masking the output array based on the nodataval. The old code was only guaranteed to work for integer dtypes.

Other minor fixes include
1. Lift function def out of loop. This avoids creating a new function object for each chunk processed.
2. Replace `math.sqrt(x[0]**2 + x[1]**2)` with a much faster equivalent: `math.hypot(*x)`
3. Better estimate for max_pixels calculation. We allocate 5 arrays (dest, data, and 3 masks) during the merge loop. We need to account for this otherwise the merge is using memory up to 5 * mem_limit.
