### PR TITLE
LNT: Sort imports

### DIFF
--- a/ci/get-new-tags.py
+++ b/ci/get-new-tags.py
@@ -1,7 +1,7 @@
-from datetime import datetime, timezone
 import json
 import sys
 import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
 
 _, filename, nhours = sys.argv
 nhours = float(nhours)

--- a/examples/async-rasterio.py
+++ b/examples/async-rasterio.py
@@ -10,9 +10,10 @@ performance.
 import asyncio
 
 import numpy as np
+from rasterio._example import compute
+
 import rasterio
 
-from rasterio._example import compute
 
 def main(infile, outfile, with_threads=False):
 

--- a/examples/decimate.py
+++ b/examples/decimate.py
@@ -2,8 +2,9 @@ import os.path
 import subprocess
 import tempfile
 
-import rasterio
 import rasterio.shutil
+
+import rasterio
 
 with rasterio.Env():
 

--- a/examples/rasterio_polygonize.py
+++ b/examples/rasterio_polygonize.py
@@ -6,9 +6,9 @@ import subprocess
 import sys
 
 import fiona
+
 import rasterio
 from rasterio.features import shapes
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger('rasterio_polygonize')

--- a/examples/rasterize_geometry.py
+++ b/examples/rasterize_geometry.py
@@ -1,10 +1,11 @@
 import logging
-import numpy as np
 import sys
+
+import numpy as np
+
 import rasterio
 from rasterio.features import rasterize
 from rasterio.transform import IDENTITY
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger('rasterize_geometry')

--- a/examples/reproject.py
+++ b/examples/reproject.py
@@ -2,9 +2,10 @@ import os
 import subprocess
 
 import numpy as np
+
 import rasterio
 from rasterio import transform
-from rasterio.warp import reproject, Resampling
+from rasterio.warp import Resampling, reproject
 
 tempdir = '/tmp'
 tiffname = os.path.join(tempdir, 'example.tif')

--- a/examples/sieve.py
+++ b/examples/sieve.py
@@ -5,9 +5,9 @@
 import subprocess
 
 import numpy as np
-import rasterio
-from rasterio.features import sieve, shapes
 
+import rasterio
+from rasterio.features import shapes, sieve
 
 # Register GDAL and OGR drivers.
 with rasterio.Env():

--- a/examples/thread_pool_executor.py
+++ b/examples/thread_pool_executor.py
@@ -12,8 +12,9 @@ import concurrent.futures
 import multiprocessing
 import threading
 
-import rasterio
 from rasterio._example import compute
+
+import rasterio
 
 
 def main(infile, outfile, num_workers=4):

--- a/examples/total.py
+++ b/examples/total.py
@@ -1,7 +1,10 @@
 from __future__ import division
-import numpy as np
-import rasterio
+
 import subprocess
