### PR TITLE
BUG: Fix `RasterioDeprecationWarning` for `rio info`

### DIFF
--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -115,7 +115,7 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
                 for name in src.subdatasets:
                     click.echo(name)
             elif meta_member == 'stats':
-                st = src.statistics(bidx)
+                st = src.stats(indexes=bidx)[0]
                 click.echo("{st.min} {st.max} {st.mean} {st.std}".format(st=st))
             elif meta_member == 'checksum':
                 click.echo(str(src.checksum(bidx)))


### PR DESCRIPTION
Use the suggested `.stats` instead of deprecated `.statistics`

Closes #3379