### PR TITLE
RtD: enable strict mode

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: false
+  fail_on_warning: true
 
 formats: all
 


### PR DESCRIPTION
This PR enables strict testing on Read the Docs to prevent new documentation issues from being introduced. See the dozens of recent PRs where I fixed several warnings in the docs for motivation.