### PR TITLE
TST: Use context manager for WarpedVRT

### DIFF
--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -37,8 +37,7 @@ def _copy_update_profile(path_in, path_out, **kwargs):
 
 def test_warped_vrt(path_rgb_byte_tif):
     """A VirtualVRT has the expected VRT properties."""
-    with rasterio.open(path_rgb_byte_tif) as src:
-        vrt = WarpedVRT(src, crs=DST_CRS)
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, crs=DST_CRS) as vrt:
         assert vrt.dst_crs == CRS.from_string(DST_CRS)
         assert vrt.src_nodata == 0.0
         assert vrt.dst_nodata == 0.0
@@ -50,8 +49,7 @@ def test_warped_vrt(path_rgb_byte_tif):
 
 def test_warped_vrt_nondefault_nodata(path_rgb_byte_tif):
     """A VirtualVRT has expected nondefault nodata values."""
-    with rasterio.open(path_rgb_byte_tif) as src:
-        vrt = WarpedVRT(src, crs=DST_CRS, src_nodata=None, nodata=None)
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, crs=DST_CRS, src_nodata=None, nodata=None) as vrt:
         assert vrt.dst_crs == CRS.from_string(DST_CRS)
         assert vrt.src_nodata is None
         assert vrt.dst_nodata is None
@@ -63,9 +61,8 @@ def test_warped_vrt_nondefault_nodata(path_rgb_byte_tif):
 
 def test_warped_vrt_add_alpha(dsrec, path_rgb_byte_tif):
     """A VirtualVRT has the expected VRT properties."""
-    with rasterio.Env() as env:
-        with rasterio.open(path_rgb_byte_tif) as src:
-            vrt = WarpedVRT(src, crs=DST_CRS, add_alpha=True)
+    with rasterio.Env() as env, rasterio.open(path_rgb_byte_tif) as src:
+        with WarpedVRT(src, crs=DST_CRS, add_alpha=True) as vrt:
 
             records = dsrec(env)
             assert len(records) == 1
@@ -91,31 +88,34 @@ def test_warped_vrt_add_alpha(dsrec, path_rgb_byte_tif):
 
 def test_warped_vrt_msk_add_alpha(path_rgb_msk_byte_tif, caplog):
     """Add an alpha band to the VRT to access per-dataset mask of a source"""
-    with rasterio.Env(GDAL_DISABLE_READDIR_ON_OPEN="TRUE"):
-        with rasterio.open(path_rgb_msk_byte_tif) as src:
-            vrt = WarpedVRT(src, crs=DST_CRS, add_alpha=True)
-            assert vrt.src_nodata is None
-            assert vrt.dst_nodata is None
-            assert vrt.count == 4
-            assert vrt.mask_flag_enums == (
-                [MaskFlags.per_dataset, MaskFlags.alpha],
-            ) * 3 + (
-                [MaskFlags.all_valid],
-            )
+    with rasterio.Env(
+        GDAL_DISABLE_READDIR_ON_OPEN="TRUE"
+    ), rasterio.open(
+        path_rgb_msk_byte_tif
+    ) as src, WarpedVRT(
+        src, crs=DST_CRS, add_alpha=True
+    ) as vrt:
+        assert vrt.src_nodata is None
+        assert vrt.dst_nodata is None
+        assert vrt.count == 4
+        assert vrt.mask_flag_enums == (
+            [MaskFlags.per_dataset, MaskFlags.alpha],
+        ) * 3 + (
+            [MaskFlags.all_valid],
+        )
 
-            caplog.set_level(logging.DEBUG)
-            with rasterio.Env(CPL_DEBUG=True):
-                masks = vrt.read_masks()
-                assert masks[0, 0, 0] == 0
-                assert masks[0].mean() > 0
+        caplog.set_level(logging.DEBUG)
+        with rasterio.Env(CPL_DEBUG=True):
+            masks = vrt.read_masks()
+            assert masks[0, 0, 0] == 0
+            assert masks[0].mean() > 0
 
