### PR TITLE
Fix geojson_type click option implementation

### DIFF
--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -5,7 +5,7 @@ import click
 from cligj import (
     precision_opt, indent_opt, compact_opt, projection_geographic_opt,
     projection_mercator_opt, projection_projected_opt,
-    use_rs_opt, geojson_type_feature_opt, geojson_type_bbox_opt,
+    use_rs_opt,
 )
 
 from .helpers import write_features, to_lower
@@ -32,8 +32,7 @@ logger = logging.getLogger(__name__)
     help="Output in specified coordinates.")
 @options.sequence_opt
 @use_rs_opt
-@geojson_type_feature_opt(True)
-@geojson_type_bbox_opt(False)
+@options.geojson_type_opt(allowed=('feature', 'bbox'), default='feature')
 @click.pass_context
 def bounds(
     ctx,

--- a/rasterio/rio/gcps.py
+++ b/rasterio/rio/gcps.py
@@ -5,8 +5,7 @@ import json
 
 import click
 from cligj import (
-    compact_opt, use_rs_opt, geojson_type_collection_opt,
-    geojson_type_feature_opt, projection_geographic_opt,
+    compact_opt, use_rs_opt, projection_geographic_opt,
     projection_projected_opt, precision_opt, indent_opt)
 
 import rasterio
@@ -27,8 +26,7 @@ sequence_opt = click.option(
 
 @click.command(short_help="Print ground control points as GeoJSON.")
 @options.file_in_arg
-@geojson_type_collection_opt()
-@geojson_type_feature_opt(default=True)
+@options.geojson_type_opt(allowed=('collection', 'feature'), default='feature')
 @projection_geographic_opt
 @projection_projected_opt
 @precision_opt

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -369,3 +369,47 @@ sequence_opt = click.option(
 format_opt = click.option(
     "-f", "--format", "--driver", "driver", help="Output format driver."
 )
+
+
+def geojson_type_opt(*, allowed, default):
+    """GeoJSON output mode"""
+    def verify_geojson_type(ctx, param, value):
+        geojson_type = ctx.params.setdefault("geojson_type", {})
+        geojson_type[param.name] = value
+        if len(geojson_type) == len(allowed):
+            # We've now seen all options for geojson_type, so verify their contents.
+            specified = [
+                name.removeprefix("geojson_type_")
+                for name, value in geojson_type.items()
+                if value
+            ]
+            if len(specified) > 1:
+                names = ",".join(f"--{name}" for name in specified)
+                raise click.BadParameter(
+                    f"too many GeoJSON output formats: {names} may not be specified together"
+                )
+            ctx.params["geojson_type"] = specified[0] if specified else default
+
+    def wrapper(func):
+        options = {
+            "collection": "feature collection(s)",
+            "feature": "feature(s)",
+            "bbox": "bounding box array(s)",
+        }
+
+        for name in allowed:
+            if name not in options:
+                raise click.UsageError(f"{name} is not a valid GeoJSON output mode")
+            help_suffix = " (default)" if name == default else ""
+            opt = click.option(
+                f"--{name}",
+                f"geojson_type_{name}",
+                is_flag=True,
+                expose_value=False,
+                callback=verify_geojson_type,
+                help=f"Output as GeoJSON {options[name]}{help_suffix}",
+            )
+            func = opt(func)
+        return func
+
+    return wrapper

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -25,8 +25,7 @@ logger = logging.getLogger(__name__)
 @cligj.projection_projected_opt
 @options.sequence_opt
 @cligj.use_rs_opt
-@cligj.geojson_type_feature_opt(True)
-@cligj.geojson_type_bbox_opt(False)
+@options.geojson_type_opt(allowed=('feature', 'bbox'), default='feature')
 @click.option('--band/--mask', default=True,
               help="Choose to extract from a band (the default) or a mask.")
 @click.option('--bidx', 'bandidx', type=int, default=None,


### PR DESCRIPTION
According to several issues upstream (e.g., [1], [2]), creating multiple options that save to the same destination is not documented or supported. Somewhere in 8.2.x, this also broke, as it depended on evaluation order in some way.

Instead, save the options to different name, and use a callback function on all of them to verify that the result is exclusive, and follows the default.

[1] https://github.com/pallets/click/issues/1688#issuecomment-707918832
[2] https://github.com/pallets/click/issues/2321#issuecomment-1184398784