### PR TITLE
CI: Add s3fs to test requirements

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -217,7 +217,7 @@ jobs:
       - name: Install dependencies and rasterio wheel
         shell: bash
         run: |
-          python -m pip install numpy aiohttp attrs pytest click mock boto3 packaging hypothesis fsspec requests
+          python -m pip install numpy aiohttp attrs pytest click mock boto3 packaging hypothesis fsspec s3fs requests
           python -m pip install --pre --no-deps --no-index --find-links dist rasterio
           python -m pip install rasterio
           python -m pip list


### PR DESCRIPTION
Still need to specify test requirements separately. Testing wheels with `requirements-dev.txt` is failing. Shapely wheels for Windows ARM are currently unavailable (expected in the next release)