-            assert "RGB2.byte.tif.msk" in caplog.text
+    assert "RGB2.byte.tif.msk" in caplog.text
 
 
 def test_warped_vrt_msk_nodata(path_rgb_msk_byte_tif, caplog):
     """Specifying dst nodata also works for source with .msk"""
-    with rasterio.open(path_rgb_msk_byte_tif) as src:
-        vrt = WarpedVRT(src, crs=DST_CRS, nodata=0.0)
+    with rasterio.open(path_rgb_msk_byte_tif) as src, WarpedVRT(src, crs=DST_CRS, nodata=0.0) as vrt:
         assert vrt.dst_crs == CRS.from_string(DST_CRS)
         assert vrt.src_nodata is None
         assert vrt.dst_nodata == 0.0
@@ -129,8 +129,7 @@ def test_warped_vrt_msk_nodata(path_rgb_msk_byte_tif, caplog):
 
 def test_warped_vrt_source(path_rgb_byte_tif):
     """A VirtualVRT has the expected source dataset."""
-    with rasterio.open(path_rgb_byte_tif) as src:
-        vrt = WarpedVRT(src, crs=DST_CRS)
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, crs=DST_CRS) as vrt:
         assert vrt.src_dataset == src
 
 
@@ -140,16 +139,13 @@ def test_warped_vrt_set_src_crs_default(path_rgb_byte_tif, tmpdir):
     _copy_update_profile(path_rgb_byte_tif, path_crs_unset, crs=None)
     with rasterio.open(path_rgb_byte_tif) as src:
         original_crs = src.crs
-    with rasterio.open(path_crs_unset) as src:
-        with WarpedVRT(src, src_crs=original_crs) as vrt:
-            assert vrt.src_crs == original_crs
-            assert vrt.dst_crs == original_crs
-
+    with rasterio.open(path_crs_unset) as src, WarpedVRT(src, src_crs=original_crs) as vrt:
+        assert vrt.src_crs == original_crs
+        assert vrt.dst_crs == original_crs
 
 def test_wrap_file(path_rgb_byte_tif):
     """A VirtualVRT has the expected dataset properties."""
-    with rasterio.open(path_rgb_byte_tif) as src:
-        vrt = WarpedVRT(src, crs=DST_CRS)
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, crs=DST_CRS) as vrt:
         assert vrt.crs == CRS.from_string(DST_CRS)
         assert tuple(round(x, 1) for x in vrt.bounds) == (
             -8789636.7, 2700460.0, -8524406.4, 2943560.2
@@ -174,25 +170,24 @@ def test_warped_vrt_dimensions(path_rgb_byte_tif):
         dst_transform = affine.Affine(
             resolution, 0.0, extent[0], 0.0, -resolution, extent[1]
         )
-        vrt = WarpedVRT(
+        with WarpedVRT(
             src, crs=DST_CRS, width=size, height=size, transform=dst_transform
-        )
-        assert vrt.dst_crs == CRS.from_string(DST_CRS)
-        assert vrt.src_nodata == 0.0
-        assert vrt.dst_nodata == 0.0
-        assert vrt.resampling == Resampling.nearest
-        assert vrt.width == size
-        assert vrt.height == size
-        assert vrt.transform == dst_transform
-        assert vrt.warp_extras == {"init_dest": "NO_DATA"}
+        ) as vrt:
+            assert vrt.dst_crs == CRS.from_string(DST_CRS)
+            assert vrt.src_nodata == 0.0
+            assert vrt.dst_nodata == 0.0
+            assert vrt.resampling == Resampling.nearest
+            assert vrt.width == size
+            assert vrt.height == size
+            assert vrt.transform == dst_transform
+            assert vrt.warp_extras == {"init_dest": "NO_DATA"}
 
 
 def test_warp_extras(path_rgb_byte_tif):
     """INIT_DEST warp extra is passed through."""
-    with rasterio.open(path_rgb_byte_tif) as src:
-        with WarpedVRT(src, crs=DST_CRS, init_dest=255) as vrt:
-            rgb = vrt.read()
-            assert (rgb[:, 0, 0] == 255).all()
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, crs=DST_CRS, init_dest=255) as vrt:
+        rgb = vrt.read()
+        assert (rgb[:, 0, 0] == 255).all()
 
 
 def test_transformer_options(path_rgb_byte_tif):
