### PR TITLE
pytest: less verbose logs

### DIFF
--- a/.github/workflows/test_gdal_build.yaml
+++ b/.github/workflows/test_gdal_build.yaml
@@ -77,7 +77,7 @@ jobs:
         run: |
           export PATH="${GDAL_DIR}/bin/:${PATH}"
           . testenv/bin/activate
-          python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
+          python -m pytest -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
 
       - if: success()
         run: echo "Success"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -85,7 +85,7 @@ jobs:
           python -m pip install dist/*.whl
           python -m pip install aiohttp boto3 fsspec hypothesis packaging pytest shapely
           rm -rf rasterio
-          python -m pytest -v -m "not wheel" -rxXs
+          python -m pytest -m "not wheel" -rxXs
 
   docker_tests:
     needs: linting
@@ -145,7 +145,7 @@ jobs:
         run: |
           . testenv/bin/activate
           python -m pip install -r requirements-dev.txt
-          python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
+          python -m pytest -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
 
   conda_test:
     needs: linting
@@ -193,10 +193,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         shell: bash -l {0}
         run: |
-          micromamba run python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing -k "not issue2353"
+          micromamba run python -m pytest -m "not wheel" -rxXs --cov rasterio --cov-report term-missing -k "not issue2353"
 
       - name: Test with Coverage (OSX)
         if: "${{matrix.os}} == 'macos-15-intel' || ${{matrix.os}} == 'macos-14'"
         shell: bash -l {0}
         run: |
-           micromamba run python -m pytest -v -m "not wheel" -rxXs  --cov rasterio --cov-report term-missing -k "not test_target_aligned_pixels and not test_reproject_error_propagation and not test_outer_boundless_pixel_fidelity and not issue2353"
+           micromamba run python -m pytest -m "not wheel" -rxXs  --cov rasterio --cov-report term-missing -k "not test_target_aligned_pixels and not test_reproject_error_propagation and not test_outer_boundless_pixel_fidelity and not issue2353"


### PR DESCRIPTION
The pytest runs in CI are very verbose, making it difficult to locate which tests are passing and which are failing. This PR reduces the verbosity, removing extraneous info that isn't useful.