+
+import numpy as np
+
+import rasterio
 
 with rasterio.Env(CPL_DEBUG=True):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ markers = [
 select = [
     "F",  # pyflakes
     "E", "W",  # pycodestyle
+    "I", # isort
 ]
 ignore = [
     "E501",  # Line too long

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -1,12 +1,12 @@
 """Rasterio"""
 
-from collections import namedtuple
-from contextlib import ExitStack
 import glob
 import logging
-from logging import NullHandler
 import os
 import platform
+from collections import namedtuple
+from contextlib import ExitStack
+from logging import NullHandler
 
 # On Windows we must explicitly register the directories that contain
 # the GDAL and supporting DLLs starting with Python 3.8. Presently, we
@@ -22,54 +22,53 @@ if platform.system() == "Windows":
                 if p and glob.glob(os.path.join(p, "gdal*.dll")):
                     os.add_dll_directory(os.path.abspath(p))
 
+# These modules are imported from the Cython extensions, but are also import
+# here to help tools like cx_Freeze find them automatically
+import rasterio._err
+import rasterio._path
+import rasterio.coords
+import rasterio.enums
 from rasterio._base import DatasetBase
 from rasterio._io import Statistics
-from rasterio._vsiopener import _opener_registration
+from rasterio._path import _parse_path, _UnparsedPath
 from rasterio._show_versions import show_versions
 from rasterio._version import gdal_version, get_geos_version, get_proj_version
+from rasterio._vsiopener import _opener_registration
 from rasterio.crs import CRS
 from rasterio.drivers import driver_from_extension, is_blacklisted
 from rasterio.dtypes import (
     bool_,
-    ubyte,
-    sbyte,
-    uint8,
-    int8,
-    uint16,
-    int16,
-    uint32,
-    int32,
-    int64,
-    uint64,
+    check_dtype,
+    complex_,
+    complex_int16,
     float16,
     float32,
     float64,
-    complex_,
-    check_dtype,
-    complex_int16,
+    int8,
+    int16,
+    int32,
+    int64,
+    sbyte,
+    ubyte,
+    uint8,
+    uint16,
+    uint32,
+    uint64,
 )
-from rasterio.env import ensure_env_with_credentials, Env
+from rasterio.env import Env, ensure_env_with_credentials
 from rasterio.errors import (
-    RasterioIOError,
     DriverCapabilityError,
     RasterioDeprecationWarning,
+    RasterioIOError,
 )
 from rasterio.io import (
     DatasetReader,
-    get_writer_for_path,
-    get_writer_for_driver,
     MemoryFile,
+    get_writer_for_driver,
+    get_writer_for_path,
 )
 from rasterio.profiles import default_gtiff_profile
 from rasterio.transform import Affine, guard_transform
-from rasterio._path import _parse_path, _UnparsedPath
-
-# These modules are imported from the Cython extensions, but are also import
-# here to help tools like cx_Freeze find them automatically
-import rasterio._err
-import rasterio.coords
-import rasterio.enums
-import rasterio._path
 
 try:
     from rasterio.io import FilePath

--- a/rasterio/_vendor/click_plugins.py
+++ b/rasterio/_vendor/click_plugins.py
@@ -43,7 +43,6 @@ import traceback
 
 import click
 
-
 __version__ = '2.0'
 
 

--- a/rasterio/_vendor/snuggs.py
+++ b/rasterio/_vendor/snuggs.py
@@ -40,26 +40,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from collections import OrderedDict
 import functools
 import operator
 import re
+from collections import OrderedDict
 from typing import Mapping
 
 from pyparsing import (  # type: ignore
-    Keyword,
-    Word,
-    oneOf,
-    Literal,
-    QuotedString,
-    ParseException,
     Forward,
     Group,
+    Keyword,
+    Literal,
     OneOrMore,
+    ParseException,
     ParseResults,
+    QuotedString,
     Regex,
+    Word,
     ZeroOrMore,
     alphanums,
+    oneOf,
     pyparsing_common,
     replace_with,
 )

--- a/rasterio/abc.py
+++ b/rasterio/abc.py
@@ -1,3 +1,6 @@
 """Abstract base classes."""
 
-from rasterio._vsiopener import FileContainer, MultiByteRangeResourceContainer  # noqa: F401
+from rasterio._vsiopener import (  # noqa: F401
+    FileContainer,
+    MultiByteRangeResourceContainer,
+)

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -2,6 +2,7 @@
 
 from enum import Enum, IntEnum
 
+
 class TransformDirection(IntEnum):
     """Coordinate transform direction
 

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -1,26 +1,26 @@
 """Rasterio's GDAL/AWS environment"""
 
-from functools import wraps, total_ordering
-from inspect import getfullargspec as getargspec
 import logging
 import os
 import re
 import threading
 import warnings
+from functools import total_ordering, wraps
+from inspect import getfullargspec as getargspec
 
 import attr
 
 from rasterio._env import (
+    GDALDataFinder,
     GDALEnv,
+    PROJDataFinder,
     get_gdal_config,
     set_gdal_config,
-    GDALDataFinder,
-    PROJDataFinder,
     set_proj_data_search_path,
 )
 from rasterio._version import gdal_version
 from rasterio.errors import EnvError, GDALVersionError, RasterioDeprecationWarning
-from rasterio.session import Session, DummySession
+from rasterio.session import DummySession, Session
 
 
 class ThreadEnv(threading.local):

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -1,18 +1,21 @@
 """Functions for working with features in a raster dataset."""
 
-from contextlib import ExitStack
 import logging
 import math
 import os
 import warnings
+from contextlib import ExitStack
 
 import numpy as np
 
 import rasterio
-from rasterio import warp
+from rasterio import warp, windows
 from rasterio._base import DatasetBase
-from rasterio._features import _shapes, _sieve, _rasterize, _bounds
+from rasterio._features import _bounds, _rasterize, _shapes, _sieve
 from rasterio.dtypes import (
+    float16,
+    float32,
+    float64,
     int8,
     int16,
     int32,
@@ -21,18 +24,13 @@ from rasterio.dtypes import (
     uint16,
     uint32,
     uint64,
-    float16,
-    float32,
-    float64,
 )
 from rasterio.enums import MergeAlg
-from rasterio.env import ensure_env, _GDAL_AT_LEAST_3_11
-from rasterio.errors import ShapeSkipWarning, RasterioDeprecationWarning
+from rasterio.env import _GDAL_AT_LEAST_3_11, ensure_env
+from rasterio.errors import RasterioDeprecationWarning, ShapeSkipWarning
 from rasterio.io import DatasetWriter
 from rasterio.rio.helpers import coords
-from rasterio.transform import Affine
-from rasterio.transform import IDENTITY, guard_transform
-from rasterio import windows
+from rasterio.transform import IDENTITY, Affine, guard_transform
 
 log = logging.getLogger(__name__)
 

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -2,9 +2,9 @@
 
 from numpy.ma import MaskedArray
 
+from rasterio import dtypes
 from rasterio._fill import _fillnodata
 from rasterio.env import ensure_env
-from rasterio import dtypes
 
 
 @ensure_env

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -6,18 +6,18 @@ Instances of these classes are called dataset objects.
 import logging
 import warnings
 
-from rasterio._base import get_dataset_driver, driver_can_create, driver_can_create_copy
+from rasterio._base import driver_can_create, driver_can_create_copy, get_dataset_driver
 from rasterio._io import (
+    BufferedDatasetWriterBase,
     DatasetReaderBase,
     DatasetWriterBase,
-    BufferedDatasetWriterBase,
     MemoryFileBase,
 )
-from rasterio.windows import WindowMethodsMixin
+from rasterio._path import _UnparsedPath
 from rasterio.env import ensure_env
 from rasterio.errors import RasterioDeprecationWarning
 from rasterio.transform import TransformMethodsMixin
-from rasterio._path import _UnparsedPath
+from rasterio.windows import WindowMethodsMixin
 
 try:
     from rasterio._filepath import FilePathBase

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -8,7 +8,6 @@ import numpy as np
 from rasterio.errors import WindowError
 from rasterio.features import geometry_mask, geometry_window
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/rasterio/path.py
+++ b/rasterio/path.py
@@ -6,9 +6,9 @@ future version.
 
 import warnings
 
+from rasterio._path import _parse_path as parse_path
 from rasterio._path import _ParsedPath as ParsedPath
 from rasterio._path import _UnparsedPath as UnparsedPath
-from rasterio._path import _parse_path as parse_path
 from rasterio._path import _vsi_path as vsi_path
 from rasterio.errors import RasterioDeprecationWarning
 

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -6,8 +6,8 @@ Primarily supports `$ rio insp`.
 """
 
 import builtins
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 
 import numpy as np
 

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -12,7 +12,6 @@ from rasterio.rio import options
 from rasterio.rio.helpers import write_features
 from rasterio.warp import transform_bounds
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -3,15 +3,19 @@ import os
 
 import click
 from cligj import (
-    precision_opt, indent_opt, compact_opt, projection_geographic_opt,
-    projection_mercator_opt, projection_projected_opt,
+    compact_opt,
+    indent_opt,
+    precision_opt,
+    projection_geographic_opt,
+    projection_mercator_opt,
+    projection_projected_opt,
     use_rs_opt,
 )
 
-from .helpers import write_features, to_lower
 from rasterio.rio import options
 from rasterio.warp import transform_bounds
 
+from .helpers import to_lower, write_features
 
 logger = logging.getLogger(__name__)
 

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -1,9 +1,9 @@
 """$ rio calc"""
 
-from collections import OrderedDict, UserDict
-from contextlib import ExitStack
 import math
+from collections import OrderedDict, UserDict
 from collections.abc import Mapping
+from contextlib import ExitStack
 
 import click
 import numpy

--- a/rasterio/rio/clip.py
+++ b/rasterio/rio/clip.py
@@ -4,13 +4,14 @@ import logging
 
 import click
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
+from rasterio import windows
 from rasterio.coords import disjoint_bounds
 from rasterio.crs import CRS
 from rasterio.enums import MaskFlags
-from rasterio import windows
+
+from . import options
+from .helpers import resolve_inout
 
 logger = logging.getLogger(__name__)
 

--- a/rasterio/rio/convert.py
+++ b/rasterio/rio/convert.py
@@ -7,7 +7,7 @@ import rasterio
 from rasterio.enums import MaskFlags
 from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
-from rasterio.windows import subdivide, Window
+from rasterio.windows import Window, subdivide
 
 
 @click.command(short_help="Copy and convert raster dataset.")

--- a/rasterio/rio/create.py
+++ b/rasterio/rio/create.py
@@ -1,8 +1,9 @@
 """The rio create command."""
 
-import click
 import json
 import os
+
+import click
 
 import rasterio
 from rasterio.crs import CRS

--- a/rasterio/rio/edit_info.py
+++ b/rasterio/rio/edit_info.py
@@ -15,7 +15,6 @@ from rasterio.errors import CRSError
 from rasterio.rio import options
 from rasterio.transform import guard_transform
 
-
 # Handlers for info module options.
 
 

--- a/rasterio/rio/gcps.py
+++ b/rasterio/rio/gcps.py
@@ -5,14 +5,18 @@ import json
 
 import click
 from cligj import (
-    compact_opt, use_rs_opt, projection_geographic_opt,
-    projection_projected_opt, precision_opt, indent_opt)
+    compact_opt,
+    indent_opt,
+    precision_opt,
+    projection_geographic_opt,
+    projection_projected_opt,
+    use_rs_opt,
+)
 
 import rasterio
 import rasterio.crs
 from rasterio.rio import options
 from rasterio.warp import transform_geom
-
 
 # Feature collection or feature sequence switch, defaulting to the
 # latter, the opposite of cligj's default.

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -3,8 +3,8 @@
 
 import json
 
-from attr import asdict
 import click
+from attr import asdict
 
 import rasterio
 from rasterio.rio import options

--- a/rasterio/rio/insp.py
+++ b/rasterio/rio/insp.py
@@ -1,16 +1,17 @@
 """Fetch and edit raster dataset metadata from the command line."""
 
 import code
+import collections
 import logging
 import sys
-import collections
 import warnings
 
-import numpy as np
 import click
+import numpy as np
+
+import rasterio
 
 from . import options
-import rasterio
 
 try:
     import matplotlib.pyplot as plt

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -39,8 +39,8 @@ import click
 import cligj
 
 import rasterio
-from rasterio.session import AWSSession
 from rasterio._vendor.click_plugins import with_plugins
+from rasterio.session import AWSSession
 
 
 def configure_logging(verbosity):

--- a/rasterio/rio/mask.py
+++ b/rasterio/rio/mask.py
@@ -3,11 +3,12 @@ import logging
 
 import click
 
-from .helpers import resolve_inout
-from . import options
 import rasterio
 import rasterio.shutil
 from rasterio.mask import mask as mask_tool
+
+from . import options
+from .helpers import resolve_inout
 
 logger = logging.getLogger(__name__)
 

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -6,9 +6,9 @@ import click
 
 from rasterio.enums import Resampling
 from rasterio.errors import RasterioDeprecationWarning
+from rasterio.merge import MERGE_METHODS
 from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
-from rasterio.merge import MERGE_METHODS
 
 
 def deprecated_precision(ctx, param, value):

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -53,22 +53,21 @@ import click
 
 import rasterio
 import rasterio.shutil
+from rasterio._path import _parse_path, _UnparsedPath
 from rasterio.dtypes import (
+    float16,
+    float32,
+    float64,
+    int8,
+    int16,
+    int32,
+    int64,
     ubyte,
     uint8,
     uint16,
     uint32,
     uint64,
-    int8,
-    int16,
-    int32,
-    int64,
-    float16,
-    float32,
-    float64
 )
-from rasterio._path import _parse_path, _UnparsedPath
-
 
 logger = logging.getLogger(__name__)
 

--- a/rasterio/rio/overview.py
+++ b/rasterio/rio/overview.py
@@ -1,13 +1,14 @@
 """Manage overviews of a dataset."""
 
-from functools import reduce
 import operator
+from functools import reduce
 
 import click
 
-from . import options
 import rasterio
 from rasterio.enums import OverviewResampling
+
+from . import options
 
 
 def build_handler(ctx, param, value):

--- a/rasterio/rio/rasterize.py
+++ b/rasterio/rio/rasterize.py
@@ -5,16 +5,15 @@ import json
 import logging
 from math import ceil
 
-from affine import Affine
 import click
+from affine import Affine
 
 import rasterio
-from rasterio.errors import CRSError
+import rasterio.shutil
 from rasterio.coords import disjoint_bounds
+from rasterio.errors import CRSError
 from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
-import rasterio.shutil
-
 
 logger = logging.getLogger(__name__)
 
@@ -118,8 +117,8 @@ def rasterize(
     """
 
     from rasterio.crs import CRS
-    from rasterio.features import rasterize
     from rasterio.features import bounds as calculate_bounds
+    from rasterio.features import rasterize
 
     output, files = resolve_inout(
         files=files, output=output, overwrite=overwrite)

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -6,10 +6,10 @@ import logging
 
 import click
 import cligj
-import rasterio
 
-from rasterio.rio import options
+import rasterio
 from rasterio.features import dataset_features
+from rasterio.rio import options
 from rasterio.rio.helpers import write_features
 
 logger = logging.getLogger(__name__)

--- a/rasterio/rio/stack.py
+++ b/rasterio/rio/stack.py
@@ -1,7 +1,7 @@
 """Raster stack CLI command."""
 
-from itertools import zip_longest
 import logging
+from itertools import zip_longest
 
 import click
 

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -16,8 +16,13 @@ from rasterio.rio.helpers import resolve_inout
 from rasterio.rio.options import _cb_key_val
 from rasterio.transform import Affine, rowcol
 from rasterio.warp import (
-    reproject, Resampling, SUPPORTED_RESAMPLING, transform_bounds,
-    aligned_target, calculate_default_transform as calcdt)
+    SUPPORTED_RESAMPLING,
+    Resampling,
+    aligned_target,
+    reproject,
+    transform_bounds,
+)
+from rasterio.warp import calculate_default_transform as calcdt
 
 logger = logging.getLogger(__name__)
 

--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -1,11 +1,12 @@
 # Workaround for issue #378. A pure Python generator.
 
-import numpy as np
 from itertools import islice
 
+import numpy as np
+
 from rasterio.enums import MaskFlags
-from rasterio.windows import Window
 from rasterio.transform import rowcol
+from rasterio.windows import Window
 
 
 def _transform_xy(dataset, xy):

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 from rasterio._path import _parse_path, _UnparsedPath
 
-
 log = logging.getLogger(__name__)
 
 try:

--- a/rasterio/stack.py
+++ b/rasterio/stack.py
@@ -1,22 +1,22 @@
 """Raster stacking tool."""
 
+import cmath
+import logging
+import math
+import numbers
+import os
+import warnings
 from collections.abc import Iterable
 from contextlib import ExitStack, contextmanager
-import logging
-import os
-import math
-import cmath
-import warnings
-import numbers
 
 import numpy as np
 
 import rasterio
+from rasterio import windows
 from rasterio.coords import disjoint_bounds
 from rasterio.enums import Resampling
 from rasterio.errors import RasterioError, StackError
 from rasterio.io import DatasetWriter
-from rasterio import windows
 from rasterio.transform import Affine
 from rasterio.windows import subdivide
 

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -1,23 +1,23 @@
 """Geospatial transforms"""
 
+import warnings
 from contextlib import ExitStack
 from functools import partial
-import numpy as np
-import warnings
 from numbers import Number
 
+import numpy as np
 from affine import Affine
 
-from rasterio.env import env_ctx_if_needed
 from rasterio._transform import (
-    _transform_from_gcps,
-    RPCTransformerBase,
     GCPTransformerBase,
+    RPCTransformerBase,
+    _transform_from_gcps,
 )
-from rasterio.enums import TransformDirection, TransformMethod
 from rasterio.control import GroundControlPoint
+from rasterio.enums import TransformDirection, TransformMethod
+from rasterio.env import env_ctx_if_needed
+from rasterio.errors import RasterioDeprecationWarning, TransformError
 from rasterio.rpc import RPC
-from rasterio.errors import TransformError, RasterioDeprecationWarning
 
 IDENTITY = Affine.identity()
 GDAL_IDENTITY = IDENTITY.to_gdal()

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -2,10 +2,10 @@
 
 import xml.etree.ElementTree as ET
 
+from rasterio._path import _parse_path
 from rasterio._warp import WarpedVRTReaderBase
 from rasterio.dtypes import _gdal_typename
 from rasterio.enums import MaskFlags, Resampling
-from rasterio._path import _parse_path
 from rasterio.transform import TransformMethodsMixin
 from rasterio.windows import WindowMethodsMixin
 

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -1,26 +1,26 @@
 """Raster warping and reprojection."""
 
-from math import ceil, floor
 import warnings
+from math import ceil, floor
 
-from affine import Affine
 import numpy as np
+from affine import Affine
 
 import rasterio
-
 from rasterio._base import _transform
-from rasterio.crs import CRS
-from rasterio.enums import Resampling
-from rasterio.env import ensure_env
-from rasterio.errors import TransformError, RPCError, RasterioDeprecationWarning
-from rasterio.transform import array_bounds
 from rasterio._warp import (
+    SUPPORTED_RESAMPLING,
     _calculate_default_transform,
     _reproject,
     _transform_bounds,
     _transform_geom,
-    SUPPORTED_RESAMPLING,
 )
+from rasterio.crs import CRS
+from rasterio.enums import Resampling
+from rasterio.env import ensure_env
+from rasterio.errors import RasterioDeprecationWarning, RPCError, TransformError
+from rasterio.transform import array_bounds
+
 
 @ensure_env
 def transform(src_crs, dst_crs, xs, ys, zs=None):

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -18,17 +18,17 @@ require instances of Window to be used.
 """
 
 import collections
-from collections.abc import Iterable
 import functools
 import math
 import warnings
+from collections.abc import Iterable
 
-from affine import Affine
 import attr
 import numpy as np
+from affine import Affine
 
-from rasterio.errors import WindowError, RasterioDeprecationWarning
-from rasterio.transform import rowcol, guard_transform
+from rasterio.errors import RasterioDeprecationWarning, WindowError
+from rasterio.transform import guard_transform, rowcol
 
 
 class WindowMethodsMixin:

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ import platform
 import pprint
 import re
 import shutil
-from subprocess import check_output
 import sys
+from subprocess import check_output
 
 from setuptools import setup
 from setuptools.extension import Extension

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,15 +12,15 @@ import affine
 import boto3
 import numpy as np
 import pytest
+from affine import Affine
 from click.testing import CliRunner
+from rasterio.crs import CRS
 
 import rasterio
 import rasterio.env
 from rasterio.coords import BoundingBox
-from rasterio.crs import CRS
 from rasterio.enums import ColorInterp
 from rasterio.env import GDALVersion
-from affine import Affine
 
 DEFAULT_SHAPE = (10, 10)
 

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -1,12 +1,11 @@
 """Tests of _env util module"""
 
 import pytest
-
 from rasterio._env import (
     GDALDataFinder,
     PROJDataFinder,
-    get_proj_data_search_paths,
     get_gdal_data,
+    get_proj_data_search_paths,
 )
 
 from .conftest import gdal_version

--- a/tests/test__version.py
+++ b/tests/test__version.py
@@ -1,5 +1,4 @@
 import pytest
-
 from rasterio._version import get_gdal_version_info, get_geos_version, get_proj_version
 
 

--- a/tests/test_band.py
+++ b/tests/test_band.py
@@ -3,7 +3,6 @@ import logging
 import rasterio
 import rasterio.env
 
-
 logging.basicConfig(level=logging.DEBUG)
 
 def test_band():

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,9 +1,9 @@
-from functools import partial
 import os.path
 import shutil
 import subprocess
 import tempfile
 import unittest
+from functools import partial
 
 import numpy as np
 import pytest

--- a/tests/test_boundless_read.py
+++ b/tests/test_boundless_read.py
@@ -1,12 +1,13 @@
 """Test of boundless reads"""
 
-from affine import Affine
 import shutil
-from hypothesis import example, given
+
 import hypothesis.strategies as st
 import numpy
-from numpy.testing import assert_almost_equal
 import pytest
+from affine import Affine
+from hypothesis import example, given
+from numpy.testing import assert_almost_equal
 
 import rasterio
 from rasterio.io import MemoryFile

--- a/tests/test_colorinterp.py
+++ b/tests/test_colorinterp.py
@@ -8,6 +8,7 @@ from rasterio.env import GDALVersion
 
 from .conftest import gdal_version
 
+
 def test_cmyk_interp(tmpdir):
     """A CMYK TIFF has cyan, magenta, yellow, black bands."""
     with rasterio.open('tests/data/RGB.byte.tif') as src:

--- a/tests/test_complex_dtypes.py
+++ b/tests/test_complex_dtypes.py
@@ -35,6 +35,7 @@ def test_read_array(tempfile, dtype, height, width):
 def test_complex_nodata(tmpdir):
     """A complex dataset can be created with a real nodata value"""
     import numpy as np
+
     import rasterio
     from rasterio.transform import Affine
 
@@ -58,6 +59,7 @@ def test_complex_nodata(tmpdir):
 def test_complex_int16(tmpdir):
     """A cint16 dataset can be created"""
     import numpy as np
+
     import rasterio
     from rasterio.transform import Affine
 

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -7,12 +7,12 @@ import pickle
 import subprocess
 
 import pytest
-
-import rasterio
 from rasterio._base import _can_create_osr
 from rasterio.crs import CRS, epsg_treats_as_latlong, epsg_treats_as_northingeasting
+
+import rasterio
 from rasterio.enums import WktVersion
-from rasterio.env import env_ctx_if_needed, Env
+from rasterio.env import Env, env_ctx_if_needed
 from rasterio.errors import CRSError
 
 # Items like "D_North_American_1983" characterize the Esri dialect

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -1,14 +1,13 @@
 """Dataset mask test."""
 
-from affine import Affine
 import numpy as np
 import pytest
+from affine import Affine
+from rasterio.crs import CRS
 
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.errors import NodataShadowWarning
-from rasterio.crs import CRS
-
 
 # Setup test arrays
 red = np.array([[0, 0, 0],

--- a/tests/test_driver_management.py
+++ b/tests/test_driver_management.py
@@ -1,7 +1,8 @@
 import logging
 
-import rasterio
 from rasterio._env import driver_count
+
+import rasterio
 
 
 def test_drivers():

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -3,31 +3,31 @@ import pytest
 
 import rasterio
 from rasterio import (
+    complex_,
+    complex_int16,
+    float16,
+    float32,
+    float64,
+    int8,
+    int16,
+    int32,
+    int64,
     ubyte,
     uint8,
     uint16,
     uint32,
     uint64,
-    int8,
-    int16,
-    int32,
-    int64,
-    float16,
-    float32,
-    float64,
-    complex_,
-    complex_int16,
 )
 from rasterio.dtypes import (
     _gdal_typename,
-    is_ndarray,
+    _get_gdal_dtype,
+    _getnpdtype,
+    _is_complex_int,
+    can_cast_dtype,
     check_dtype,
     get_minimum_dtype,
-    can_cast_dtype,
+    is_ndarray,
     validate_dtype,
-    _is_complex_int,
-    _getnpdtype,
-    _get_gdal_dtype,
 )
 from tests.conftest import gdal_version, requires_gdal3_11
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -8,18 +8,32 @@ from unittest import mock
 
 import boto3
 import pytest
+from rasterio._env import del_gdal_config, get_gdal_config, set_gdal_config
 
 import rasterio
 from rasterio import _env
-from rasterio._env import del_gdal_config, get_gdal_config, set_gdal_config
-from rasterio.env import Env, defenv, delenv, getenv, setenv, ensure_env, ensure_env_credentialled
-from rasterio.env import GDALVersion, require_gdal_version
+from rasterio.env import (
+    Env,
+    GDALVersion,
+    defenv,
+    delenv,
+    ensure_env,
+    ensure_env_credentialled,
+    getenv,
+    require_gdal_version,
+    setenv,
+)
 from rasterio.errors import EnvError, GDALVersionError
 from rasterio.rio.main import main_group
-from rasterio.session import AWSSession, DummySession, OSSSession, SwiftSession, AzureSession
+from rasterio.session import (
+    AWSSession,
+    AzureSession,
+    DummySession,
+    OSSSession,
+    SwiftSession,
+)
 
 from .conftest import credentials
-
 
 L8TIF = "s3://sentinel-cogs/sentinel-s2-l2a-cogs/45/C/VQ/2022/11/S2B_45CVQ_20221102_0_L2A/B01.tif"
 L8TIFB2 = "s3://sentinel-cogs/sentinel-s2-l2a-cogs/45/C/VQ/2022/11/S2B_45CVQ_20221102_0_L2A/B02.tif"

--- a/tests/test_err.py
+++ b/tests/test_err.py
@@ -1,10 +1,11 @@
 """Testing related to GDAL CPLError handling."""
 
 import logging
+
 import pytest
+from rasterio._err import CPLE_BaseError
 
 import rasterio
-from rasterio._err import CPLE_BaseError
 from rasterio.errors import RasterioIOError
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,20 +1,32 @@
-from copy import deepcopy
 import math
+from copy import deepcopy
 from unittest import mock
 
-from affine import Affine
 import numpy as np
 import pytest
+from affine import Affine
 from numpy.testing import assert_allclose
 
 import rasterio
 from rasterio.enums import MergeAlg
-from rasterio.errors import WindowError, ShapeSkipWarning
+from rasterio.errors import ShapeSkipWarning, WindowError
 from rasterio.features import (
-    bounds, geometry_mask, geometry_window, is_valid_geom, rasterize, sieve,
-    shapes)
+    bounds,
+    geometry_mask,
+    geometry_window,
+    is_valid_geom,
+    rasterize,
+    shapes,
+    sieve,
+)
 
-from .conftest import MockGeoInterface, requires_gdal3_11, requires_gdal_lt_3_11, requires_gdal3_12_1, requires_gdal_lt_3_12_1
+from .conftest import (
+    MockGeoInterface,
+    requires_gdal3_11,
+    requires_gdal3_12_1,
+    requires_gdal_lt_3_11,
+    requires_gdal_lt_3_12_1,
+)
 
 DEFAULT_SHAPE = (10, 10)
 

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -3,15 +3,15 @@ Tests in this file will ONLY run for GDAL >= 3.x"""
 
 # TODO: delete at version 2.0. FilePath is deprecated in version 1.4.
 
-from io import BytesIO
 import logging
 import os.path
+from io import BytesIO
 
 import pytest
+from rasterio.shutil import copyfiles
 
 import rasterio
 from rasterio.enums import MaskFlags
-from rasterio.shutil import copyfiles
 from rasterio.windows import Window
 
 try:

--- a/tests/test_gdal_raster_io.py
+++ b/tests/test_gdal_raster_io.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 import rasterio
-
 from tests.conftest import gdal_version
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -6,9 +6,8 @@ import numpy as np
 import pytest
 
 import rasterio
-from rasterio.errors import WindowError
 from rasterio import windows
-
+from rasterio.errors import WindowError
 
 DATA_WINDOW = ((3, 5), (2, 6))
 
@@ -202,7 +201,7 @@ def test_3x3matrix():
 
       None of them should intersect or have an intersection
     """
-    from itertools import product, combinations
+    from itertools import combinations, product
 
     pairs = ((0, 2), (2, 4), (4, 6))
     arrangement = product(pairs, pairs)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,6 @@ import pytest
 
 from rasterio.io import DatasetReader, DatasetWriter
 
-
 httpstif = (
     "https://github.com/rasterio/rasterio/blob/main/tests/data/float32.tif?raw=true"
 )

--- a/tests/test_io_mixins.py
+++ b/tests/test_io_mixins.py
@@ -1,9 +1,8 @@
-from affine import Affine
 import pytest
+from affine import Affine
 
 import rasterio
 from rasterio.windows import Window, WindowMethodsMixin
-
 
 EPS = 1.0e-8
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -3,7 +3,7 @@ import pytest
 from affine import Affine
 
 import rasterio
-from rasterio.mask import raster_geometry_mask, mask
+from rasterio.mask import mask, raster_geometry_mask
 
 from .conftest import MockGeoInterface
 

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -1,18 +1,18 @@
 """MemoryFile tests.  MemoryFile requires GDAL 2.0+.
 Tests in this file will ONLY run for GDAL >= 2.x"""
 
-from io import BytesIO
 import os.path
+from io import BytesIO
 from pathlib import Path
 
-from affine import Affine
 import numpy
 import pytest
+from affine import Affine
+from rasterio.shutil import copyfiles
 
 import rasterio
-from rasterio.io import MemoryFile, ZipMemoryFile
 from rasterio.enums import MaskFlags
-from rasterio.shutil import copyfiles
+from rasterio.io import MemoryFile, ZipMemoryFile
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,20 +1,21 @@
 """Tests of rasterio.merge"""
 
-import boto3
-from hypothesis import given, settings
-from hypothesis.strategies import floats
-import numpy
-import pytest
 import warnings
 
 import affine
-import rasterio
-from rasterio.merge import merge
+import boto3
+import numpy
+import pytest
+from hypothesis import given, settings
+from hypothesis.strategies import floats
 from rasterio.crs import CRS
+
+import rasterio
+from rasterio import windows
 from rasterio.errors import MergeError, RasterioError
+from rasterio.merge import merge
 from rasterio.vrt import WarpedVRT
 from rasterio.warp import aligned_target
-from rasterio import windows
 
 from .conftest import gdal_version
 
@@ -152,9 +153,10 @@ def test_unsafe_casting():
 )
 def test_issue2202(dx, dy):
     shapely = pytest.importorskip("shapely", reason="Test requires shapely.")
-    import rasterio.merge
     from shapely import wkt
     from shapely.affinity import translate
+
+    import rasterio.merge
 
     aoi = wkt.loads(
         r"POLYGON((11.09 47.94, 11.06 48.01, 11.12 48.11, 11.18 48.11, 11.18 47.94, 11.09 47.94))"

--- a/tests/test_nodata.py
+++ b/tests/test_nodata.py
@@ -1,10 +1,10 @@
 import logging
-import pytest
 import re
 import subprocess
 import sys
 
 import numpy
+import pytest
 
 import rasterio
 from rasterio.io import MemoryFile

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,6 +1,8 @@
-import pytest
-import rasterio
 from pathlib import Path
+
+import pytest
+
+import rasterio
 
 
 def test_open_bad_path():

--- a/tests/test_open_options.py
+++ b/tests/test_open_options.py
@@ -5,6 +5,7 @@ import pytest
 import rasterio
 from rasterio.transform import Affine
 
+
 def test_fail_with_missing_driver():
     """Fail to open a GeoTIFF without the GTiff driver"""
     with pytest.raises(rasterio.errors.RasterioIOError):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,5 +1,6 @@
 import click
 import pytest
+
 from rasterio.rio import options
 
 

--- a/tests/test_overviews.py
+++ b/tests/test_overviews.py
@@ -4,8 +4,7 @@ import numpy as np
 import pytest
 
 import rasterio
-from rasterio.enums import OverviewResampling
-from rasterio.enums import Resampling
+from rasterio.enums import OverviewResampling, Resampling
 from rasterio.errors import OverviewCreationError
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -5,8 +5,8 @@ import sys
 import pytest
 
 import rasterio
+from rasterio._path import _parse_path, _ParsedPath, _UnparsedPath, _vsi_path
 from rasterio.errors import PathError
-from rasterio._path import _parse_path, _vsi_path, _ParsedPath, _UnparsedPath
 
 
 def test_parsed_path_name():

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -8,9 +8,8 @@ import matplotlib
 import numpy as np
 
 import rasterio
-from rasterio.plot import show, show_hist, get_plt, plotting_extent, adjust_band
 from rasterio.enums import ColorInterp
-
+from rasterio.plot import adjust_band, get_plt, plotting_extent, show, show_hist
 
 matplotlib.use("agg")
 plt.show = lambda: None

--- a/tests/test_png.py
+++ b/tests/test_png.py
@@ -1,8 +1,10 @@
 import logging
-import pytest
 import subprocess
 import sys
+
 import numpy as np
+import pytest
+
 import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -5,8 +5,7 @@ import pickle
 import pytest
 
 import rasterio
-from rasterio.profiles import Profile, DefaultGTiffProfile
-from rasterio.profiles import default_gtiff_profile
+from rasterio.profiles import DefaultGTiffProfile, Profile, default_gtiff_profile
 
 
 def test_base_profile():

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -3,14 +3,14 @@
 import io
 import os
 import warnings
+import zipfile
 from pathlib import Path
 from threading import Thread
-import zipfile
 
-from affine import Affine
 import fsspec
 import numpy as np
 import pytest
+from affine import Affine
 
 import rasterio
 from rasterio.enums import MaskFlags

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,11 +1,11 @@
-from hashlib import md5
 import unittest
+from hashlib import md5
 
 import numpy as np
 import pytest
+from rasterio._err import CPLE_AppDefinedError
 
 import rasterio
-from rasterio._err import CPLE_AppDefinedError
 from rasterio.errors import DatasetIOShapeError, RasterioIOError
 
 # Find out if we've got HDF support (needed below).

--- a/tests/test_reshape_image.py
+++ b/tests/test_reshape_image.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from rasterio import plot
 import rasterio
+from rasterio import plot
 
 try:
     import matplotlib as mpl

--- a/tests/test_rio_blocks.py
+++ b/tests/test_rio_blocks.py
@@ -1,14 +1,14 @@
 """Unittests for $ rio blocks"""
 
-from itertools import zip_longest
 import json
 import re
+from itertools import zip_longest
 
 import numpy as np
 
 import rasterio
-from rasterio.warp import transform_bounds
 from rasterio.rio.main import main_group
+from rasterio.warp import transform_bounds
 
 
 def check_features_block_windows(features, src, bidx):

--- a/tests/test_rio_clip.py
+++ b/tests/test_rio_clip.py
@@ -4,8 +4,9 @@ import numpy
 import pytest
 
 import rasterio
-from rasterio.rio.main import main_group
 from rasterio import windows
+from rasterio.rio.main import main_group
+
 TEST_BBOX = [-11850000, 4804000, -11840000, 4808000]
 
 

--- a/tests/test_rio_convert.py
+++ b/tests/test_rio_convert.py
@@ -3,7 +3,6 @@ import pytest
 import rasterio
 from rasterio.rio.main import main_group
 
-
 # Tests: format and type conversion, --format and --dtype
 
 

--- a/tests/test_rio_create.py
+++ b/tests/test_rio_create.py
@@ -1,7 +1,8 @@
 """Tests of rio create."""
 
-import rasterio
 from rasterio.crs import CRS
+
+import rasterio
 from rasterio.io import MemoryFile
 from rasterio.rio.main import main_group
 

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -6,20 +6,19 @@ import json
 import click
 import numpy
 import pytest
+import rasterio.shutil
 
 import rasterio
 from rasterio import CRS
 from rasterio.enums import ColorInterp
 from rasterio.rio.edit_info import (
     all_handler,
+    colorinterp_handler,
     crs_handler,
     tags_handler,
     transform_handler,
-    colorinterp_handler,
 )
 from rasterio.rio.main import main_group
-import rasterio.shutil
-
 
 PARAM_HANDLER = {
     'crs': crs_handler,

--- a/tests/test_rio_gcp.py
+++ b/tests/test_rio_gcp.py
@@ -3,7 +3,6 @@ import sys
 
 from rasterio.rio.main import main_group
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -7,7 +7,6 @@ from rasterio.rio.main import main_group
 
 from .conftest import credentials
 
-
 with rasterio.Env() as env:
     HAVE_NETCDF = "netCDF" in env.drivers().keys()
 

--- a/tests/test_rio_insp.py
+++ b/tests/test_rio_insp.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 
 import rasterio
-from rasterio.rio.main import main_group
 from rasterio.rio.insp import stats
+from rasterio.rio.main import main_group
 
 
 def test_insp(runner):

--- a/tests/test_rio_main.py
+++ b/tests/test_rio_main.py
@@ -5,7 +5,6 @@ from packaging.version import parse
 
 from rasterio.rio.main import main_group
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -1,19 +1,19 @@
 """Unittests for $ rio merge"""
 
-from io import StringIO
 import os
 import textwrap
+from io import StringIO
 from pathlib import Path
 
 import affine
-from click.testing import CliRunner
 import numpy as np
-from pytest import fixture
 import pytest
+from click.testing import CliRunner
+from pytest import fixture
 
 import rasterio
 from rasterio.enums import Resampling
-from rasterio.merge import merge, MERGE_METHODS
+from rasterio.merge import MERGE_METHODS, merge
 from rasterio.rio.main import main_group
 from rasterio.transform import Affine
 

--- a/tests/test_rio_options.py
+++ b/tests/test_rio_options.py
@@ -9,12 +9,12 @@ import pytest
 
 from rasterio.enums import ColorInterp
 from rasterio.rio.options import (
+    _cb_key_val,
     bounds_handler,
+    edit_nodata_handler,
     file_in_handler,
     like_handler,
-    edit_nodata_handler,
     nodata_handler,
-    _cb_key_val,
 )
 
 

--- a/tests/test_rio_overview.py
+++ b/tests/test_rio_overview.py
@@ -6,7 +6,6 @@ import pytest
 from rasterio.rio.main import main_group as cli
 from rasterio.rio.overview import get_maximum_overview_level
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_rio_rasterize.py
+++ b/tests/test_rio_rasterize.py
@@ -9,7 +9,6 @@ import numpy as np
 import rasterio
 from rasterio.rio.main import main_group
 
-
 DEFAULT_SHAPE = (10, 10)
 
 

--- a/tests/test_rio_rm.py
+++ b/tests/test_rio_rm.py
@@ -2,9 +2,9 @@
 
 
 import pytest
+import rasterio.shutil
 
 import rasterio
-import rasterio.shutil
 from rasterio.rio.main import main_group
 
 

--- a/tests/test_rio_sample.py
+++ b/tests/test_rio_sample.py
@@ -3,7 +3,6 @@ import sys
 
 from rasterio.rio.main import main_group
 
-
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 

--- a/tests/test_rio_shapes.py
+++ b/tests/test_rio_shapes.py
@@ -10,7 +10,6 @@ import pytest
 import rasterio
 from rasterio.rio.main import main_group
 
-
 DEFAULT_SHAPE = (10, 10)
 
 

--- a/tests/test_rio_warp.py
+++ b/tests/test_rio_warp.py
@@ -8,9 +8,9 @@ import numpy as np
 import pytest
 
 import rasterio
-from rasterio.warp import SUPPORTED_RESAMPLING
 from rasterio.rio import warp
 from rasterio.rio.main import main_group
+from rasterio.warp import SUPPORTED_RESAMPLING
 
 
 def test_dst_crs_error(runner, tmpdir):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,13 +5,13 @@ from unittest import mock
 import pytest
 
 from rasterio.session import (
-    DummySession,
     AWSSession,
-    Session,
-    OSSSession,
-    GSSession,
-    SwiftSession,
     AzureSession,
+    DummySession,
+    GSSession,
+    OSSSession,
+    Session,
+    SwiftSession,
     parse_bool,
 )
 

--- a/tests/test_shutil.py
+++ b/tests/test_shutil.py
@@ -1,15 +1,15 @@
 """Tests for ``rasterio.shutil```."""
 
 
-from contextlib import ExitStack
 import os
+from contextlib import ExitStack
 
 import numpy
 import pytest
-
-import rasterio
 import rasterio.shutil
 from rasterio._err import CPLE_NotSupportedError
+
+import rasterio
 from rasterio.errors import DriverRegistrationError, RasterioIOError
 
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,11 +1,11 @@
 """Test of a dataset's statistics method."""
 
-from numpy.testing import assert_almost_equal
 import pytest
+from numpy.testing import assert_almost_equal
 
 import rasterio
 from rasterio import Statistics
-from rasterio.errors import RasterioError, RasterioDeprecationWarning
+from rasterio.errors import RasterioDeprecationWarning, RasterioError
 
 
 def test_statistics(path_rgb_byte_tif):

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 import pytest
+
 import rasterio
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,6 +1,6 @@
-from threading import Thread
 import time
 import unittest
+from threading import Thread
 
 import rasterio as rio
 from rasterio.env import get_gdal_config

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,7 +1,7 @@
 from functools import partial
 
-from rasterio.features import dataset_features
 from rasterio import tools
+from rasterio.features import dataset_features
 
 
 def test_dataset_features_tool(tmpdir, path_rgb_byte_tif):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -9,9 +9,9 @@ import pytest
 from affine import Affine
 
 import rasterio
+from rasterio import transform
 from rasterio.control import GroundControlPoint
 from rasterio.errors import TransformError
-from rasterio import transform
 from rasterio.transform import (
     AffineTransformer,
     GCPTransformer,

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,7 +1,8 @@
+import pytest
+from affine import Affine
+
 import rasterio
 from rasterio.errors import NodataShadowWarning, NotGeoreferencedWarning
-from affine import Affine
-import pytest
 
 
 def gen_rpcs():

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -5,33 +5,33 @@ import os
 import re
 import sys
 
-from affine import Affine
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pytest
+from affine import Affine
+from numpy.testing import assert_almost_equal
+from rasterio._err import CPLE_AppDefinedError
+from rasterio.crs import CRS
 
 import rasterio
-from rasterio._err import CPLE_AppDefinedError
+from rasterio import windows
 from rasterio.control import GroundControlPoint
-from rasterio.crs import CRS
 from rasterio.enums import Resampling
 from rasterio.errors import (
     CRSError,
     RasterioDeprecationWarning,
-    TransformError,
     RPCError,
+    TransformError,
     WarpOperationError,
 )
 from rasterio.warp import (
+    SUPPORTED_RESAMPLING,
+    aligned_target,
+    calculate_default_transform,
     reproject,
-    transform_geom,
     transform,
     transform_bounds,
-    calculate_default_transform,
-    aligned_target,
-    SUPPORTED_RESAMPLING,
+    transform_geom,
 )
-from rasterio import windows
 
 from . import rangehttpserver
 
@@ -2282,8 +2282,8 @@ def test_reproject_rpcs_approx_transformer(caplog):
 def http_error_server(data):
     """Serves files from the test data directory, poorly."""
     import functools
-    import multiprocessing
     import http.server
+    import multiprocessing
 
     Handler = functools.partial(RangeRequestErrorHandler, directory=str(data))
     httpd = http.server.HTTPServer(("", 0), Handler)

--- a/tests/test_warp_transform.py
+++ b/tests/test_warp_transform.py
@@ -1,17 +1,17 @@
 """Tests of the warp module's coordinate transformation features."""
 
-import os
 import logging
+import os
 
 import numpy
 import pytest
 from numpy.testing import assert_almost_equal
+from rasterio._err import CPLE_AppDefinedError, CPLE_BaseError
+from rasterio._warp import _calculate_default_transform
+from rasterio.crs import CRS
 
 import rasterio
-from rasterio._err import CPLE_BaseError, CPLE_AppDefinedError
-from rasterio._warp import _calculate_default_transform
 from rasterio.control import GroundControlPoint
-from rasterio.crs import CRS
 from rasterio.errors import CRSError
 from rasterio.transform import from_bounds
 from rasterio.warp import calculate_default_transform, transform_bounds

--- a/tests/test_warpedvrt.py
+++ b/tests/test_warpedvrt.py
@@ -6,19 +6,19 @@ import shutil
 import affine
 import numpy
 import pytest
+from rasterio.crs import CRS
 
 import rasterio
+from rasterio import shutil as rio_shutil
 from rasterio.control import GroundControlPoint
-from rasterio.crs import CRS
-from rasterio.enums import Resampling, MaskFlags
+from rasterio.enums import MaskFlags, Resampling
 from rasterio.errors import WarpOptionsError
 from rasterio.io import MemoryFile
-from rasterio import shutil as rio_shutil
 from rasterio.vrt import WarpedVRT
 from rasterio.warp import transform_bounds
 from rasterio.windows import Window
 
-from .conftest import gdal_version, credentials
+from .conftest import credentials, gdal_version
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -5,16 +5,28 @@ import sys
 import numpy as np
 import pytest
 from affine import Affine
-from hypothesis import given, assume, settings, HealthCheck
+from hypothesis import HealthCheck, assume, given, settings
 from hypothesis.strategies import floats, integers
 
 import rasterio
-from rasterio.transform import from_origin
 from rasterio.errors import WindowError
+from rasterio.transform import from_origin
 from rasterio.windows import (
-    crop, from_bounds, bounds, transform, evaluate, window_index, shape,
-    Window, intersect, intersection, get_data_window, union,
-    round_window_to_full_blocks, subdivide)
+    Window,
+    bounds,
+    crop,
+    evaluate,
+    from_bounds,
+    get_data_window,
+    intersect,
+    intersection,
+    round_window_to_full_blocks,
+    shape,
+    subdivide,
+    transform,
+    union,
+    window_index,
+)
 
 EPS = 1.0e-8
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,7 +1,7 @@
 import logging
 import re
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
 import affine
 import numpy as np
@@ -12,6 +12,7 @@ from rasterio.drivers import blacklist
 from rasterio.enums import MaskFlags, Resampling
 from rasterio.env import Env
 from rasterio.errors import RasterioIOError
+
 
 def test_validate_dtype_None(tmpdir):
     """Raise TypeError if there is no dtype"""


### PR DESCRIPTION
Related: https://github.com/rasterio/rasterio/issues/1965

Enabled import sorting with ruff. Continuation of (https://github.com/rasterio/rasterio/pull/3457).

@sgillies, you have had hesitations about this in the past, So, won't move forward unless you are okay with it.