@@ -240,27 +235,25 @@ def test_transformer_options__width_height(path_rgb_byte_tif):
 def test_wrap_s3():
     """A warp wrapper's dataset has the expected properties"""
     L8TIF = "s3://sentinel-cogs/sentinel-s2-l2a-cogs/45/C/VQ/2022/11/S2B_45CVQ_20221102_0_L2A/B01.tif"
-    with rasterio.open(L8TIF) as src:
-        with WarpedVRT(src, crs=DST_CRS, src_nodata=0, nodata=0) as vrt:
-            assert vrt.crs == DST_CRS
-            assert tuple(round(x, 1) for x in vrt.bounds) == (
-                9222324.9, -14139657.4, 9730075.2, -13635650.5
-            )
-            assert vrt.name == f"WarpedVRT({L8TIF})"
-            assert vrt.indexes == (1,)
-            assert vrt.nodatavals == (0,)
-            assert vrt.dtypes == ("uint16",)
-            assert vrt.shape == (1885, 1899)
+    with rasterio.open(L8TIF) as src, WarpedVRT(src, crs=DST_CRS, src_nodata=0, nodata=0) as vrt:
+        assert vrt.crs == DST_CRS
+        assert tuple(round(x, 1) for x in vrt.bounds) == (
+            9222324.9, -14139657.4, 9730075.2, -13635650.5
+        )
+        assert vrt.name == f"WarpedVRT({L8TIF})"
+        assert vrt.indexes == (1,)
+        assert vrt.nodatavals == (0,)
+        assert vrt.dtypes == ("uint16",)
+        assert vrt.shape == (1885, 1899)
 
 
 def test_warped_vrt_nodata_read(path_rgb_byte_tif):
     """A read from a VirtualVRT respects dst_nodata."""
-    with rasterio.open(path_rgb_byte_tif) as src:
-        with WarpedVRT(src, crs=DST_CRS, src_nodata=0) as vrt:
-            data = vrt.read(1, masked=True)
-            assert data.mask.any()
-            mask = vrt.dataset_mask()
-            assert not mask.all()
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, crs=DST_CRS, src_nodata=0) as vrt:
+        data = vrt.read(1, masked=True)
+        assert data.mask.any()
+        mask = vrt.dataset_mask()
+        assert not mask.all()
 
 
 @pytest.mark.parametrize("complex", (True, False))
@@ -356,18 +349,17 @@ def test_image(red_green):
 
 def test_image_nodata_mask(red_green):
     """Nodata of 0 masks out the black background"""
-    with rasterio.Env():
-        with rasterio.open(str(red_green.join("red.tif"))) as src, WarpedVRT(
-            src,
-            nodata=0,
-            transform=affine.Affine.translation(-src.width / 2, src.height / 2) * src.transform,
-            width=3 * src.width,
-            height=3 * src.height
-        ) as vrt:
-            masks = vrt.read_masks()
-            image = numpy.moveaxis(masks, 0, -1)
-            assert image[63, 63, 0] == 0
-            assert image[64, 64, 0] == 255
+    with rasterio.Env(), rasterio.open(str(red_green.join("red.tif"))) as src, WarpedVRT(
+        src,
+        nodata=0,
+        transform=affine.Affine.translation(-src.width / 2, src.height / 2) * src.transform,
+        width=3 * src.width,
+        height=3 * src.height
+    ) as vrt:
+        masks = vrt.read_masks()
+        image = numpy.moveaxis(masks, 0, -1)
+        assert image[63, 63, 0] == 0
+        assert image[64, 64, 0] == 255
 
 
 def test_hit_ovr(red_green):
@@ -392,8 +384,7 @@ def test_hit_ovr(red_green):
 
 def test_warped_vrt_1band_add_alpha():
     """Add an alpha band to the VRT to access per-dataset mask of a source"""
