### PR TITLE
warp.py: fix typo in doc string

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -278,7 +278,7 @@ def reproject(
     Returns
     ---------
     destination: ndarray or Band
-        The transformed narray or Band.
+        The transformed ndarray or Band.
     dst_transform: Affine
         The affine transformation matrix of the destination.
     """


### PR DESCRIPTION
The rest of the documentation uses
ndarray to refer to ndarrays, so update
this doc string to also do so.