### PR TITLE
BUG: Fix type of flags parameter to GDALOpenEx

### DIFF
--- a/rasterio/_base.pxd
+++ b/rasterio/_base.pxd
@@ -33,4 +33,4 @@ cdef class DatasetBase:
 cdef const char *get_driver_name(GDALDriverH driver)
 
 cdef void osr_set_traditional_axis_mapping_strategy(OGRSpatialReferenceH hSrs)
-cdef GDALDatasetH open_dataset(object filename, int flags, object allowed_drivers, object open_options, bint sharing, object siblings) except NULL
+cdef GDALDatasetH open_dataset(object filename, unsigned int flags, object allowed_drivers, object open_options, bint sharing, object siblings) except NULL

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -181,7 +181,7 @@ cdef _band_dtype(GDALRasterBandH band):
 
 cdef GDALDatasetH open_dataset(
     object filename,
-    int flags,
+    unsigned int flags,
     object allowed_drivers,
     object open_options,
     bint sharing,
@@ -301,7 +301,7 @@ cdef class DatasetBase:
         dataset
         """
         self._hds = NULL
-        cdef flags = GDAL_OF_READONLY
+        cdef unsigned int flags = GDAL_OF_READONLY
         if thread_safe:
             if not _GDAL_AT_LEAST_3_10:
                 raise GDALOptionNotImplementedError("'thread_safe' option requires GDAL 3.10+.")

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -363,7 +363,7 @@ cdef extern from "gdal.h" nogil:
     void GDALSetDescription(GDALMajorObjectH obj, const char *text)
     GDALDriverH GDALGetDriverByName(const char *name)
     GDALDatasetH GDALOpen(const char *filename, GDALAccess access) # except -1
-    GDALDatasetH GDALOpenEx(const char *filename, int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
+    GDALDatasetH GDALOpenEx(const char *filename, unsigned int flags, const char **allowed_drivers, const char **options, const char **siblings) # except -1
     GDALDatasetH GDALOpenShared(const char *filename, GDALAccess access) # except -1
     void GDALFlushCache(GDALDatasetH hds)
     void GDALClose(GDALDatasetH hds)


### PR DESCRIPTION
The `flags` parameter is `unsigned int`, not `int`: https://gdal.org/en/stable/api/raster_c_api.html#gdal_8h_1a9cb8585d0b3c16726b08e25bcc94274a

Also, in `DatasetBase.__init__`, add the type to the `cdef` for `flags`, which was previously going through unnecessary C-to-Python conversion for every operation and Python-to-C conversion in the `open_dataset` call.

This is just something I noticed while investigating #3499, but it does not fix it.