### PR TITLE
Drop click-plugins dependency from pyproject.toml & update doc link.

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -711,7 +711,7 @@ information on how to build these plugins in general.
 
 To use these plugins with rio, add the commands to the
 ``rasterio.rio_plugins`` entry point in your ``setup.py`` file, as described
-`here <https://github.com/click-contrib/click-plugins#developing-plugins>`__
+`here <https://github.com/click-contrib/click-plugins/blob/main/click_plugins.rst#i-am-a-plugin-author>`__
 and in ``rasterio/rio/main.py``.
 
 See the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "certifi",
     # Avoid https://github.com/pallets/click/issues/2939
     "click>=4.0,!=8.2.*",
-    "click-plugins",
     "cligj>=0.5",
     "numpy>=2",
     "pyparsing",


### PR DESCRIPTION
1.5rc0 reintroduced the click-plugins dependency with the move from setup.cfg/requirements.txt to pyproject.toml, this has been removed again.

The documentation also contained a broken link after upstream reworked their README.md.