### PR TITLE
DOC: enable pydocstyle checks (via ruff check) and associated fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.8
+    rev: v0.15.8
     hooks:
       # Run the linter
       - id: ruff-check

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -56,7 +56,6 @@ clean:
 .PHONY: html
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,12 @@ docstring-code-format = true
 select = [
     "F",  # pyflakes
     "E", "W",  # pycodestyle
+    "D",  # pydocstyle
 ]
 ignore = [
+    "D400",  # First line should end with a period
+    "D401",  # First line of docstring should be in imperative mood
+    "D105",  # Missing docstring in magic method
     "E501",  # Line too long
     "E722",  # Do not use bare `except`
     "E741",  # Ambiguous variable name
@@ -144,6 +148,14 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"ci/*" = ["D"]
+"docs/*" = ["D"]
+"examples/*" = ["D"]
+"benchmarks/*" = ["D"]
+"rasterio/_vendor/*" = ["ALL"]
 "rasterio/__init__.py" = ["F401"]
 "rasterio/path.py" = ["F401"]
-"**/tests/*" = ["E402"]
+"**/tests/*" = ["D", "E402"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -456,7 +456,7 @@ def band(ds, bidx):
 
 
 def pad(array, transform, pad_width, mode=None, **kwargs):
-    """pad array and adjust affine transform matrix.
+    """Pad array and adjust affine transform matrix.
 
     Parameters
     ----------

--- a/rasterio/drivers.py
+++ b/rasterio/drivers.py
@@ -27,10 +27,11 @@ blacklist = {
 @ensure_env
 def raster_driver_extensions():
     """
+    Map of extensions to the driver.
+
     Returns
     -------
-    dict:
-        Map of extensions to the driver.
+    dict
     """
     return _raster_driver_extensions()
 

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -184,7 +184,6 @@ def get_minimum_dtype(values):
 
 def is_ndarray(array):
     """Check if array is a ndarray."""
-
     return isinstance(array, numpy.ndarray) or hasattr(array, "__array__")
 
 

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -22,6 +22,8 @@ class TransformDirection(IntEnum):
 
 
 class TransformMethod(Enum):
+    """Georeferencing transform method."""
+
     affine = "transform"
     gcps = "gcps"
     rpcs = "rpcs"
@@ -76,7 +78,7 @@ class Resampling(IntEnum):
     """Available warp resampling algorithms.
 
     Notes
-    ----------
+    -----
     The first 8, 'nearest', 'bilinear', 'cubic', 'cubic_spline',
     'lanczos', 'average', 'mode', and 'gauss', are available for making
     dataset overviews.
@@ -175,6 +177,8 @@ class Compression(Enum):
 
 
 class Interleaving(Enum):
+    """Raster band interleave method."""
+
     pixel = "PIXEL"
     line = "LINE"
     band = "BAND"
@@ -183,6 +187,8 @@ class Interleaving(Enum):
 
 
 class MaskFlags(IntEnum):
+    """Mask band flags."""
+
     all_valid = 1
     per_dataset = 2
     alpha = 4
@@ -190,6 +196,8 @@ class MaskFlags(IntEnum):
 
 
 class PhotometricInterp(Enum):
+    """Photometric interpretation flag."""
+
     black = "MINISBLACK"
     white = "MINISWHITE"
     rgb = "RGB"
@@ -201,7 +209,7 @@ class PhotometricInterp(Enum):
 
 
 class MergeAlg(Enum):
-    """Available rasterization algorithms"""
+    """Available rasterization algorithms."""
 
     replace = "REPLACE"
     add = "ADD"
@@ -209,9 +217,9 @@ class MergeAlg(Enum):
 
 class WktVersion(Enum):
     """
-     .. versionadded:: 1.3.0
+    Supported CRS WKT string versions.
 
-    Supported CRS WKT string versions
+     .. versionadded:: 1.3.0
     """
 
     #: WKT Version 2 from 2015

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -24,6 +24,8 @@ from rasterio.session import Session, DummySession
 
 
 class ThreadEnv(threading.local):
+    """Thread environment."""
+
     def __init__(self):
         self._env = None  # Initialises in each thread
 
@@ -146,7 +148,6 @@ class Env:
 
         Examples
         --------
-
         >>> with Env(CPL_DEBUG=True, CPL_CURL_VERBOSE=True):
         ...     with rasterio.open("https://example.com/a.tif") as src:
         ...         print(src.profile)
@@ -242,6 +243,7 @@ class Env:
         return Env(*args, **options)
 
     def aws_creds_from_context_options(self):
+        """Get credentials from context options."""
         return {k: v for k, v in self.context_options.items() if k.startswith("AWS_")}
 
     def credentialize(self):
@@ -354,6 +356,7 @@ def getenv():
 
 
 def hasenv():
+    """Check if there is an existing environment."""
     return bool(local._env)
 
 
@@ -366,6 +369,7 @@ def setenv(**options):
 
 
 def hascreds():
+    """Check if the given configuration has proper credentials."""
     warnings.warn(
         "Please use Env.session.hascreds() instead", RasterioDeprecationWarning
     )
@@ -387,6 +391,8 @@ def delenv():
 
 
 class NullContextManager:
+    """A do-nothing context manager."""
+
     def __init__(self):
         pass
 
@@ -413,7 +419,8 @@ def env_ctx_if_needed():
 
 def ensure_env(f):
     """A decorator that ensures an env exists before a function
-    calls any GDAL C functions."""
+    calls any GDAL C functions.
+    """  # noqa: D205
 
     @wraps(f)
     def wrapper(*args, **kwds):
@@ -483,10 +490,11 @@ def ensure_env_with_credentials(f):
 @attr.s(slots=True)
 @total_ordering
 class GDALVersion:
-    """Convenience class for obtaining GDAL major and minor version components
-    and comparing between versions.  This is highly simplistic and assumes a
-    very normal numbering scheme for versions and ignores everything except
-    the major and minor components."""
+    """Convenience class to obtain and compare GDAL versions.
+
+    This is highly simplistic and assumes a very normal numbering scheme for
+    versions and ignores everything except the major and minor components.
+    """
 
     major = attr.ib(default=0, validator=attr.validators.instance_of(int))
     minor = attr.ib(default=0, validator=attr.validators.instance_of(int))
@@ -516,9 +524,9 @@ class GDALVersion:
 
     @classmethod
     def parse(cls, input, include_patch=False):
-        """
-        Parses input tuple or string to GDALVersion. If input is a GDALVersion
-        instance, it is returned.
+        """Parses input tuple or string to GDALVersion.
+
+        If input is a GDALVersion instance, it is returned.
 
         Parameters
         ----------
@@ -530,7 +538,6 @@ class GDALVersion:
         -------
         GDALVersion instance
         """
-
         if isinstance(input, cls):
             return input
         if isinstance(input, tuple):
@@ -561,6 +568,7 @@ class GDALVersion:
         return cls.parse(gdal_version(), include_patch=include_patch)
 
     def at_least(self, other, include_patch=False):
+        """Check if this version is greater than or equal to another."""
         other = self.__class__.parse(other, include_patch=include_patch)
         return self >= other
 
@@ -609,7 +617,7 @@ def require_gdal_version(
 
 
     Parameters
-    ------------
+    ----------
     version: tuple, string, or GDALVersion
     param: string (optional, default: None)
         If `values` are absent, then all use of this parameter with a value
@@ -626,10 +634,9 @@ def require_gdal_version(
         if necessary context to the user.
 
     Returns
-    ---------
+    -------
     wrapped function
-    """
-
+    """  # noqa: D205
     if values is not None:
         if param is None:
             raise ValueError("require_gdal_version: param must be provided with values")

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -17,12 +17,14 @@ class WindowError(RasterioError):
 
 class CRSError(ValueError):
     """Raised when a CRS string or mapping is invalid or cannot serve
-    to define a coordinate transformation."""
+    to define a coordinate transformation.
+    """  # noqa: D205
 
 
 class EnvError(RasterioError):
     """Raised when the state of GDAL/AWS environment cannot be created
-    or modified."""
+    or modified.
+    """  # noqa: D205
 
 
 class DriverCapabilityError(RasterioError, ValueError):
@@ -73,8 +75,9 @@ class ShapeSkipWarning(UserWarning):
 
 
 class GDALBehaviorChangeException(RuntimeError):
-    """Raised when GDAL's behavior differs from the given arguments.  For
-    example, antimeridian cutting is always on as of GDAL 2.2.0.  Users
+    """Raised when GDAL's behavior differs from the given arguments.
+
+    For example, antimeridian cutting is always on as of GDAL 2.2.0.  Users
     expecting it to be off will be presented with a MultiPolygon when the
     rest of their code expects a Polygon.
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -112,7 +112,7 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
         pixel coordinates
 
     Yields
-    -------
+    ------
     polygon, value
         A pair of (polygon, value) for each feature found in the image.
         Polygons are GeoJSON-like dicts and the values are the
@@ -436,7 +436,6 @@ def bounds(geometry, north_up=True, transform=None):
     tuple
         Bounding box: (left, bottom, right, top)
     """
-
     geometry = getattr(geometry, "__geo_interface__", None) or geometry
 
     if "bbox" in geometry:
@@ -500,7 +499,7 @@ def geometry_window(
     -------
     rasterio.windows.Window
 
-    """
+    """  # noqa: D205
     if north_up is not None:
         warnings.warn(
             "The north_up parameter is unused, deprecated, and will be removed in the future.",
@@ -549,9 +548,9 @@ def geometry_window(
 
 def is_valid_geom(geom):
     """
-    Checks to see if geometry is a valid GeoJSON geometry type or
-    GeometryCollection.  Geometry must be GeoJSON or implement the geo
-    interface.
+    Checks to see if geometry is a valid GeoJSON geometry type or GeometryCollection.
+
+    Geometry must be GeoJSON or implement the geo interface.
 
     Geometries must be non-empty, and have at least x, y coordinates.
 
@@ -565,7 +564,6 @@ def is_valid_geom(geom):
     -------
     bool: True if object is a valid GeoJSON geometry type
     """
-
     geom_types = {
         "Point",
         "MultiPoint",

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -38,8 +38,9 @@ class DatasetReader(DatasetReaderBase, WindowMethodsMixin, TransformMethodsMixin
 
 
 class DatasetWriter(DatasetWriterBase, WindowMethodsMixin, TransformMethodsMixin):
-    """An unbuffered data and metadata writer. Its methods write data
-    directly to disk.
+    """An unbuffered data and metadata writer.
+
+    Its methods write data directly to disk.
     """
 
     def __repr__(self):
@@ -56,7 +57,7 @@ class BufferedDatasetWriter(
 
     This allows incremental updates to datasets using formats that don't
     otherwise support updates, such as JPEG.
-    """
+    """  # noqa: D205
 
     def __repr__(self):
         return "<{} BufferedDatasetWriter name='{}' mode='{}'>".format(
@@ -75,7 +76,6 @@ class MemoryFile(MemoryFileBase):
 
     Examples
     --------
-
     A GeoTIFF can be loaded in memory and accessed using the GeoTIFF
     format driver
 

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -21,8 +21,7 @@ def raster_geometry_mask(
     pad=False,
     pad_width=0.5,
 ):
-    """Create a mask from shapes, transform, and optional window within original
-    raster.
+    """Create a mask from shapes, transform, and optional window within original raster.
 
     By default, mask is intended for use as a numpy mask, where pixels that
     overlap shapes are False.
@@ -136,6 +135,7 @@ def mask(
     indexes=None,
 ):
     """Creates a masked or filled array using input shapes.
+
     Pixels are masked or set to nodata outside the input shapes, unless
     `invert` is `True`.
 
@@ -194,7 +194,6 @@ def mask(
                 Information for mapping pixel coordinates in `masked` to another
                 coordinate system.
     """
-
     if nodata is None:
         if dataset.nodata is not None:
             nodata = dataset.nodata

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_plt():
-    """import matplotlib.pyplot
+    """Import matplotlib.pyplot
+
     raise import error if matplotlib is not installed
     """
     try:
@@ -204,7 +205,7 @@ def plotting_extent(source, transform=None):
     -------
     tuple of float
         left, right, bottom, top
-    """
+    """  # noqa: D205
     if hasattr(source, "bounds"):
         extent = (
             source.bounds.left,
@@ -235,7 +236,7 @@ def reshape_as_image(arr):
     ----------
     arr : array-like of shape (bands, rows, columns)
         image to reshape
-    """
+    """  # noqa: D205
     # swap the axes order from (bands, rows, columns) to (rows, columns, bands)
     im = np.ma.transpose(arr, [1, 2, 0])
     return im
@@ -250,7 +251,7 @@ def reshape_as_raster(arr):
     ----------
     arr : array-like in the image form of (rows, columns, bands)
         image to reshape
-    """
+    """  # noqa: D205
     # swap the axes order from (rows, columns, bands) to (bands, rows, columns)
     im = np.transpose(arr, [2, 0, 1])
     return im
@@ -374,6 +375,7 @@ def contrast_strech(arr, percent_range=(2.0, 98.0)):
 
 def adjust_band(band, kind=None):
     """Adjust a band to be between 0 and 1.
+
     Parameters
     ----------
     band : array, shape (height, width)

--- a/rasterio/profiles.py
+++ b/rasterio/profiles.py
@@ -15,7 +15,8 @@ class Profile(UserDict):
 
     def __init__(self, data={}, **kwds):
         """Create a new profile based on the class defaults, which are
-        overlaid with items from the `data` dict and keyword arguments."""
+        overlaid with items from the `data` dict and keyword arguments.
+        """  # noqa: D205
         UserDict.__init__(self)
         initdata = self.defaults.copy()
         initdata.update(data)

--- a/rasterio/rio/__init__.py
+++ b/rasterio/rio/__init__.py
@@ -1,3 +1,1 @@
-"""
-Rasterio commandline interface components
-"""
+"""Rasterio commandline interface components."""

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -37,7 +37,6 @@ class _Collection:
         dict
             GeoJSON polygon feature
         """
-
         self._src = dataset
         self._bidx = bidx
         self._precision = precision
@@ -100,7 +99,7 @@ class _Collection:
 def blocks(
     ctx, input, output, precision, indent, compact, projection, sequence, use_rs, bidx
 ):
-    """Write dataset blocks as GeoJSON features.
+    r"""Write dataset blocks as GeoJSON features.
 
     This command prints features describing a raster's internal blocks,
     which are used directly for raster I/O.  These features can be used

--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -1,3 +1,5 @@
+"""rio bounds prints bounding boxes to stdout as GeoJSON."""
+
 import logging
 import os
 
@@ -44,8 +46,9 @@ def bounds(
     use_rs,
     geojson_type,
 ):
-    """Write bounding boxes to stdout as GeoJSON for use with, e.g.,
-    geojsonio::
+    """Write bounding boxes to stdout as GeoJSON.
+
+    For example, to use with geojsonio::
 
       $ rio bounds *.tif | geojsonio
 

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -33,6 +33,7 @@ def _read_array(ix, subix=None, dtype=None):
 
 
 def asarray(*args):
+    """Returns as NumPy array."""
     if len(args) == 1 and hasattr(args[0], "__iter__"):
         return numpy.asanyarray(list(args[0]))
     else:
@@ -49,8 +50,8 @@ class FuncMapper(UserDict, Mapping):
         elif key in __builtins__ and not key.startswith("__"):
             return __builtins__[key]
         else:
-            return (
-                lambda g, *args, **kwargs: getattr(g, key)(*args, **kwargs)
+            return lambda g, *args, **kwargs: (
+                getattr(g, key)(*args, **kwargs)
                 if callable(getattr(g, key))
                 else getattr(g, key)
             )
@@ -92,7 +93,7 @@ def calc(
     mem_limit,
     creation_options,
 ):
-    """A raster data calculator
+    r"""A raster data calculator.
 
     Evaluates an expression using input datasets and writes the result
     to a new dataset.
@@ -136,7 +137,7 @@ def calc(
     The maximum amount of memory used to perform calculations defaults to
     64 MB. This number can be increased to improve speed of calculation.
 
-    """  # noqa: W605
+    """
     dst = None
     sources = []
 

--- a/rasterio/rio/create.py
+++ b/rasterio/rio/create.py
@@ -79,7 +79,7 @@ def create(
     overwrite,
     creation_options,
 ):
-    """Create an empty dataset.
+    r"""Create an empty dataset.
 
     The fundamental, required parameters are: format driver name, data
     type, count of bands, height and width in pixels. Long and short

--- a/rasterio/rio/edit_info.py
+++ b/rasterio/rio/edit_info.py
@@ -81,10 +81,10 @@ def transform_handler(ctx, param, value):
 
 
 def colorinterp_handler(ctx, param, value):
-    """Validate a string like ``red,green,blue,alpha`` and convert to
-    a tuple.  Also handle ``RGB`` and ``RGBA``.
-    """
+    """Validate a string like ``red,green,blue,alpha`` and convert to a tuple.
 
+    Also handle ``RGB`` and ``RGBA``.
+    """
     if value is None:
         return value
     # Using '--like'
@@ -169,7 +169,9 @@ def edit(
     like,
     colorinterp,
 ):
-    """Edit a dataset's metadata: coordinate reference system, affine
+    """Edit a dataset's metadata.
+
+    Editable metadata include coordinate reference system, affine
     transformation matrix, nodata value, and tags.
 
     The coordinate reference system may be either a PROJ.4 or EPSG:nnnn

--- a/rasterio/rio/gcps.py
+++ b/rasterio/rio/gcps.py
@@ -29,7 +29,7 @@ from rasterio.warp import transform_geom
 def gcps(
     ctx, input, geojson_type, projection, precision, sequence, use_rs, indent, compact
 ):
-    """Print GeoJSON representations of a dataset's control points.
+    r"""Print GeoJSON representations of a dataset's control points.
 
     Each ground control point is represented as a GeoJSON feature. The
     'properties' member of each feature contains a JSON representation
@@ -48,7 +48,6 @@ def gcps(
         info:
             A brief description of the control point.
     """
-
     # Handle the invalid combinations of args.
     if geojson_type == "feature" and indent and not use_rs:
         raise click.BadParameter(

--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -1,6 +1,4 @@
-"""
-Helper objects used by multiple CLI commands.
-"""
+"""Helper objects used by multiple CLI commands."""
 
 import json
 import os
@@ -12,7 +10,9 @@ from rasterio.errors import FileOverwriteError
 
 def coords(obj):
     """Yield all coordinate coordinate tuples from a geometry or feature.
-    From python-geojson package."""
+
+    From python-geojson package.
+    """
     if isinstance(obj, (tuple, list)):
         coordinates = obj
     elif "geometry" in obj:
@@ -30,8 +30,7 @@ def coords(obj):
 def write_features(
     fobj, collection, sequence=False, geojson_type="feature", use_rs=False, **dump_kwds
 ):
-    """Read an iterator of (feat, bbox) pairs and write to file using
-    the selected modes."""
+    """Read an iterator of (feat, bbox) pairs and write to file using the selected modes."""
     # Sequence of features expressed as bbox, feature, or collection.
     if sequence:
         for feat in collection():

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -44,11 +44,13 @@ from rasterio._vendor.click_plugins import with_plugins
 
 
 def configure_logging(verbosity):
+    """Configure logging."""
     log_level = max(10, 30 - 10 * verbosity)
     logging.basicConfig(stream=sys.stderr, level=log_level)
 
 
 def gdal_version_cb(ctx, param, value):
+    """GDAL version callback."""
     if not value or ctx.resilient_parsing:
         return
 
@@ -57,6 +59,7 @@ def gdal_version_cb(ctx, param, value):
 
 
 def show_versions_cb(ctx, param, value):
+    """Show versions callback."""
     if not value or ctx.resilient_parsing:
         return
 

--- a/rasterio/rio/mask.py
+++ b/rasterio/rio/mask.py
@@ -1,3 +1,5 @@
+"""The rio mask CLI command."""
+
 import json
 import logging
 
@@ -59,7 +61,9 @@ def mask(
     overwrite,
     creation_options,
 ):
-    """Masks in raster using GeoJSON features (masks out all areas not covered
+    """Mask raster using features.
+
+    Masks in raster using GeoJSON features (masks out all areas not covered
     by features), and optionally crops the output raster to the extent of the
     features.  Features are assumed to be in the same coordinate reference
     system as the input raster.
@@ -80,7 +84,6 @@ def mask(
     --crop option is not valid if features are completely outside extent of
     input raster.
     """
-
     output, files = resolve_inout(files=files, output=output, overwrite=overwrite)
     input = files[0]
 

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -12,6 +12,7 @@ from rasterio.merge import MERGE_METHODS
 
 
 def deprecated_precision(ctx, param, value):
+    """Show RasterioDeprecationWarning if precision is used."""
     if value is not None:
         warnings.warn(
             "The --precision option is unused, deprecated, and will be removed in 2.0.0.",
@@ -88,7 +89,7 @@ def merge(
     use_highest_res,
     creation_options,
 ):
-    """Copy valid pixels from input files to an output file.
+    r"""Copy valid pixels from input files to an output file.
 
     All files must have the same number of bands, data type, and
     coordinate reference system. Rotated rasters cannot be merged.

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -75,7 +75,9 @@ logger = logging.getLogger(__name__)
 
 def _cb_key_val(ctx, param, value):
     """
-    click callback to validate `--opt KEY1=VAL1 --opt KEY2=VAL2` and collect
+    Click callback to parse and validate KEY=VALUE pairs to a dict.
+
+    E.g., this will validate `--opt KEY1=VAL1 --opt KEY2=VAL2` and collect
     in a dictionary like the one below, which is what the CLI function receives.
     If no value or `None` is received then an empty dictionary is returned.
 
@@ -86,7 +88,6 @@ def _cb_key_val(ctx, param, value):
 
     Note: `==VAL` breaks this as `str.split('=', 1)` is used.
     """
-
     if not value:
         return {}
     else:
@@ -152,7 +153,8 @@ def files_inout_handler(ctx, param, value):
 
 def from_like_context(ctx, param, value):
     """Return the value for an option from the context if the option
-    or `--all` is given, else return None."""
+    or `--all` is given, else return None.
+    """  # noqa: D205
     if ctx.obj and ctx.obj.get("like") and (value == "like" or ctx.obj.get("all_like")):
         return ctx.obj["like"][param.name]
     else:
@@ -161,7 +163,8 @@ def from_like_context(ctx, param, value):
 
 def like_handler(ctx, param, value):
     """Copy a dataset's meta property to the command context for access
-    from other callbacks."""
+    from other callbacks.
+    """  # noqa: D205
     if ctx.obj is None:
         ctx.obj = {}
     if value:

--- a/rasterio/rio/overview.py
+++ b/rasterio/rio/overview.py
@@ -11,6 +11,7 @@ from rasterio.enums import OverviewResampling
 
 
 def build_handler(ctx, param, value):
+    """Callback for overview --build value."""
     if value:
         try:
             if "^" in value:
@@ -29,7 +30,8 @@ def build_handler(ctx, param, value):
 
 
 def get_maximum_overview_level(width, height, minsize=256):
-    """
+    """Get maximum overview level.
+
     Calculate the maximum overview level of a dataset at which
     the smallest overview is smaller than `minsize`.
 

--- a/rasterio/rio/rasterize.py
+++ b/rasterio/rio/rasterize.py
@@ -138,7 +138,6 @@ def rasterize(
     functionality may be added in the future.
 
     """
-
     from rasterio.crs import CRS
     from rasterio.features import rasterize
     from rasterio.features import bounds as calculate_bounds

--- a/rasterio/rio/rm.py
+++ b/rasterio/rio/rm.py
@@ -29,7 +29,6 @@ def rm(path, yes, driver):
     deleting side car files.  This command is aware of datasets and
     their sidecar files.
     """
-
     try:
         rasterio.shutil.delete(path, driver=driver)
     except (DriverRegistrationError, RasterioIOError) as e:

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -20,7 +20,7 @@ def _(obj):
 @click.option("-b", "--bidx", default=None, help="Indexes of input file bands.")
 @click.pass_context
 def sample(ctx, files, bidx):
-    """Sample a dataset at one or more points
+    r"""Sample a dataset at one or more points
 
     Sampling points (x, y) encoded as JSON arrays, in the coordinate
     reference system of the dataset, are read from the second

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -69,9 +69,11 @@ def shapes(
     with_nodata,
     as_mask,
 ):
-    """Extracts shapes from one band or mask of a dataset and writes
-    them out as GeoJSON. Unless otherwise specified, the shapes will be
-    transformed to WGS 84 coordinates.
+    """
+    Extracts shapes from one band or mask of a dataset and writes them out as GeoJSON.
+
+    Unless otherwise specified, the shapes will be transformed to WGS 84
+    coordinates.
 
     The default action of this command is to extract shapes from the
     first band of the input dataset. The shapes are polygons bounding
@@ -136,6 +138,8 @@ def shapes(
 
 
 def feature_gen(src, env, *args, **kwargs):
+    """Feature Collection generator."""
+
     class Collection:
         def __init__(self, env):
             self.bboxes = []

--- a/rasterio/rio/stack.py
+++ b/rasterio/rio/stack.py
@@ -68,8 +68,8 @@ def stack(
     use_highest_res,
     creation_options,
 ):
-    """Stack a number of bands from one or more input files into a
-    multiband dataset.
+    """
+    Stack a number of bands from one or more input files into a multiband dataset.
 
     Input datasets must be of a kind: same data type, dimensions, etc. The
     output is cloned from the first input.

--- a/rasterio/rio/transform.py
+++ b/rasterio/rio/transform.py
@@ -13,7 +13,7 @@ from rasterio.rio import options
 @options.precision_opt
 @click.pass_context
 def transform(ctx, input, src_crs, dst_crs, precision):
-    """Transform coordinates between coordinate reference systems.
+    r"""Transform coordinates between coordinate reference systems.
 
     JSON arrays of coordinates, interleaved, are read from stdin.
     Aarrays of transformed coordinates are written to stdout.

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -137,7 +137,7 @@ def warp(
     warper_options,
     dry_run,
 ):
-    """
+    r"""
     Warp a raster dataset.
 
     If a template raster is provided using the --like option, the

--- a/rasterio/rpc.py
+++ b/rasterio/rpc.py
@@ -1,3 +1,5 @@
+"""Rational Polynomial Coefficients module."""
+
 import attr
 
 
@@ -55,7 +57,6 @@ class RPC:
         -----
         The `err_bias` and `err_rand` are optional, and are not written to datasets by GDAL.
         """
-
         out = {
             "HEIGHT_OFF": str(self.height_off),
             "HEIGHT_SCALE": str(self.height_scale),
@@ -83,7 +84,6 @@ class RPC:
     @classmethod
     def from_gdal(cls, rpcs):
         """Deserialize dict values to float or list.
-
 
         Returns
         -------

--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -1,3 +1,4 @@
+"""Raster sample module."""
 # Workaround for issue #378. A pure Python generator.
 
 import numpy as np

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -380,7 +380,6 @@ class OSSSession(Session):
         oss_endpoint: string, optional (default: None)
             the region attached to the bucket
         """
-
         self._creds = {
             "oss_access_key_id": oss_access_key_id,
             "oss_secret_access_key": oss_secret_access_key,
@@ -432,7 +431,6 @@ class GSSession(Session):
         google_application_credentials: string
             Path to the google application credentials JSON file.
         """
-
         if google_application_credentials is not None:
             self._creds = {
                 "google_application_credentials": google_application_credentials
@@ -546,12 +544,14 @@ class SwiftSession(Session):
     @classmethod
     def hascreds(cls, config):
         """Determine if the given configuration has proper credentials
+
         Parameters
         ----------
         cls : class
             A Session class.
         config : dict
             GDAL configuration as a dict.
+
         Returns
         -------
         bool
@@ -565,6 +565,7 @@ class SwiftSession(Session):
 
     def get_credential_options(self):
         """Get credentials as GDAL configuration options
+
         Returns
         -------
         dict

--- a/rasterio/stack.py
+++ b/rasterio/stack.py
@@ -162,9 +162,11 @@ def stack(
                     best_res = min(
                         best_res,
                         src.res,
-                        key=lambda x: x
-                        if isinstance(x, numbers.Number)
-                        else math.sqrt(x[0] ** 2 + x[1] ** 2),
+                        key=lambda x: (
+                            x
+                            if isinstance(x, numbers.Number)
+                            else math.sqrt(x[0] ** 2 + x[1] ** 2)
+                        ),
                     )
 
                 # The stack tool requires non-rotated rasters with origins at their

--- a/rasterio/tools.py
+++ b/rasterio/tools.py
@@ -64,7 +64,6 @@ class JSONSequenceTool:
         ------------
         Writes sequences of JSON texts to the named output file.
         """
-
         src_kwargs = src_kwargs or {}
         dst_kwargs = dst_kwargs or {}
         func_args = func_args or []

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -34,7 +34,7 @@ class TransformMethodsMixin:
     A subclass with this mixin MUST provide a `transform`
     property.
 
-    """
+    """  # noqa: D205
 
     def xy(
         self,
@@ -446,6 +446,7 @@ class TransformerBase:
             Determines if the returned coordinates are for the center of the
             pixel or for a corner. Available options include center, ul, ur, ll,
             lr.
+
         Raises
         ------
         ValueError
@@ -498,11 +499,14 @@ class TransformerBase:
 
 
 class GDALTransformerBase(TransformerBase):
+    """GDAL transformer base class."""
+
     def __init__(self):
         super().__init__()
         self._env = ExitStack()
 
     def close(self):
+        """Destroy transformer."""
         pass
 
     def __enter__(self):
@@ -546,8 +550,7 @@ class AffineTransformer(TransformerBase):
 
 class RPCTransformer(RPCTransformerBase, GDALTransformerBase):
     """
-    Class related to Rational Polynomial Coeffecients (RPCs) based
-    coordinate transformations.
+    Class related to Rational Polynomial Coeffecients (RPCs) based coordinate transformations.
 
     Uses GDALCreateRPCTransformer and GDALRPCTransform for computations. Options
     for GDALCreateRPCTransformer may be passed using `rpc_options`.
@@ -567,8 +570,7 @@ class RPCTransformer(RPCTransformerBase, GDALTransformerBase):
 
 class GCPTransformer(GCPTransformerBase, GDALTransformerBase):
     """
-    Class related to Ground Control Point (GCPs) based
-    coordinate transformations.
+    Class related to Ground Control Point (GCPs) based coordinate transformations.
 
     Uses GDALCreateGCPTransformer and GDALGCPTransform for computations.
     Ensure that GDAL transformer objects are destroyed by calling `close()`

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -101,7 +101,6 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin, TransformMethodsMixin):
 
     Examples
     --------
-
     >>> with rasterio.open("tests/data/RGB.byte.tif") as src:
     ...     with WarpedVRT(src, crs="EPSG:3857") as vrt:
     ...         data = vrt.read()

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -31,7 +31,7 @@ def transform(src_crs, dst_crs, xs, ys, zs=None):
     coordinate reference system into target.
 
     Parameters
-    ------------
+    ----------
     src_crs: CRS or dict
         Source coordinate reference system, as a rasterio CRS object.
         Example: CRS({'init': 'EPSG:4326'})
@@ -45,7 +45,7 @@ def transform(src_crs, dst_crs, xs, ys, zs=None):
         Contains z values.  Assumed to be all 0 if absent.
 
     Returns
-    ---------
+    -------
     out: tuple of array_like, (xs, ys, [zs])
         Tuple of x, y, and optionally z vectors, transformed into the target
         coordinate reference system.
@@ -73,7 +73,7 @@ def transform_geom(
     """Transform geometry from source coordinate reference system into target.
 
     Parameters
-    ------------
+    ----------
     src_crs: CRS or dict
         Source coordinate reference system, in rasterio dict format.
         Example: CRS({'init': 'EPSG:4326'})
@@ -90,7 +90,7 @@ def transform_geom(
         values will be preserved (default).
 
     Returns
-    ---------
+    -------
     out: GeoJSON like dict object or list of GeoJSON like objects.
         Transformed geometry(s) in GeoJSON dict format
     """
@@ -183,7 +183,7 @@ def reproject(
     transforms will be read from the appropriate datasets.
 
     Parameters
-    ------------
+    ----------
     source: ndarray or Band
         The source is a 2 or 3-D ndarray, or a single or a multiple
         Rasterio Band object. The dimensionality of source
@@ -267,7 +267,7 @@ def reproject(
         INIT_DEST=NO_DATA).
 
     Returns
-    ---------
+    -------
     destination: ndarray or Band
         The transformed ndarray or Band.
     dst_transform: Affine

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -39,7 +39,7 @@ class WindowMethodsMixin:
     A subclass with this mixin MUST provide the following
     properties: `transform`, `height` and `width`.
 
-    """
+    """  # noqa: D205
 
     def window(self, left, bottom, right, top, precision=None):
         """Get the window corresponding to the bounding coordinates.
@@ -118,7 +118,7 @@ class WindowMethodsMixin:
 def iter_args(function):
     """Decorator to allow function to take either ``*args`` or
     a single iterable which gets expanded to ``*args``.
-    """
+    """  # noqa: D205
 
     @functools.wraps(function)
     def wrapper(*args, **kwargs):
@@ -525,6 +525,7 @@ def round_window_to_full_blocks(window, block_shapes, height=0, width=0):
 
 
 def validate_length_value(instance, attribute, value):
+    """Validate length value to be non-negative."""
     if value and value < 0:
         raise ValueError("Number of columns or rows must be non-negative")
 
@@ -649,8 +650,7 @@ class Window:
         Returns
         -------
         Window
-        """
-
+        """  # noqa: D205
         # Normalize to slices
         if isinstance(rows, (tuple, list)):
             if len(rows) != 2:
@@ -733,6 +733,7 @@ class Window:
         return Window(self.col_off, self.row_off, width, height)
 
     def round_shape(self, **kwds):
+        """Deprecated method; use :meth:`round_lengths` instead."""
         warnings.warn(
             "round_shape is deprecated and will be removed in Rasterio 2.0.0.",
             RasterioDeprecationWarning,
@@ -781,7 +782,6 @@ class Window:
 
         Parameters
         ----------
-
         other: Window
             Another window
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+"""Setuptools build script."""
 # These following environmental variables influence this script:
 #
 # GDAL_CONFIG: the path to a gdal-config program that points to GDAL headers,
@@ -32,6 +32,7 @@ log = logging.getLogger()
 
 
 def copy_data_tree(datadir, destdir):
+    """Copy data tree to destination dir."""
     try:
         shutil.rmtree(destdir)
     except OSError:
@@ -79,7 +80,6 @@ def _find_executable(executable_name: str) -> str | None:
 
     Return the absolute path to the executable if found, otherwise None.
     """
-
     log.info("Searching for executable %s on sys.prefix")
     executable_path = shutil.which(executable_name, path=sys.prefix)
     if executable_path is None:
@@ -108,7 +108,6 @@ def find_gdal_install_with_executable(
 
     This does not check if the install is complete.
     """
-
     executable_path = _find_executable(executable_name)
     # Run it to get the GDAL version
     result = check_output([executable_name, "--version"], text=True).strip()
@@ -139,7 +138,6 @@ def fill_gdal_build_options_using_executable(executable_name: str) -> None:
 
     Raise `RuntimeError` if we don't find a GDAL install.
     """
-
     global \
         gdal_data_dir, \
         gdalversion, \
@@ -204,7 +202,6 @@ def fill_gdal_build_options_using_gdal_config() -> None:
     If gdal-config's path isn't found, raise `FileNotFoundError`.
     If it fails, raise `CalledProcessError`.
     """
-
     global gdalversion
 
     log.info("Using gdal-config to get GDAL build options")


### PR DESCRIPTION
This enables ruff check's [pydocstyle (D)](https://docs.astral.sh/ruff/rules/#pydocstyle-d) with associated automated and manual fixes.

The manual fixes were primarily for [missing-blank-line-after-summary (D205)](https://docs.astral.sh/ruff/rules/missing-blank-line-after-summary/#missing-blank-line-after-summary-d205), usually by re-phrasing parts or extending the first line beyond the usual 88-char limit. In some cases these were left as-is with a `noqa: D205` comment. Other fixes were to add missing docstrings for public functions  and modules. Revisions to the proposed manual edits are welcome!

A few other changes:

- Update ruff-pre-commit revision, with a few minor ruff-format changes
- Remove `docs/_build/html/.nojekyll` file generation, since this was a legacy from hosting docs on GitHub Pages, no longer needed for Read the Docs
