### PR TITLE
BUG: Ensure consistent error for invalid tile sizes

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1531,8 +1531,15 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                     GDALCreate(drv, fname, width, height, count, gdal_dtype, options)
                 )
 
+            except CPLE_IllegalArgError as exc:
+                if "must be a multiple of 16" in str(exc):  # For GDAL 3.12+.
+                    raise RasterBlockError(
+                        "The height and width of TIFF dataset blocks must be multiples of 16"
+                    )
+                else:
+                    raise RasterioIOError(str(exc))
             except CPLE_AppDefinedError as exc:
-                if "Bad value" in str(exc):
+                if "Bad value" in str(exc):  # For GDAL < 3.12.
                     raise RasterBlockError(
                         "The height and width of TIFF dataset blocks must be multiples of 16"
                     )


### PR DESCRIPTION
Extracted from #3394 

GDAL 3.12 now has a more specific error for incorrect tile size [1], but for backwards compatibility, catch that and raise the same one that used to be raised.

[1] https://github.com/OSGeo/gdal/pull/12679