### PR TITLE
fix: add pixel count guard in rio warp to prevent hang on Python 3.14

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,10 @@ Changes
 ------------------
 
 Bug fixes:
--
+
+- rio warp: add pixel count guard to prevent hang when --bounds and --res
+  use mismatched units, raising RasterioIOError instead of attempting to
+  allocate an impossibly large output raster (#3556).
 
 Full list of software versions: https://github.com/rasterio/rasterio/blob/1.5.1/ci/config.sh#L1-L25
 

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -10,7 +10,7 @@ import numpy as np
 import rasterio
 from rasterio.crs import CRS
 from rasterio.env import setenv
-from rasterio.errors import CRSError
+from rasterio.errors import CRSError, RasterioIOError
 from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
 from rasterio.rio.options import _cb_key_val
@@ -407,6 +407,22 @@ def warp(
                 click.echo("Output dataset profile:")
                 click.echo(json.dumps(dict(**out_kwargs), indent=2, default=to_json))
             else:
+                # Guard against unreasonable output dimensions that
+                # can result from mismatched bounds and resolution
+                # units (e.g. projected-metre bounds with a
+                # degree-scale resolution).  GDAL may hang or OOM
+                # instead of failing fast.
+                MAX_PIXELS = 10_000_000_000  # 10 billion pixels
+                total_pixels = dst_width * dst_height
+                if total_pixels > MAX_PIXELS:
+                    raise RasterioIOError(
+                        f"Output dimensions {dst_width} x {dst_height} "
+                        f"({total_pixels:,} pixels) exceed the safety "
+                        f"limit of {MAX_PIXELS:,} pixels. Check that "
+                        "--bounds and --res use the same units as "
+                        "--dst-crs."
+                    )
+
                 with rasterio.open(output, "w", **out_kwargs) as dst:
                     reproject(
                         source=rasterio.band(src, list(range(1, src.count + 1))),


### PR DESCRIPTION
## Summary

- Add a pixel count safety check in `rio warp` before creating the output dataset. When `--bounds` and `--res` use mismatched coordinate units (e.g. projected-metre bounds with degree-scale resolution), the computed output dimensions can be absurdly large (trillions of pixels). GDAL attempts allocation and hangs or OOMs instead of failing fast particularly on Python 3.14.
- The guard raises `RasterioIOError` (exit code 1) when total pixels exceed 10 billion, only in the non-dry-run path so `--dry-run` can still report the computed dimensions.
- Adds a `CHANGES.txt` entry for 1.5.1.

## Context

While verifying Python 3.14 compatibility, `test_warp_reproject_bounds_crossup_fail` hangs indefinitely. The test passes bounds `[-11850000, 4810000, -11849000, 4812000]` (projected metres) with `--res 0.001` (degrees) and `--dst-crs EPSG:4326`, producing a 1,000,000 x 2,000,000 pixel output (2 trillion pixels, ~16 TB). On Python 3.12/3.13 GDAL happens to fail fast, but on 3.14 it hangs attempting allocation.

The fix adds an explicit dimension check before `rasterio.open()` in the write path, consistent with similar guards in `merge.py` and `stack.py`.

## Test plan

- [x] `test_warp_reproject_bounds_crossup_fail` previously hung, now passes (exit code 1)
- [x] `test_dry_run` still passes (guard is skipped for dry runs)
- [x] Full test suite: 1961 passed, 31 skipped, 12 xfailed, 9 xpassed (Python 3.14.3, GDAL 3.12.1)
- [x] Pre-commit (ruff check, ruff format, codespell) passes