### PR TITLE
Add missing test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,12 +271,15 @@ extra_reqs = {
     "plot": ["matplotlib"],
     "s3": ["boto3>=1.2.4"],
     "test": [
+        "aiohttp",
         "boto3>=1.2.4",
         "fsspec",
         "hypothesis",
+        "matplotlib",
         "packaging",
         "pytest-cov>=2.2.0",
         "pytest>=2.8.2",
+        "requests",
         "shapely",
     ],
 }


### PR DESCRIPTION
When running the tests locally in a minimal environment, I see the following test failures:
```
FAILED tests/test_merge.py::test_issue2202 - ImportError: Could not import matplotlib
FAILED tests/test_open_sharing.py::test_sharing_off - AssertionError: assert 528 == 2
FAILED tests/test_pyopener.py::test_opener_fsspec_http_fs - ImportError: HTTPFileSystem requires "requests" and "aiohttp" to be installed
FAILED tests/test_pyopener.py::test_fsspec_http_msk_sidecar - ImportError: HTTPFileSystem requires "requests" and "aiohttp" to be installed
```
This PR adds these missing dependencies.

@mwtoews this would also need to be added to your pyproject.toml PR depending on the order in which PRs are merged.