-    with rasterio.open('tests/data/shade.tif') as src:
-        vrt = WarpedVRT(src, add_alpha=True)
+    with rasterio.open('tests/data/shade.tif') as src, WarpedVRT(src, add_alpha=True) as vrt:
         assert vrt.count == 2
         assert vrt.mask_flag_enums == (
             [MaskFlags.per_dataset, MaskFlags.alpha],
@@ -410,8 +401,7 @@ def test_invalid_add_alpha():
 
 def test_warpedvrt_float32_preserve(data):
     """WarpedVRT preserves float32 dtype of source"""
-    with rasterio.open("tests/data/float32.tif") as src:
-        with WarpedVRT(src, src_crs="EPSG:4326") as vrt:
+    with rasterio.open("tests/data/float32.tif") as src, WarpedVRT(src, src_crs="EPSG:4326") as vrt:
             assert src.dtypes == vrt.dtypes == ("float32",)
 
 
@@ -421,9 +411,8 @@ def test_warpedvrt_float32_override(data):
     with rasterio.open(float32file, "r+") as dst:
         dst.nodata = -3.4028230607370965e+38
 
-    with rasterio.open(float32file) as src:
-        with WarpedVRT(src, src_crs="EPSG:4326", dtype="float32") as vrt:
-            assert src.dtypes == vrt.dtypes == ("float32",)
+    with rasterio.open(float32file) as src, WarpedVRT(src, src_crs="EPSG:4326", dtype="float32") as vrt:
+        assert src.dtypes == vrt.dtypes == ("float32",)
 
 
 def test_warpedvrt_float32_override_nodata(data):
@@ -432,9 +421,8 @@ def test_warpedvrt_float32_override_nodata(data):
     with rasterio.open(float32file, "r+") as dst:
         dst.nodata = -3.4028230607370965e+38
 
-    with rasterio.open(float32file) as src:
-        with WarpedVRT(src, src_crs="EPSG:4326", nodata=0.0001, dtype="float32") as vrt:
-            assert src.dtypes == vrt.dtypes == ("float32",)
+    with rasterio.open(float32file) as src, WarpedVRT(src, src_crs="EPSG:4326", nodata=0.0001, dtype="float32") as vrt:
+        assert src.dtypes == vrt.dtypes == ("float32",)
 
 
 @pytest.mark.xfail(reason="GDAL's output defaults to float64")
@@ -444,22 +432,20 @@ def test_warpedvrt_issue1744(data):
     with rasterio.open(float32file, "r+") as dst:
         dst.nodata = -3.4028230607370965e+38
 
-    with rasterio.open(float32file) as src:
-        with WarpedVRT(src, src_crs="EPSG:4326") as vrt:
-            assert src.dtypes == vrt.dtypes == ("float32",)
+    with rasterio.open(float32file) as src, WarpedVRT(src, src_crs="EPSG:4326") as vrt:
+        assert src.dtypes == vrt.dtypes == ("float32",)
 
 
 def test_open_datasets(capfd, path_rgb_byte_tif):
     """Number of open datasets is expected"""
     with rasterio.Env() as env:
-
         with rasterio.open(path_rgb_byte_tif) as src:
             env._dump_open_datasets()
             captured = capfd.readouterr()
             assert "1 N GTiff" in captured.err
             assert "1 S GTiff" not in captured.err
 
-            with WarpedVRT(src) as vrt:
+            with WarpedVRT(src):
                 env._dump_open_datasets()
                 captured = capfd.readouterr()
                 assert "2 N GTiff" in captured.err
@@ -505,31 +491,29 @@ def test_warp_warp(dsrec, path_rgb_byte_tif):
 
 def test_out_dtype(red_green):
     """Read as float"""
-    with rasterio.Env():
-        with rasterio.open(str(red_green.join("red.tif"))) as src, WarpedVRT(
-            src,
-            transform=affine.Affine.translation(-src.width / 4, src.height / 4) * src.transform,
-            width=2 * src.width,
-            height=2 * src.height
-        ) as vrt:
-            data = vrt.read(out_dtype="float32")
-            image = numpy.moveaxis(data, 0, -1)
-            assert image[31, 31, 0] == 0.0
-            assert image[32, 32, 0] == 204.0
-            assert image[32, 32, 1] == 17.0
+    with rasterio.Env(), rasterio.open(str(red_green.join("red.tif"))) as src, WarpedVRT(
+        src,
+        transform=affine.Affine.translation(-src.width / 4, src.height / 4) * src.transform,
+        width=2 * src.width,
+        height=2 * src.height
+    ) as vrt:
+        data = vrt.read(out_dtype="float32")
+        image = numpy.moveaxis(data, 0, -1)
+        assert image[31, 31, 0] == 0.0
+        assert image[32, 32, 0] == 204.0
+        assert image[32, 32, 1] == 17.0
 
 
 def test_sample(red_green):
     """See https://github.com/rasterio/rasterio/issues/1833."""
-    with rasterio.Env():
-        with rasterio.open(str(red_green.join("red.tif"))) as src, WarpedVRT(
-            src,
-            transform=affine.Affine.translation(-src.width / 4, src.height / 4) * src.transform,
-            width=2 * src.width,
-            height=2 * src.height
-        ) as vrt:
-            sample = next(vrt.sample([(-20, -50)]))
-            assert not sample.any()
+    with rasterio.Env(), rasterio.open(str(red_green.join("red.tif"))) as src, WarpedVRT(
+        src,
+        transform=affine.Affine.translation(-src.width / 4, src.height / 4) * src.transform,
+        width=2 * src.width,
+        height=2 * src.height
+    ) as vrt:
+        sample = next(vrt.sample([(-20, -50)]))
+        assert not sample.any()
 
 
 @pytest.fixture
@@ -560,18 +544,17 @@ def dsrec(capfd):
 
 def test_warped_vrt_resizing():
     """Confirm fix of #1921"""
-    with rasterio.open("tests/data/RGB.byte.tif") as rgb:
-        with WarpedVRT(rgb, height=10, width=10) as vrt:
-            assert vrt.height == 10
-            assert vrt.width == 10
+    with rasterio.open("tests/data/RGB.byte.tif") as rgb, WarpedVRT(rgb, height=10, width=10) as vrt:
+        assert vrt.height == 10
+        assert vrt.width == 10
 
 
 def test_warped_vrt_resizing_repro():
     """Confirm fix of #1921"""
-    with rasterio.open("tests/data/RGB.byte.tif") as rgb:
-        with WarpedVRT(rgb, crs="EPSG:3857", height=10, width=10) as vrt:
-            assert vrt.height == 10
-            assert vrt.width == 10
+    with rasterio.open("tests/data/RGB.byte.tif") as rgb, WarpedVRT(rgb, crs="EPSG:3857", height=10, width=10) as vrt:
+        assert vrt.height == 10
+        assert vrt.width == 10
+
 
 
 def test_vrt_src_mode(path_rgb_byte_tif):
@@ -587,18 +570,15 @@ def test_vrt_src_mode(path_rgb_byte_tif):
             dst.write(bands)
 
             with pytest.warns(FutureWarning):
-                vrt = WarpedVRT(dst, crs="EPSG:3857")
+                with WarpedVRT(dst, crs="EPSG:3857"):
+                    pass
 
 
 def test_vrt_src_kept_alive(path_rgb_byte_tif):
     """VRT source dataset is kept alive, preventing crashes"""
 
-    with rasterio.open(path_rgb_byte_tif) as dst:
-        vrt = WarpedVRT(dst, crs="EPSG:3857")
-
-    assert (vrt.read() != 0).any()
-    vrt.close()
-
+    with rasterio.open(path_rgb_byte_tif) as dst, WarpedVRT(dst, crs="EPSG:3857") as vrt:
+        assert (vrt.read() != 0).any()
 
 def test_vrt_mem_src_kept_alive(path_rgb_byte_tif):
     """VRT in-memory source dataset is kept alive, preventing crashes"""
@@ -606,33 +586,29 @@ def test_vrt_mem_src_kept_alive(path_rgb_byte_tif):
     with open(path_rgb_byte_tif, "rb") as fp:
         bands = fp.read()
 
-    with MemoryFile(bands) as memfile, memfile.open() as dst:
-        vrt = WarpedVRT(dst, crs="EPSG:3857")
-
-    assert (vrt.read() != 0).any()
-    vrt.close()
-
+    with MemoryFile(bands) as memfile, memfile.open() as dst, WarpedVRT(dst, crs="EPSG:3857") as vrt:
+        assert (vrt.read() != 0).any()
 
 def test_warped_vrt_is_closed(path_rgb_byte_tif):
     """A VirtualVRT should be set as closed on exit."""
-    with rasterio.open(path_rgb_byte_tif) as src:
-        with WarpedVRT(src, crs=DST_CRS) as vrt:
-            assert not vrt.closed
-        assert vrt.closed
+    with rasterio.open(path_rgb_byte_tif) as src, WarpedVRT(src, crs=DST_CRS) as vrt:
+        assert not vrt.closed
+    assert vrt.closed
 
 
 def test_issue2086():
     """Create a WarpedVRT from a dataset with GCPs"""
-    with rasterio.open("tests/data/white-gemini-iv.vrt") as src:
-        with WarpedVRT(src, crs=DST_CRS) as vrt:
-            assert vrt.shape == (1031, 1146)
+    with rasterio.open("tests/data/white-gemini-iv.vrt") as src, WarpedVRT(src, crs=DST_CRS) as vrt:
+        assert vrt.shape == (1031, 1146)
+
 
 
 def test_gauss_no(path_rgb_byte_tif):
     """Guard against the issue reported in #2190"""
     with rasterio.open(path_rgb_byte_tif) as src:
         with pytest.raises(Exception):
-            WarpedVRT(src, resampling=Resampling.gauss)
+            with WarpedVRT(src, resampling=Resampling.gauss):
+                pass
 
 @pytest.mark.parametrize(
     "affine_c_param",
@@ -663,25 +639,23 @@ def test_warpedvrt_gcps__width_height(affine_c_param, tmp_path):
     with rasterio.open(tiffname, mode='w', height=800, width=800, count=3, dtype=numpy.uint8) as source:
         source.gcps = (src_gcps, crs)
 
-    with rasterio.open(tiffname) as src:
-        with WarpedVRT(src, width=10, height=10) as vrt:
-            assert vrt.height == 10
-            assert vrt.width == 10
-            assert vrt.crs == crs
-            assert vrt.dst_transform.almost_equals(
-                affine.Affine(22271.389322449897, 0.0, affine_c_param, 0.0, -20016.05875815117, 2818720.0)
-            )
+    with rasterio.open(tiffname) as src, WarpedVRT(src, width=10, height=10) as vrt:
+        assert vrt.height == 10
+        assert vrt.width == 10
+        assert vrt.crs == crs
+        assert vrt.dst_transform.almost_equals(
+            affine.Affine(22271.389322449897, 0.0, affine_c_param, 0.0, -20016.05875815117, 2818720.0)
+        )
 
 
 def test_warpedvrt_rpcs__width_height():
-    with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src:
-        with WarpedVRT(src, src_crs="EPSG:4326", width=10, height=10) as vrt:
-            assert vrt.height == 10
-            assert vrt.width == 10
-            assert vrt.crs == CRS.from_epsg(4326)
-            assert vrt.dst_transform.almost_equals(
-                affine.Affine(0.008598908695300157, 0.0, -123.48824818566573, 0.0, -0.0041566403046337285, 49.52797830474037)
-            )
+    with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src, WarpedVRT(src, src_crs="EPSG:4326", width=10, height=10) as vrt:
+        assert vrt.height == 10
+        assert vrt.width == 10
+        assert vrt.crs == CRS.from_epsg(4326)
+        assert vrt.dst_transform.almost_equals(
+            affine.Affine(0.008598908695300157, 0.0, -123.48824818566573, 0.0, -0.0041566403046337285, 49.52797830474037)
+        )
 
 
 def test_warpedvrt_dst_alpha():


### PR DESCRIPTION
Continuation of #3444

Addresses:
https://github.com/rasterio/rasterio/actions/runs/20071106104/job/57573146383
```
__________________________ test_warped_vrt_add_alpha ___________________________

dsrec = <function dsrec.<locals>.func at 0x7f5609d53740>
path_rgb_byte_tif = '/home/runner/work/rasterio/rasterio/tests/data/RGB.byte.tif'

    def test_warped_vrt_add_alpha(dsrec, path_rgb_byte_tif):
        """A VirtualVRT has the expected VRT properties."""
        with rasterio.Env() as env:
            with rasterio.open(path_rgb_byte_tif) as src:
                vrt = WarpedVRT(src, crs=DST_CRS, add_alpha=True)
    
                records = dsrec(env)
>               assert len(records) == 1
E               AssertionError: assert 3 == 1
E                +  where 3 = len(['  1 N GTiff       -1 791x718x1 /home/runner/work/rasterio/rasterio/tests/data/RGB2.byte.tif.msk', '  1 N GTiff       -1 791x718x3 /home/runner/work/rasterio/rasterio/tests/data/RGB2.byte.tif', '  2 N GTiff       -1 791x718x3 /home/runner/work/rasterio/rasterio/tests/data/RGB.byte.tif'])

tests/test_warpedvrt.py:71: AssertionError
------------------------------ Captured log call -------------------------------
WARNING  rasterio._env:test_warpedvrt.py:68 CPLE_NotSupported in transformer options does not support option INIT_DEST
________________________________ test_warp_warp ________________________________

dsrec = <function dsrec.<locals>.func at 0x7f5609da56f0>
path_rgb_byte_tif = '/home/runner/work/rasterio/rasterio/tests/data/RGB.byte.tif'

    def test_warp_warp(dsrec, path_rgb_byte_tif):
        """Vincent! :P"""
        with rasterio.Env() as env:
    
            with rasterio.open(path_rgb_byte_tif) as src:
                # We should have one open dataset with a refcount of 1.
                records = dsrec(env)
>               assert len(records) == 1
E               AssertionError: assert 4 == 1
E                +  where 4 = len(['  1 N GTiff       -1 791x718x3 /home/runner/work/rasterio/rasterio/tests/data/RGB.byte.tif', '  1 N GTiff       -1 791x718x1 /home/runner/work/rasterio/rasterio/tests/data/RGB2.byte.tif.msk', '  1 N GTiff       -1 791x718x3 /home/runner/work/rasterio/rasterio/tests/data/RGB2.byte.tif', '  1 N GTiff       -1 791x718x3 /home/runner/work/rasterio/rasterio/tests/data/RGB.byte.tif'])

tests/test_warpedvrt.py:479: AssertionError
______________________________ test_open_datasets ______________________________

capfd = <_pytest.capture.CaptureFixture object at 0x7f5609d56250>
path_rgb_byte_tif = '/home/runner/work/rasterio/rasterio/tests/data/RGB.byte.tif'

    def test_open_datasets(capfd, path_rgb_byte_tif):
        """Number of open datasets is expected"""
        with rasterio.Env() as env:
    
            with rasterio.open(path_rgb_byte_tif) as src:
                env._dump_open_datasets()
                captured = capfd.readouterr()
                assert "1 N GTiff" in captured.err
                assert "1 S GTiff" not in captured.err
    
                with WarpedVRT(src) as vrt:
                    env._dump_open_datasets()
                    captured = capfd.readouterr()
                    assert "2 N GTiff" in captured.err
    
            env._dump_open_datasets()
            captured = capfd.readouterr()
>           assert "1 N GTiff" not in captured.err
E           AssertionError: assert '1 N GTiff' not in 'Open GDAL D...B.byte.tif\n'
E             
E             '1 N GTiff' is contained here:
E               Open GDAL Datasets:
E                 1 N GTiff       -1 791x718x1 /home/runner/work/rasterio/rasterio/tests/data/RGB2.byte.tif.msk
E             ?   +++++++++
E                 1 N GTiff       -1 791x718x3 /home/runner/work/rasterio/rasterio/tests/data/RGB2.byte.tif
E                 1 N GTiff       -1 791x718x3 /home/runner/work/rasterio/rasterio/tests/data/RGB.byte.tif

tests/test_warpedvrt.py:469: AssertionError
```